### PR TITLE
Schedule daily updates of rubygem info

### DIFF
--- a/app/jobs/rubygem_update_job.rb
+++ b/app/jobs/rubygem_update_job.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+#
+# This sidekiq background job takes care of syncing the data
+# of one individual rubygem from rubygems.org to the local
+# mirror db
+#
 class RubygemUpdateJob < ApplicationJob
   def perform(name)
     info = fetch_gem_info name

--- a/app/jobs/rubygems_sync_job.rb
+++ b/app/jobs/rubygems_sync_job.rb
@@ -4,6 +4,11 @@ require "rubygems"
 require "rubygems/remote_fetcher"
 require "rubygems/name_tuple"
 
+#
+# This sidekiq background job compares the rubygems.org
+# gem index against the gems present in the local mirror
+# and queues updates on differing gems
+#
 class RubygemsSyncJob < ApplicationJob
   def perform
     (remote_gems - local_gems).each do |locally_missing_gem|

--- a/app/jobs/rubygems_update_scheduler_job.rb
+++ b/app/jobs/rubygems_update_scheduler_job.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+#
+# This sidekiq background job enqueues gem data updates.
+# It tries to distribute updates evenly throughout the day
+# to avoid creating a thundering herd at midnight.
+#
+class RubygemsUpdateSchedulerJob < ApplicationJob
+  def perform
+    Rubygem.update_batch.each do |name|
+      RubygemUpdateJob.perform_async name
+    end
+  end
+end

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -8,4 +8,11 @@ class Rubygem < ApplicationRecord
           foreign_key: :rubygem_name,
           inverse_of: :rubygem,
           dependent: :destroy
+
+  def self.update_batch
+    where("updated_at < ? ", 24.hours.ago.utc)
+      .order(updated_at: :asc)
+      .limit((count / 24.0).ceil)
+      .pluck(:name)
+  end
 end

--- a/app/services/cron.rb
+++ b/app/services/cron.rb
@@ -7,6 +7,8 @@
 #
 class Cron
   def run(time: Time.current.utc)
+    RubygemsUpdateSchedulerJob.perform_async
+
     case time.hour
     when 0
       RubygemsSyncJob.perform_async

--- a/spec/jobs/rubygems_update_scheduler_job_spec.rb
+++ b/spec/jobs/rubygems_update_scheduler_job_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RubygemsUpdateSchedulerJob, type: :job do
+  let(:job) { described_class.new }
+  let(:do_perform) { job.perform }
+
+  it "does nothing when no gems need an update" do
+    allow(Rubygem).to receive(:update_batch).and_return([])
+    expect(RubygemUpdateJob).not_to receive(:perform_async)
+    do_perform
+  end
+
+  # I am not aware of a better way to test consecutive calls here,
+  # if you know one, please send a PR :)
+  #
+  # rubocop:disable RSpec/MultipleExpectations
+  it "enqueues all gems returned in the update_batch" do
+    allow(Rubygem).to receive(:update_batch).and_return(%w[foo bar])
+    expect(RubygemUpdateJob).to receive(:perform_async).with("foo")
+    expect(RubygemUpdateJob).to receive(:perform_async).with("bar")
+    do_perform
+  end
+  # rubocop:enable RSpec/MultipleExpectations
+end

--- a/spec/models/rubygem_spec.rb
+++ b/spec/models/rubygem_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Rubygem, type: :model do
+  describe ".update_batch" do
+    before do
+      Rubygem.create! name: "up-to-date", downloads: 50, current_version: "1.0.0", updated_at: 23.hours.ago
+      Rubygem.create! name: "outdated1", downloads: 50, current_version: "1.0.0", updated_at: 27.hours.ago
+      Rubygem.create! name: "outdated2", downloads: 50, current_version: "1.0.0", updated_at: 26.hours.ago
+    end
+
+    it "contains a subset of gems that should be updated" do
+      expect(described_class.update_batch).to match %w[outdated1]
+    end
+
+    it "the subset grows with to the total count of gems" do
+      24.times do |i|
+        Rubygem.create! name: "outdated#{i + 3}", downloads: 50, current_version: "1.0.0", updated_at: 25.hours.ago
+      end
+
+      expect(described_class.update_batch).to match %w[outdated1 outdated2]
+    end
+  end
+end

--- a/spec/services/cron_spec.rb
+++ b/spec/services/cron_spec.rb
@@ -9,6 +9,11 @@ RSpec.describe Cron, type: :service do
     Time.utc(2018, 1, 3, hour, 10, 12)
   end
 
+  it "queues RubygemUpdateSchedulerJob every hour" do
+    expect(RubygemsUpdateSchedulerJob).to receive(:perform_async)
+    cron.run time: time_at(rand(24))
+  end
+
   it "enqueues RubygemsSyncJob at 0 am" do
     expect(RubygemsSyncJob).to receive(:perform_async)
     cron.run time: time_at(0)


### PR DESCRIPTION
This builds upon #47 and #53 and adds daily updates of rubygem info from the rubygems.org API via sidekiq