### PR TITLE
Operations tidbits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ jobs:
     deploy:
       provider: heroku
       api_key:
-        secure: KjWlZDF/3XlhjcS6xNPEUlMhUFH05JrMuMiVc1CLooTl/43y/WjjXN0CY24wYZMJ8Ro+G9vm7Hn2YViNEEzVFoth65LoUDfUIHoe/nxmuayZ1+Vh66La3w+OvZSzm1IfQFl115HaUcW11Ho1zw94YuBit7vjOtdtFbwHSF477moQhgB8Z3C0oBIehm3ErdfmSV8V36siip1XICtY4YfrZ7CcPZw4lHHz0ntkklpVvRjauDJFwl9AyevtwlBR5dxTS6TYVrnO62PSbLex7xXQn+gI/skO1Y2j+sJwYiQKeJd3foD3AvoYB+i0wumymlHbVKgiQ8L10X8vOB+JacsJpZHTfQVBA89TJ+CwdGOCSILFKQ7c99TwAqTM5DcxfnDVlOcCBfcMU65tM5gfb75kg8lpnIxEk9itPcqlbiKkAWuuIVu0ItdJbdJZck5LnSxgvv5uiwIwolrcGBDdVnkITmbYCGbgCGTT2aGw2dtkC17KkCrRpJYcfMJDNbHscUPMZomXH3aqGIkby6qnFRi4gJke5Qq3jENMAZ+XX9yWCkdao5/PBYyK3xGY87KXZNWXkp/i0yHC/jIGwQlKeECNbaZCFcjt5mzVaR4GzcWjHTmkOPGTaGyLJA6w2h0PtxILYwt/9oc98HtF5crP932LNZ+t0JdgzmRR594Go1c0BTU=
+        secure: $HEROKU_API_KEY_ENCRYPTED
       app:
-        master: rubytoolbox-production
+        co-ops: rubytoolbox-production
       run:
         - "rake db:migrate"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,6 @@ jobs:
       api_key:
         secure: lVZxGuy5uNaR4OdFfV3uu7bEqlN2RwC9UzeYEh/712UPM0AOXYRW+3UdjTn3Zr2e11bE1h7K2OcqJp7WhV25sUD2PPezKkf9lxrmu48UtzlGlkQJH1/fb3jlATV1uCtgxgutzysmcnw9ewtOnSoQltT+rFXQeFR62chqqtkA5qYFWgUxSlEK8Y1Z7uFRTPdBS33R5qDhyuohsI8FM64q4XtmARHsjUuOry8L8Ia89Rue5pbkfl29eRLt3ZAQX2ZVaevqgxWMEaOvKLqN7ZpeM3uQEA8M5G7PbdC3EVe8HvdjsXXVyOD/ljhdSxvW1xt/aV+Q1yHWNmv4FGTdQzPqzUPv1DorLTSusf4zePEGA56zdCNZ56x1wvV8rba01qNbrtrKewtTPcKp/M5bgyGGXSVFNGWnQv08hVOTXQEGWEqB/gcAAn+uCIl1eflySbxKX/LCMWjmCx0tfdKtS23hxuZPsWKKIJhUYWfpP7VWUok0z+XxCbhboSTsspw0VZmXsv6Vm6OpplVu3Sc2O4riVOZnRNLPiPeGszIwbNK0qlUG/G+RiLFuKZoI8RBhYprebIcZu2rd+F/yElhlHWvBQlvL8FQE1FKnjmIxyjY698gs7acC7ste7HxZp3m29+mEvnJcCfAqkFe2960+JVXB2p012g0vvQkznA/HbO6xq04=
       app:
-        co-ops: rubytoolbox-production
+        master: rubytoolbox-production
       run:
       - rake db:migrate

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,8 @@ jobs:
     script: skip
     deploy:
       provider: heroku
-      api_key: $HEROKU_API_KEY_ENCRYPTED
+      api_key:
+        secure: lVZxGuy5uNaR4OdFfV3uu7bEqlN2RwC9UzeYEh/712UPM0AOXYRW+3UdjTn3Zr2e11bE1h7K2OcqJp7WhV25sUD2PPezKkf9lxrmu48UtzlGlkQJH1/fb3jlATV1uCtgxgutzysmcnw9ewtOnSoQltT+rFXQeFR62chqqtkA5qYFWgUxSlEK8Y1Z7uFRTPdBS33R5qDhyuohsI8FM64q4XtmARHsjUuOry8L8Ia89Rue5pbkfl29eRLt3ZAQX2ZVaevqgxWMEaOvKLqN7ZpeM3uQEA8M5G7PbdC3EVe8HvdjsXXVyOD/ljhdSxvW1xt/aV+Q1yHWNmv4FGTdQzPqzUPv1DorLTSusf4zePEGA56zdCNZ56x1wvV8rba01qNbrtrKewtTPcKp/M5bgyGGXSVFNGWnQv08hVOTXQEGWEqB/gcAAn+uCIl1eflySbxKX/LCMWjmCx0tfdKtS23hxuZPsWKKIJhUYWfpP7VWUok0z+XxCbhboSTsspw0VZmXsv6Vm6OpplVu3Sc2O4riVOZnRNLPiPeGszIwbNK0qlUG/G+RiLFuKZoI8RBhYprebIcZu2rd+F/yElhlHWvBQlvL8FQE1FKnjmIxyjY698gs7acC7ste7HxZp3m29+mEvnJcCfAqkFe2960+JVXB2p012g0vvQkznA/HbO6xq04=
       app:
         co-ops: rubytoolbox-production
       run:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,14 @@ jobs:
     - bundle exec rspec
   - script: bundle exec rubocop
   - stage: deploy
+    cache: skip
+    install: skip
+    before_script: skip
     script: skip
     deploy:
       provider: heroku
-      api_key:
-        secure: $HEROKU_API_KEY_ENCRYPTED
+      api_key: $HEROKU_API_KEY_ENCRYPTED
       app:
         co-ops: rubytoolbox-production
       run:
-        - "rake db:migrate"
-
+      - rake db:migrate

--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,8 @@ gem "webpacker", require: false
 
 gem "foreman", require: false
 
+gem "appsignal"
+
 gem "rack-canonical-host"
 gem "rack-ssl-enforcer"
 

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,8 @@ gem "slim-rails"
 
 # Shorter request logs
 gem "lograge"
+# Needed for logstash json_event formatter for lograge
+gem "logstash-event"
 
 # Faster JSON
 gem "oj"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,8 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    appsignal (2.4.0)
+      rack
     arel (8.0.0)
     ast (2.3.0)
     bindex (0.5.0)
@@ -278,6 +280,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  appsignal
   byebug
   coffee-rails (~> 4.2)
   foreman

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,7 @@ GEM
       activesupport (>= 4, < 5.2)
       railties (>= 4, < 5.2)
       request_store (~> 1.0)
+    logstash-event (1.2.02)
     loofah (2.1.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -285,6 +286,7 @@ DEPENDENCIES
   guard-rubocop
   listen (>= 3.0.5, < 3.2)
   lograge
+  logstash-event
   oj
   overcommit
   pg (~> 0.18)

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,6 +28,7 @@ module Rubytoolbox
     # -- all .rb files in that directory are automatically loaded.
 
     config.lograge.enabled = true
+    config.lograge.formatter = Lograge::Formatters::Logstash.new
 
     config.active_record.schema_format = :sql
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]


### PR DESCRIPTION
A bunch of ops tidbits:

* Set rails logger to info in production (*that default of `debug` is surprising...*)
* Use logstash json_event formatter for better log analytics
* ~~Move Heroku deploy API key from `.travis.yml` to travis env (keeping it encrypted) - this adds an extra layer of protection in case Travis' private key is leaked, and also makes it easier to change down the line~~ Turns out this is much harder to achieve than I thought... I could not figure out from neither Travis docs nor github code search how to set this up appropriately - maybe was using `travis encrypt` wrong, but I tried many variants. Will need to follow up with travis support.
