### PR TITLE
Report cron errors to appsignal

### DIFF
--- a/app/services/cron.rb
+++ b/app/services/cron.rb
@@ -11,5 +11,8 @@ class Cron
     when 0
       RubygemsSyncJob.perform_async
     end
+  rescue StandardError => err
+    Appsignal.set_error err
+    raise err
   end
 end


### PR DESCRIPTION
Following #53, this forwards cron exceptions to Appsignal