### PR TITLE
Rubygems to Projects

### DIFF
--- a/app/jobs/project_update_job.rb
+++ b/app/jobs/project_update_job.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class ProjectUpdateJob < ApplicationJob
+  def perform(permalink)
+    Project.find_or_initialize_by(permalink: permalink).tap do |project|
+      project.rubygem = Rubygem.find_by(name: permalink)
+      project.github_repo_path = detect_repo_path(project)&.strip&.downcase
+      project.save!
+    end
+  end
+
+  private
+
+  def detect_repo_path(project)
+    if project.github_only?
+      project.permalink
+    else
+      return unless project.rubygem
+      Github.detect_repo_name project.rubygem.homepage_url,
+                              project.rubygem.source_code_url,
+                              project.rubygem.bug_tracker_url
+    end
+  end
+end

--- a/app/jobs/rubygem_update_job.rb
+++ b/app/jobs/rubygem_update_job.rb
@@ -8,6 +8,7 @@ class RubygemUpdateJob < ApplicationJob
       Rubygem.find_or_initialize_by(name: name).tap do |gem|
         gem.update_attributes! mapped_attributes(info)
       end
+      ProjectUpdateJob.perform_async name
     else
       Rubygem.where(name: name).destroy_all
     end

--- a/app/models/github.rb
+++ b/app/models/github.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Github
+  ALLOWED_HOSTS = %w[github.com www.github.com].freeze
+
+  # Tries to find a github repo name from the given urls
+  def self.detect_repo_name(*urls)
+    urls.map(&:presence).compact.each do |url|
+      next unless ALLOWED_HOSTS.include? URI.parse(url).host
+      match = url.match %r{github\.com\/([^\/]+\/[^\/]+)}
+      return match[1] if match
+    rescue URI::InvalidURIError
+      next
+    end
+
+    nil
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -18,6 +18,10 @@ class Project < ApplicationRecord
              optional:    true,
              inverse_of:  :project
 
+  def github_only?
+    permalink.include? "/"
+  end
+
   def description
     Forgery(:lorem_ipsum).words(rand(20..39))
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -12,11 +12,17 @@ class Project < ApplicationRecord
 
   has_many :categories, through: :categorizations
 
+  belongs_to :rubygem,
+             primary_key: :name,
+             foreign_key: :rubygem_name,
+             optional:    true,
+             inverse_of:  :project
+
   def description
     Forgery(:lorem_ipsum).words(rand(20..39))
   end
 
   def score
-    (rand * 100.0).round(2)
+    rand(100).round(2)
   end
 end

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -2,4 +2,10 @@
 
 class Rubygem < ApplicationRecord
   self.primary_key = :name
+
+  has_one :project,
+          primary_key: :name,
+          foreign_key: :rubygem_name,
+          inverse_of: :rubygem,
+          dependent: :destroy
 end

--- a/db/migrate/20180103193038_add_gem_and_repo_to_projects.rb
+++ b/db/migrate/20180103193038_add_gem_and_repo_to_projects.rb
@@ -5,5 +5,6 @@ class AddGemAndRepoToProjects < ActiveRecord::Migration[5.1]
     add_column :projects, :rubygem_name, :string
     add_column :projects, :github_repo_path, :string
     add_index  :projects, :rubygem_name, unique: true
+    add_foreign_key :projects, :rubygems, column: :rubygem_name, primary_key: :name
   end
 end

--- a/db/migrate/20180103193038_add_gem_and_repo_to_projects.rb
+++ b/db/migrate/20180103193038_add_gem_and_repo_to_projects.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddGemAndRepoToProjects < ActiveRecord::Migration[5.1]
+  def change
+    add_column :projects, :rubygem_name, :string
+    add_column :projects, :github_repo_path, :string
+    add_index  :projects, :rubygem_name, unique: true
+  end
+end

--- a/db/migrate/20180103194335_add_check_constraint_on_project_gem_reference.rb
+++ b/db/migrate/20180103194335_add_check_constraint_on_project_gem_reference.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class AddCheckConstraintOnProjectGemReference < ActiveRecord::Migration[5.1]
+  def self.up
+    execute <<~SQL
+      ALTER TABLE
+        projects
+      ADD CONSTRAINT
+        check_project_permalink_and_rubygem_name_parity
+      CHECK (
+        rubygem_name IS NULL OR rubygem_name = permalink
+      )
+    SQL
+  end
+
+  def self.down
+    execute "ALTER TABLE projects DROP CONSTRAINT check_project_permalink_and_rubygem_name_parity"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -19,6 +19,20 @@ CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
 COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
 
 
+--
+-- Name: pg_stat_statements; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION pg_stat_statements; Type: COMMENT; Schema: -; Owner: -
+--
+
+COMMENT ON EXTENSION pg_stat_statements IS 'track execution statistics of all SQL statements executed';
+
+
 SET search_path = public, pg_catalog;
 
 SET default_tablespace = '';
@@ -258,6 +272,14 @@ ALTER TABLE ONLY categorizations
 
 ALTER TABLE ONLY categories
     ADD CONSTRAINT fk_rails_4bd2d3273a FOREIGN KEY (category_group_permalink) REFERENCES category_groups(permalink);
+
+
+--
+-- Name: fk_rails_ddb4eb0108; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY projects
+    ADD CONSTRAINT fk_rails_ddb4eb0108 FOREIGN KEY (rubygem_name) REFERENCES rubygems(name);
 
 
 --

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -103,7 +103,10 @@ CREATE TABLE category_groups (
 CREATE TABLE projects (
     permalink character varying NOT NULL,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    rubygem_name character varying,
+    github_repo_path character varying,
+    CONSTRAINT check_project_permalink_and_rubygem_name_parity CHECK (((rubygem_name IS NULL) OR ((rubygem_name)::text = (permalink)::text)))
 );
 
 
@@ -220,6 +223,13 @@ CREATE UNIQUE INDEX index_projects_on_permalink ON projects USING btree (permali
 
 
 --
+-- Name: index_projects_on_rubygem_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE UNIQUE INDEX index_projects_on_rubygem_name ON projects USING btree (rubygem_name);
+
+
+--
 -- Name: index_rubygems_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -262,6 +272,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20171026220117'),
 ('20171026221717'),
 ('20171028210534'),
-('20171230223928');
+('20171230223928'),
+('20180103193038'),
+('20180103194335');
 
 

--- a/spec/jobs/project_update_job_spec.rb
+++ b/spec/jobs/project_update_job_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ProjectUpdateJob, type: :job do
+  let(:job) { described_class.new }
+  let(:do_perform) { job.perform permalink }
+  let(:permalink) { "rspec" }
+
+  describe "#perform" do
+    it "creates the project if not existent yet" do
+      expect { do_perform }.to change { Project.find_by(permalink: permalink) }
+        .from(nil).to(kind_of(Project))
+    end
+
+    it "does not create another project if present" do
+      Project.create! permalink: permalink
+      expect { do_perform }.not_to(change { Project.count })
+    end
+
+    it "assigns an existing gem if matching" do
+      project = Project.create! permalink: permalink
+      RubygemUpdateJob.new.perform(permalink)
+      rubygem = Rubygem.find(permalink)
+      expect { do_perform }.to change { project.reload.rubygem }.from(nil).to(rubygem)
+    end
+
+    it "assigns a github_repo_path if detected in gem urls" do
+      project = Project.create! permalink: permalink
+      RubygemUpdateJob.new.perform(permalink)
+      expect { do_perform }.to change { project.reload.github_repo_path }.from(nil).to("rspec/rspec")
+    end
+
+    describe "for github-only project" do
+      let(:permalink) { "RSPEC/RsPeC" } # Also verify downcasing / normalization work
+
+      it "assigns permalink as the github_repo_path for github-only projects" do
+        project = Project.create! permalink: permalink
+        expect { do_perform }.to change { project.reload.github_repo_path }.from(nil).to("rspec/rspec")
+      end
+    end
+  end
+end

--- a/spec/jobs/rubygem_update_job_spec.rb
+++ b/spec/jobs/rubygem_update_job_spec.rb
@@ -30,6 +30,11 @@ RSpec.describe RubygemUpdateJob, type: :job do
       expect(Rubygem.find(gem_name)).to have_attributes(expected_attributes)
     end
 
+    it "enqueues a corresponding project update job" do
+      expect(ProjectUpdateJob).to receive(:perform_async).with(gem_name)
+      do_perform
+    end
+
     describe "when rubygems.org is down" do
       let(:gem_name) { "thisisdowninmock" }
 

--- a/spec/models/github_spec.rb
+++ b/spec/models/github_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Github, type: :model do
+  describe ".detect_repo_name" do
+    {
+      [nil] => nil,
+      [nil, ""] => nil,
+      [nil, "", " "] => nil,
+      [nil, "", "wat"] => nil,
+      ["fakegithub.com/rails/rails"] => nil,
+      ["http://github.com/{github_username}/{project_name}"] => nil,
+      ["http://github.com/rails/rails"] => "rails/rails",
+      ["foobar", "http://github.com/rails/rails"] => "rails/rails",
+    }.each do |args, expected_name|
+      it "is #{expected_name.inspect} when given #{args.inspect}" do
+        expect(Github.detect_repo_name(*args)).to be == expected_name
+      end
+    end
+  end
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -22,4 +22,14 @@ RSpec.describe Project, type: :model do
       /check_project_permalink_and_rubygem_name_parity/
     )
   end
+
+  describe "#github_only?" do
+    it "is false when no / is present in permalink" do
+      expect(Project.new(permalink: "foobar")).not_to be_github_only
+    end
+
+    it "is true when a / is present in permalink" do
+      expect(Project.new(permalink: "foo/bar")).to be_github_only
+    end
+  end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Project, type: :model do
   describe "#score" do
     it "is a random number" do
-      expect(described_class.new.score).to be_a Float
+      expect(described_class.new.score).to be_an Integer
     end
   end
 
@@ -13,5 +13,13 @@ RSpec.describe Project, type: :model do
     it "is a random string" do
       expect(described_class.new.description).to be_a String
     end
+  end
+
+  it "does not allow mismatches between permalink and rubygem name" do
+    project = Project.create! permalink: "simplecov"
+    expect { project.update_attributes! rubygem_name: "rails" }.to raise_error(
+      ActiveRecord::StatementInvalid,
+      /check_project_permalink_and_rubygem_name_parity/
+    )
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,7 @@ require File.expand_path("../../config/environment", __FILE__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require "rspec/rails"
+require "sidekiq/testing"
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # It's early stages, and SimpleCov is not happy about those not being loaded


### PR DESCRIPTION
This adds references between the shallow projects table and rubygems as added via #47 

It also prepares github repo references, detecting them from the gem's URLs on the fly.