### PR TITLE
Rubygem info import

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,3 +62,7 @@ Style/StringLiterals:
 
 Style/TrailingCommaInLiteral:
   EnforcedStyleForMultiline: comma
+
+RSpec/FilePath:
+  Exclude:
+    - 'spec/integration/*'

--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,8 @@ gem "forgery"
 gem "rack-canonical-host"
 gem "rack-ssl-enforcer"
 
+gem "http"
+
 gem "sidekiq"
 
 gem "redcarpet"
@@ -69,6 +71,9 @@ end
 group :test do
   gem "rails-controller-testing"
   gem "simplecov", require: false
+
+  gem "vcr"
+  gem "webmock"
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,7 @@ group :test do
   gem "simplecov", require: false
 
   gem "vcr"
-  gem "webmock"
+  gem "webmock", require: "webmock/rspec"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,9 +59,13 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.0.5)
     connection_pool (2.2.1)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     crass (1.0.3)
     diff-lcs (1.3)
     docile (1.1.5)
+    domain_name (0.5.20170404)
+      unf (>= 0.0.5, < 1.0.0)
     dotenv (0.7.0)
     erubi (1.7.0)
     execjs (2.7.0)
@@ -94,6 +98,16 @@ GEM
     guard-rubocop (1.3.0)
       guard (~> 2.0)
       rubocop (~> 0.20)
+    hashdiff (0.3.7)
+    http (2.2.2)
+      addressable (~> 2.3)
+      http-cookie (~> 1.0)
+      http-form_data (~> 1.0.1)
+      http_parser.rb (~> 0.6.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    http-form_data (1.0.3)
+    http_parser.rb (0.6.0)
     i18n (0.9.1)
       concurrent-ruby (~> 1.0)
     iniparse (1.4.4)
@@ -218,6 +232,7 @@ GEM
       rubocop (>= 0.52.0)
     ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
+    safe_yaml (1.0.4)
     sass (3.5.3)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -270,12 +285,20 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.1.2)
       execjs (>= 0.3.0, < 3)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.4)
     unicode-display_width (1.3.0)
+    vcr (3.0.3)
     web-console (3.5.1)
       actionview (>= 5.0)
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webmock (2.3.2)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     webpacker (3.2.0)
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
@@ -296,6 +319,7 @@ DEPENDENCIES
   guard-bundler
   guard-rspec
   guard-rubocop
+  http
   listen (>= 3.0.5, < 3.2)
   lograge
   logstash-event
@@ -321,7 +345,9 @@ DEPENDENCIES
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
+  vcr
   web-console (>= 3.3.0)
+  webmock
   webpacker
 
 RUBY VERSION

--- a/app/jobs/rubygem_info_job.rb
+++ b/app/jobs/rubygem_info_job.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class RubygemInfoJob < ApplicationJob
+  def perform(name)
+    info = fetch_gem_info name
+
+    if info
+      Rubygem.find_or_initialize_by(name: name).tap do |gem|
+        gem.update_attributes! description: info["info"],
+                               downloads: info["downloads"]
+      end
+    else
+      Rubygem.where(name: name).destroy_all
+    end
+  end
+
+  private
+
+  def fetch_gem_info(name)
+    url = File.join("https://rubygems.org/api/v1/gems", "#{name}.json")
+    response = HTTP.get(url)
+
+    return nil if response.status == 404
+    return Oj.load(response.body)  if response.status == 200
+
+    raise "Unknown response status #{response.status}"
+  end
+end

--- a/app/jobs/rubygem_update_job.rb
+++ b/app/jobs/rubygem_update_job.rb
@@ -18,7 +18,7 @@ class RubygemUpdateJob < ApplicationJob
 
   def fetch_gem_info(name)
     url = File.join("https://rubygems.org/api/v1/gems", "#{name}.json")
-    response = HTTP.get(url)
+    response = HttpService.client.get url
 
     return nil if response.status == 404
     return Oj.load(response.body)  if response.status == 200

--- a/app/jobs/rubygem_update_job.rb
+++ b/app/jobs/rubygem_update_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RubygemInfoJob < ApplicationJob
+class RubygemUpdateJob < ApplicationJob
   def perform(name)
     info = fetch_gem_info name
 
@@ -23,6 +23,6 @@ class RubygemInfoJob < ApplicationJob
     return nil if response.status == 404
     return Oj.load(response.body)  if response.status == 200
 
-    raise "Unknown response status #{response.status}"
+    raise "Unknown response status #{response.status.to_i}"
   end
 end

--- a/app/jobs/rubygem_update_job.rb
+++ b/app/jobs/rubygem_update_job.rb
@@ -6,8 +6,7 @@ class RubygemUpdateJob < ApplicationJob
 
     if info
       Rubygem.find_or_initialize_by(name: name).tap do |gem|
-        gem.update_attributes! description: info["info"],
-                               downloads: info["downloads"]
+        gem.update_attributes! mapped_attributes(info)
       end
     else
       Rubygem.where(name: name).destroy_all
@@ -15,6 +14,26 @@ class RubygemUpdateJob < ApplicationJob
   end
 
   private
+
+  ATTRIBUTE_MAPPING = {
+    authors: :authors,
+    bug_tracker_uri: :bug_tracker_url,
+    documentation_uri: :documentation_url,
+    downloads: :downloads,
+    homepage_uri: :homepage_url,
+    info: :description,
+    licenses: :licenses,
+    mailing_list_uri: :mailing_list_url,
+    source_code_uri: :source_code_url,
+    version: :current_version,
+    wiki_uri: :wiki_url,
+  }.freeze
+
+  def mapped_attributes(info)
+    ATTRIBUTE_MAPPING.each_with_object({}) do |(remote_name, local_name), mapped|
+      mapped[local_name] = info[remote_name.to_s].presence
+    end
+  end
 
   def fetch_gem_info(name)
     url = File.join("https://rubygems.org/api/v1/gems", "#{name}.json")

--- a/app/jobs/rubygems_sync_job.rb
+++ b/app/jobs/rubygems_sync_job.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rubygems"
+require "rubygems/remote_fetcher"
+require "rubygems/name_tuple"
+
+class RubygemsSyncJob < ApplicationJob
+  def perform
+    (remote_gems - local_gems).each do |locally_missing_gem|
+      RubygemUpdateJob.perform_async locally_missing_gem
+    end
+
+    (local_gems - remote_gems).each do |remotely_missing_gem|
+      RubygemUpdateJob.perform_async remotely_missing_gem
+    end
+  end
+
+  def local_gems
+    @local_gems ||= Rubygem.pluck(:name)
+  end
+
+  def remote_gems
+    @remote_gems ||= ::Gem::Source.new("https://rubygems.org")
+                                  .load_specs(:latest)
+                                  .map(&:name)
+  end
+end

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Rubygem < ApplicationRecord
+  self.primary_key = :name
+end

--- a/app/services/http_service.rb
+++ b/app/services/http_service.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module HttpService
+  USER_AGENT = "ruby-toolbox.com API client"
+
+  class << self
+    def client
+      if Rails.configuration.http_connect
+        real_http_client
+      else
+        mock_http_client
+      end
+    end
+
+    private
+
+    def real_http_client
+      HTTP.timeout(connect: 3, write: 3, read: 3)
+          .headers(
+            "Accept" => "application/json",
+            "Content-Type" => "application/json",
+            "User-Agent" => USER_AGENT
+          )
+    end
+
+    def mock_http_client
+      MockClient.new
+    end
+  end
+
+  class MockClient
+    class UnmockedRequestError < StandardError; end
+
+    def get(url)
+      response = responses[url]
+      raise UnmockedRequestError unless response
+      HTTP::Response.new(status: response["status"], body: response["body"], version: "1.1")
+    end
+
+    def responses
+      YAML.load_file responses_source_file_path
+    end
+
+    def responses_source_file_path
+      Rails.root.join("config", "http_mock_responses.yml")
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -42,5 +42,7 @@ module Rubytoolbox
       c.javascripts  = false
       c.stylesheets  = false
     end
+
+    config.http_connect = true
   end
 end

--- a/config/http_mock_responses.yml
+++ b/config/http_mock_responses.yml
@@ -1,0 +1,43 @@
+"https://rubygems.org/api/v1/gems/rspec.json":
+  status: 200
+  body: |
+    {
+      "name": "rspec",
+      "downloads": 145999055,
+      "version": "3.7.0",
+      "version_downloads": 20169199,
+      "platform": "ruby",
+      "authors": "Steven Baker, David Chelimsky, Myron Marston",
+      "info": "BDD for Ruby",
+      "licenses": [
+        "MIT"
+      ],
+      "metadata": {},
+      "sha": "0174cfbed780e42aa181227af623e2ae37511f20a2fdfec48b54f6cf4d7a6404",
+      "project_uri": "https://rubygems.org/gems/rspec",
+      "gem_uri": "https://rubygems.org/gems/rspec-3.7.0.gem",
+      "homepage_uri": "http://github.com/rspec",
+      "wiki_uri": "",
+      "documentation_uri": "http://relishapp.com/rspec",
+      "mailing_list_uri": "http://rubyforge.org/mailman/listinfo/rspec-users",
+      "source_code_uri": "http://github.com/rspec/rspec",
+      "bug_tracker_uri": "",
+      "changelog_uri": null,
+      "dependencies": {
+        "development": [],
+        "runtime": [
+          {
+            "name": "rspec-core",
+            "requirements": "~> 3.7.0"
+          },
+          {
+            "name": "rspec-expectations",
+            "requirements": "~> 3.7.0"
+          },
+          {
+            "name": "rspec-mocks",
+            "requirements": "~> 3.7.0"
+          }
+        ]
+      }
+    }

--- a/db/migrate/20171230223928_create_rubygems.rb
+++ b/db/migrate/20171230223928_create_rubygems.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateRubygems < ActiveRecord::Migration[5.1]
+  def change
+    create_table :rubygems, id: false do |t|
+      t.string  :name, null: false
+      t.text    :description
+      t.integer :downloads, null: false
+      t.timestamps
+    end
+
+    add_index :rubygems, :name, unique: true
+  end
+end

--- a/db/migrate/20171230223928_create_rubygems.rb
+++ b/db/migrate/20171230223928_create_rubygems.rb
@@ -4,8 +4,21 @@ class CreateRubygems < ActiveRecord::Migration[5.1]
   def change
     create_table :rubygems, id: false do |t|
       t.string  :name, null: false
-      t.text    :description
       t.integer :downloads, null: false
+      t.string  :current_version, null: false
+
+      t.string  :authors
+      t.text    :description
+      t.string  :licenses, array: true, default: []
+
+      t.string :bug_tracker_url,
+               :changelog_url,
+               :documentation_url,
+               :homepage_url,
+               :mailing_list_url,
+               :source_code_url,
+               :wiki_url
+
       t.timestamps
     end
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -103,6 +103,25 @@ CREATE TABLE category_groups (
 CREATE TABLE projects (
     permalink character varying NOT NULL,
     created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
+    repo character varying,
+    description text,
+    downloads integer,
+    stars integer,
+    watchers integer,
+    forks integer
+);
+
+
+--
+-- Name: rubygems; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE rubygems (
+    name character varying NOT NULL,
+    description text,
+    downloads integer NOT NULL,
+    created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL
 );
 
@@ -197,6 +216,13 @@ CREATE UNIQUE INDEX index_projects_on_permalink ON projects USING btree (permali
 
 
 --
+-- Name: index_rubygems_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE UNIQUE INDEX index_rubygems_on_name ON rubygems USING btree (name);
+
+
+--
 -- Name: fk_rails_1c87ed593b; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -231,6 +257,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20171026202351'),
 ('20171026220117'),
 ('20171026221717'),
-('20171028210534');
+('20171028210534'),
+('20171230221823'),
+('20171230223928');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -103,13 +103,7 @@ CREATE TABLE category_groups (
 CREATE TABLE projects (
     permalink character varying NOT NULL,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL,
-    repo character varying,
-    description text,
-    downloads integer,
-    stars integer,
-    watchers integer,
-    forks integer
+    updated_at timestamp without time zone NOT NULL
 );
 
 
@@ -119,8 +113,18 @@ CREATE TABLE projects (
 
 CREATE TABLE rubygems (
     name character varying NOT NULL,
-    description text,
     downloads integer NOT NULL,
+    current_version character varying NOT NULL,
+    authors character varying,
+    description text,
+    licenses character varying[] DEFAULT '{}'::character varying[],
+    bug_tracker_url character varying,
+    changelog_url character varying,
+    documentation_url character varying,
+    homepage_url character varying,
+    mailing_list_url character varying,
+    source_code_url character varying,
+    wiki_url character varying,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL
 );
@@ -258,7 +262,6 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20171026220117'),
 ('20171026221717'),
 ('20171028210534'),
-('20171230221823'),
 ('20171230223928');
 
 

--- a/spec/cassettes/rspec.yml
+++ b/spec/cassettes/rspec.yml
@@ -1,0 +1,86 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://rubygems.org/api/v1/gems/rspec.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - rubygems.org
+      User-Agent:
+      - http.rb/2.2.2
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'; script-src 'self' https://secure.gaug.es; style-src 'self'
+        https://fonts.googleapis.com; img-src 'self' https://secure.gaug.es https://gravatar.com
+        https://secure.gravatar.com; font-src 'self' https://fonts.gstatic.com; connect-src
+        https://s3-us-west-2.amazonaws.com/rubygems-dumps/; frame-src https://ghbtns.com
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET
+      Access-Control-Max-Age:
+      - '1728000'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 5ba49d3c-d613-4ee9-8e05-3a70eb6a37b1
+      X-Runtime:
+      - '0.014185'
+      Strict-Transport-Security:
+      - max-age=0
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      X-Backend:
+      - F_Rails 54.186.104.15:443
+      Transfer-Encoding:
+      - chunked
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 02 Jan 2018 19:38:55 GMT
+      Via:
+      - 1.1 varnish
+      Age:
+      - '0'
+      Connection:
+      - close
+      X-Served-By:
+      - cache-hhn1521-HHN
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1514921935.087763,VS0,VE175
+      Vary:
+      - Accept-Encoding,Fastly-SSL
+      Etag:
+      - '"db395f58b6abb4a2f5472e4819cae84e"'
+      Server:
+      - RubyGems.org
+    body:
+      encoding: UTF-8
+      string: '{"name":"rspec","downloads":145987798,"version":"3.7.0","version_downloads":20159948,"platform":"ruby","authors":"Steven
+        Baker, David Chelimsky, Myron Marston","info":"BDD for Ruby","licenses":["MIT"],"metadata":{},"sha":"0174cfbed780e42aa181227af623e2ae37511f20a2fdfec48b54f6cf4d7a6404","project_uri":"https://rubygems.org/gems/rspec","gem_uri":"https://rubygems.org/gems/rspec-3.7.0.gem","homepage_uri":"http://github.com/rspec","wiki_uri":"","documentation_uri":"http://relishapp.com/rspec","mailing_list_uri":"http://rubyforge.org/mailman/listinfo/rspec-users","source_code_uri":"http://github.com/rspec/rspec","bug_tracker_uri":"","changelog_uri":null,"dependencies":{"development":[],"runtime":[{"name":"rspec-core","requirements":"~\u003e
+        3.7.0"},{"name":"rspec-expectations","requirements":"~\u003e 3.7.0"},{"name":"rspec-mocks","requirements":"~\u003e
+        3.7.0"}]}}'
+    http_version: 
+  recorded_at: Tue, 02 Jan 2018 19:38:55 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/unknown_gem.yml
+++ b/spec/cassettes/unknown_gem.yml
@@ -1,0 +1,56 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://rubygems.org/api/v1/gems/(foo).json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - rubygems.org
+      User-Agent:
+      - http.rb/2.2.2
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Request-Id:
+      - 2157e20f-5b90-4a33-8ccc-012c3c1da35f
+      X-Runtime:
+      - '0.001416'
+      Strict-Transport-Security:
+      - max-age=0
+      Content-Length:
+      - '34'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 02 Jan 2018 19:38:54 GMT
+      Via:
+      - 1.1 varnish
+      Age:
+      - '90'
+      Connection:
+      - close
+      X-Served-By:
+      - cache-hhn1525-HHN
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1514921935.917655,VS0,VE0
+      Server:
+      - RubyGems.org
+    body:
+      encoding: UTF-8
+      string: '{"status":404,"error":"Not Found"}'
+    http_version: 
+  recorded_at: Tue, 02 Jan 2018 19:38:54 GMT
+recorded_with: VCR 3.0.3

--- a/spec/integration/rubygem_update_spec.rb
+++ b/spec/integration/rubygem_update_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe RubygemUpdateJob do
+RSpec.describe RubygemUpdateJob, :real_http do
   let(:job) { described_class.new }
   let(:do_perform) { job.perform gem_name }
 

--- a/spec/integration/rubygem_update_spec.rb
+++ b/spec/integration/rubygem_update_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe RubygemUpdateJob, :real_http do
 
     describe "which exists locally" do
       it "deletes the local record" do
-        Rubygem.create! name: gem_name, downloads: 500
+        Rubygem.create! name: gem_name, downloads: 500, current_version: "123"
         expect { do_perform }.to change { Rubygem.count }.by(-1)
       end
     end

--- a/spec/integration/rubygem_update_spec.rb
+++ b/spec/integration/rubygem_update_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RubygemInfoJob do
+  let(:job) { described_class.new }
+  let(:do_perform) { job.perform gem_name }
+
+  describe "for existing gem" do
+    let(:gem_name) { "rspec" }
+
+    shared_examples_for "a rubygem data update" do
+      it "stores the data locally" do
+        do_perform
+        expect(Rubygem.find(gem_name)).to have_attributes(
+          description: kind_of(String),
+          downloads: (a_value > 1_000_000)
+        )
+      end
+    end
+
+    describe "which exists locally" do
+      it_behaves_like "a rubygem data update"
+    end
+
+    describe "which does not exist locally" do
+      it "creates a new record" do
+        expect { do_perform }.to change { Rubygem.count }.by(1)
+      end
+
+      it_behaves_like "a rubygem data update"
+    end
+  end
+
+  describe "for non-existent gem" do
+    let(:gem_name) { "(foo)" }
+
+    describe "which exists locally" do
+      it "deletes the local record" do
+        Rubygem.create! name: gem_name, downloads: 500
+        expect { do_perform }.to change { Rubygem.count }.by(-1)
+      end
+    end
+
+    describe "which does not exist locally" do
+      it "does not create a record" do
+        expect { do_perform }.not_to(change { Rubygem.count })
+      end
+    end
+  end
+end

--- a/spec/jobs/rubygem_update_job_spec.rb
+++ b/spec/jobs/rubygem_update_job_spec.rb
@@ -8,13 +8,26 @@ RSpec.describe RubygemUpdateJob, type: :job do
   let(:gem_name) { "rspec" }
 
   describe "#perform" do
+    let(:expected_attributes) do
+      {
+        authors: "Steven Baker, David Chelimsky, Myron Marston",
+        bug_tracker_url: nil,
+        current_version: "3.7.0",
+        documentation_url: "http://relishapp.com/rspec",
+        downloads: 145_999_055,
+        homepage_url: "http://github.com/rspec",
+        licenses: %w[MIT],
+        mailing_list_url: "http://rubyforge.org/mailman/listinfo/rspec-users",
+        name: "rspec",
+        source_code_url: "http://github.com/rspec/rspec",
+        wiki_url: nil,
+      }
+    end
+
     it "applies the remote info attributes" do
       do_perform
 
-      expect(Rubygem.find(gem_name)).to have_attributes(
-        name: "rspec",
-        downloads: 145_999_055
-      )
+      expect(Rubygem.find(gem_name)).to have_attributes(expected_attributes)
     end
   end
 end

--- a/spec/jobs/rubygem_update_job_spec.rb
+++ b/spec/jobs/rubygem_update_job_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RubygemUpdateJob, type: :job do
+  let(:job) { described_class.new }
+  let(:do_perform) { job.perform gem_name }
+  let(:gem_name) { "rspec" }
+
+  describe "#perform" do
+    it "applies the remote info attributes" do
+      do_perform
+
+      expect(Rubygem.find(gem_name)).to have_attributes(
+        name: "rspec",
+        downloads: 145_999_055
+      )
+    end
+  end
+end

--- a/spec/jobs/rubygems_sync_job_spec.rb
+++ b/spec/jobs/rubygems_sync_job_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RubygemsSyncJob, type: :job do
+  let(:job) { described_class.new }
+
+  describe "#remote_gems" do
+    it "acquires the latest rubygems specs and returns all gem names" do
+      source = instance_double(::Gem::Source)
+
+      allow(::Gem::Source).to receive(:new)
+        .with("https://rubygems.org")
+        .and_return(source)
+
+      specs = [OpenStruct.new(name: "foo"), OpenStruct.new(name: "bar")]
+      allow(source).to receive(:load_specs)
+        .with(:latest).and_return(specs)
+
+      expect(job.remote_gems).to be == %w[foo bar]
+    end
+  end
+
+  describe "#local_gems" do
+    it "is a collection of names of local gems" do
+      allow(Rubygem).to receive(:pluck).with(:name).and_return(%w[foo bar])
+      expect(job.local_gems).to be == %w[foo bar]
+    end
+  end
+
+  describe "#perform" do
+    let(:local_gems)  { %w[rspec what simplecov] }
+    let(:remote_gems) { %w[rspec rails simplecov] }
+
+    before do
+      allow(job).to receive(:local_gems).and_return(local_gems)
+      allow(job).to receive(:remote_gems).and_return(remote_gems)
+    end
+
+    it "triggers update jobs for all locally missing gems" do
+      allow(RubygemUpdateJob).to receive(:perform_async).with("what")
+      expect(RubygemUpdateJob).to receive(:perform_async).with("rails")
+      job.perform
+    end
+
+    it "triggers update jobs for all remotely missing gems" do
+      allow(RubygemUpdateJob).to receive(:perform_async).with("rails")
+      expect(RubygemUpdateJob).to receive(:perform_async).with("what")
+      job.perform
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -51,6 +51,10 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = true
 
+  config.before do |example|
+    Rails.configuration.http_connect = example.metadata[:real_http]
+  end
+
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
   # `post` in specs under `spec/controllers`.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -36,6 +36,12 @@ Dir[Rails.root.join("spec", "support", "**", "*.rb")].each { |f| require f }
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!
 
+VCR.configure do |c|
+  c.cassette_library_dir = Rails.root.join("spec", "cassettes")
+  c.hook_into :webmock
+  c.configure_rspec_metadata!
+end
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"

--- a/spec/services/http_service_spec.rb
+++ b/spec/services/http_service_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe HttpService do
+  describe ".client" do
+    let(:client) { described_class.client }
+
+    it "is a MockClient in test env" do
+      expect(client).to be_a described_class::MockClient
+    end
+
+    it "is an HTTP.rb client when given :real_http spec metadata", :real_http do
+      expect(client).to be_a HTTP::Client
+    end
+  end
+
+  describe HttpService::MockClient do
+    describe "#get" do
+      let(:do_get) { described_class.new.get url }
+
+      describe "for a known url" do
+        let(:url) { "https://rubygems.org/api/v1/gems/rspec.json" }
+
+        it "returns an HTTP response" do
+          expect(do_get).to be_a HTTP::Response
+        end
+
+        it "has the expected status code" do
+          expect(do_get.status).to be == 200
+        end
+
+        it "has the expected body" do
+          expect(Oj.load(do_get.body)).to have_key "downloads"
+        end
+      end
+
+      describe "for an unknown url" do
+        let(:url) { "http://www.thisisnotpartofthemocks.com" }
+
+        it "raises an UnmockedRequestError" do
+          expect { do_get }.to raise_error(described_class::UnmockedRequestError)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Following #45, this adds a rubygems db model and background jobs for syncing the general rubygems index itself as well as individual gem info from the rubygems API to the local mirror. 

It also adds basic facilities for unit and integration testing of things that interact with http - in unit specs, the data is fetched from a static yaml file for easy control over the test environment for unit tests, and fuller-stack integration specs should use real HTTP, backed by VCR and webmock.

Next up:

* Link project and rubygem models in the DB
* Detect github repository from gem's urls and set it on the project
* Fetch github repo data
* Calculate scores
* Add actual stats to the beta UI
* Ship it