### PR TITLE
Set up deployment to Heroku via Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
       api_key:
         secure: KjWlZDF/3XlhjcS6xNPEUlMhUFH05JrMuMiVc1CLooTl/43y/WjjXN0CY24wYZMJ8Ro+G9vm7Hn2YViNEEzVFoth65LoUDfUIHoe/nxmuayZ1+Vh66La3w+OvZSzm1IfQFl115HaUcW11Ho1zw94YuBit7vjOtdtFbwHSF477moQhgB8Z3C0oBIehm3ErdfmSV8V36siip1XICtY4YfrZ7CcPZw4lHHz0ntkklpVvRjauDJFwl9AyevtwlBR5dxTS6TYVrnO62PSbLex7xXQn+gI/skO1Y2j+sJwYiQKeJd3foD3AvoYB+i0wumymlHbVKgiQ8L10X8vOB+JacsJpZHTfQVBA89TJ+CwdGOCSILFKQ7c99TwAqTM5DcxfnDVlOcCBfcMU65tM5gfb75kg8lpnIxEk9itPcqlbiKkAWuuIVu0ItdJbdJZck5LnSxgvv5uiwIwolrcGBDdVnkITmbYCGbgCGTT2aGw2dtkC17KkCrRpJYcfMJDNbHscUPMZomXH3aqGIkby6qnFRi4gJke5Qq3jENMAZ+XX9yWCkdao5/PBYyK3xGY87KXZNWXkp/i0yHC/jIGwQlKeECNbaZCFcjt5mzVaR4GzcWjHTmkOPGTaGyLJA6w2h0PtxILYwt/9oc98HtF5crP932LNZ+t0JdgzmRR594Go1c0BTU=
       app:
-        co-heroku: rubytoolbox-production
+        master: rubytoolbox-production
       run:
         - "rake db:migrate"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,28 @@
 language: ruby
-
 # See https://docs.travis-ci.com/user/database-setup/#PostgreSQL
 services:
-  - postgresql
+- postgresql
 addons:
-  postgresql: "9.6"
-
+  postgresql: '9.6'
 # Cache bundle between builds
 # See https://docs.travis-ci.com/user/caching/
 cache: bundler
-
 jobs:
   include:
-    - stage: test
-      before_script:
-        - bin/rails db:setup
-      script:
-        - bundle exec rspec
-    - script: bundle exec rubocop
+  - stage: test
+    before_script:
+    - bin/rails db:setup
+    script:
+    - bundle exec rspec
+  - script: bundle exec rubocop
+  - stage: deploy
+    script: skip
+    deploy:
+      provider: heroku
+      api_key:
+        secure: KjWlZDF/3XlhjcS6xNPEUlMhUFH05JrMuMiVc1CLooTl/43y/WjjXN0CY24wYZMJ8Ro+G9vm7Hn2YViNEEzVFoth65LoUDfUIHoe/nxmuayZ1+Vh66La3w+OvZSzm1IfQFl115HaUcW11Ho1zw94YuBit7vjOtdtFbwHSF477moQhgB8Z3C0oBIehm3ErdfmSV8V36siip1XICtY4YfrZ7CcPZw4lHHz0ntkklpVvRjauDJFwl9AyevtwlBR5dxTS6TYVrnO62PSbLex7xXQn+gI/skO1Y2j+sJwYiQKeJd3foD3AvoYB+i0wumymlHbVKgiQ8L10X8vOB+JacsJpZHTfQVBA89TJ+CwdGOCSILFKQ7c99TwAqTM5DcxfnDVlOcCBfcMU65tM5gfb75kg8lpnIxEk9itPcqlbiKkAWuuIVu0ItdJbdJZck5LnSxgvv5uiwIwolrcGBDdVnkITmbYCGbgCGTT2aGw2dtkC17KkCrRpJYcfMJDNbHscUPMZomXH3aqGIkby6qnFRi4gJke5Qq3jENMAZ+XX9yWCkdao5/PBYyK3xGY87KXZNWXkp/i0yHC/jIGwQlKeECNbaZCFcjt5mzVaR4GzcWjHTmkOPGTaGyLJA6w2h0PtxILYwt/9oc98HtF5crP932LNZ+t0JdgzmRR594Go1c0BTU=
+      app:
+        co-heroku: rubytoolbox-production
+      run:
+        - "rake db:migrate"
+

--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,9 @@ gem "webpacker", require: false
 
 gem "foreman", require: false
 
+gem "rack-canonical-host"
+gem "rack-ssl-enforcer"
+
 gem "redcarpet"
 gem "slim-rails"
 

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,8 @@ gem "uglifier", ">= 1.3.0"
 # Heroku ruby buildpack installs yarn only when webpacker gem is detected...
 gem "webpacker", require: false
 
+gem "foreman", require: false
+
 gem "redcarpet"
 gem "slim-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,8 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     arel (8.0.0)
     ast (2.3.0)
     bindex (0.5.0)
@@ -132,10 +134,15 @@ GEM
     pry (0.11.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    public_suffix (3.0.0)
     puma (3.10.0)
     rack (2.0.3)
+    rack-canonical-host (0.2.3)
+      addressable (> 0, < 3)
+      rack (>= 1.0.0, < 3)
     rack-proxy (0.6.2)
       rack
+    rack-ssl-enforcer (0.2.9)
     rack-test (0.7.0)
       rack (>= 1.0, < 3)
     rails (5.1.4)
@@ -283,6 +290,8 @@ DEPENDENCIES
   pg (~> 0.18)
   pry
   puma (~> 3.7)
+  rack-canonical-host
+  rack-ssl-enforcer
   rails (~> 5.1.4)
   rails-controller-testing
   redcarpet

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,9 +57,13 @@ GEM
     crass (1.0.2)
     diff-lcs (1.3)
     docile (1.1.5)
+    dotenv (0.7.0)
     erubi (1.7.0)
     execjs (2.7.0)
     ffi (1.9.18)
+    foreman (0.64.0)
+      dotenv (~> 0.7.0)
+      thor (>= 0.13.6)
     formatador (0.2.5)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
@@ -268,6 +272,7 @@ PLATFORMS
 DEPENDENCIES
   byebug
   coffee-rails (~> 4.2)
+  foreman
   guard-bundler
   guard-rspec
   guard-rubocop

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec puma --threads 4:$RAILS_MAX_THREADS

--- a/config.ru
+++ b/config.ru
@@ -4,4 +4,6 @@
 
 require_relative "config/environment"
 
+use Rack::SslEnforcer if Rails.env.production?
+use Rack::CanonicalHost, ENV["CANONICAL_HOST"] if ENV["CANONICAL_HOST"].present?
 run Rails.application


### PR DESCRIPTION
Heroku is sponsoring hosting for the future Ruby Toolbox :fireworks: :rocket: :rainbow:

This PR adds deployment of the master branch to heroku using Travis CI.

It also adds rack middlewares for enforcing the canonical domain as well as TLS. 