### PR TITLE
Pull 'rubygems is down' case from integration to unit spec

### DIFF
--- a/config/http_mock_responses.yml
+++ b/config/http_mock_responses.yml
@@ -41,3 +41,6 @@
         ]
       }
     }
+
+"https://rubygems.org/api/v1/gems/thisisdowninmock.json":
+  status: 500

--- a/spec/integration/rubygem_update_spec.rb
+++ b/spec/integration/rubygem_update_spec.rb
@@ -48,17 +48,4 @@ RSpec.describe RubygemUpdateJob, :real_http do
       end
     end
   end
-
-  describe "when rubygems is down" do
-    let(:gem_name) { "foo" }
-
-    before do
-      stub_request(:get, "https://rubygems.org/api/v1/gems/foo.json")
-        .to_return(status: 500)
-    end
-
-    it "raises an exception" do
-      expect { do_perform }.to raise_error "Unknown response status 500"
-    end
-  end
 end

--- a/spec/jobs/rubygem_update_job_spec.rb
+++ b/spec/jobs/rubygem_update_job_spec.rb
@@ -29,5 +29,13 @@ RSpec.describe RubygemUpdateJob, type: :job do
 
       expect(Rubygem.find(gem_name)).to have_attributes(expected_attributes)
     end
+
+    describe "when rubygems.org is down" do
+      let(:gem_name) { "thisisdowninmock" }
+
+      it "raises an exception" do
+        expect { do_perform }.to raise_error "Unknown response status 500"
+      end
+    end
   end
 end


### PR DESCRIPTION
Oops, I forgot to push this final commit in #47 :confetti_ball: 