### PR TITLE
Improve responsiveness of project stats on mobile

### DIFF
--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -82,14 +82,21 @@ header.section
   .description
     @extend .has-text-grey
     padding: 0.75rem
+
   .metrics
-    @extend .columns
+    @extend .columns, .is-multiline
     display: flex
+    strong
+      @extend .is-size-5
+
+    .label
+      @extend .column, .is-2-tablet, .is-12-mobile
+      align-self: flex-end
+
     .metric
-      @extend .column
+      @extend .column, .is-3-tablet, .is-6-mobile
       // Align content to bottom
       align-self: flex-end
       strong
-        @extend .is-size-5
         // Compensate for default icon padding in heading above
         margin-left: 5px

--- a/app/views/categories/show.html.slim
+++ b/app/views/categories/show.html.slim
@@ -21,31 +21,32 @@ section.section: .container: .columns
           = project.description
 
         .metrics
-          .metric
+          .label
             span &nbsp;
             strong
               | Popularity
-          .metric
-            .heading
-              span.icon
-                i.fa.fa-download
-              | Downloads
-            strong= rand(500_000)
-          .metric
-            .heading
-              span.icon
-                i.fa.fa-star
-              | Stars
-            strong= rand(3000)
-          .metric
-            .heading
-              span.icon
-                i.fa.fa-code-fork
-              | Forks
-            strong= rand(500)
-          .metric
-            .heading
-              span.icon
-                i.fa.fa-eye
-              | Watchers
-            strong= rand(100)
+          .column: .metrics
+            .metric
+              .heading
+                span.icon
+                  i.fa.fa-download
+                | Downloads
+              strong= rand(500_000)
+            .metric
+              .heading
+                span.icon
+                  i.fa.fa-star
+                | Stars
+              strong= rand(3000)
+            .metric
+              .heading
+                span.icon
+                  i.fa.fa-code-fork
+                | Forks
+              strong= rand(500)
+            .metric
+              .heading
+                span.icon
+                  i.fa.fa-eye
+                | Watchers
+              strong= rand(100)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,5 +3,5 @@
 
 
 bulma@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/bulma/-/bulma-0.6.0.tgz#4f5c5de582810d11aa0cfb1f30aec8a792d0d92c"
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/bulma/-/bulma-0.6.1.tgz#5f21a77c0c06f7d80051c06628c23516081bd649"


### PR DESCRIPTION
This changes the display of stats on mobile from 

![localhost_3000_categories_background_jobs nexus 6p 1](https://user-images.githubusercontent.com/13972/34505209-fdf8f8f4-f023-11e7-85d2-8f08278aa535.png)

to

![localhost_3000_categories_background_jobs nexus 6p](https://user-images.githubusercontent.com/13972/34505214-045857da-f024-11e7-89c9-881be0287ce4.png)

* Also fixes some mistaken margin on the stats row label
* Also upgrades https://bulma.io/