### PR TITLE
Touch rubygems on update to track what's been fetched

### DIFF
--- a/app/jobs/rubygem_update_job.rb
+++ b/app/jobs/rubygem_update_job.rb
@@ -11,6 +11,8 @@ class RubygemUpdateJob < ApplicationJob
 
     if info
       Rubygem.find_or_initialize_by(name: name).tap do |gem|
+        # Set updated at to ensure we flag what we've pulled
+        gem.updated_at = Time.current.utc
         gem.update_attributes! mapped_attributes(info)
       end
       ProjectUpdateJob.perform_async name

--- a/spec/jobs/rubygem_update_job_spec.rb
+++ b/spec/jobs/rubygem_update_job_spec.rb
@@ -30,6 +30,12 @@ RSpec.describe RubygemUpdateJob, type: :job do
       expect(Rubygem.find(gem_name)).to have_attributes(expected_attributes)
     end
 
+    it "changes the updated_at timestamp regardless of changes" do
+      described_class.new.perform gem_name
+      Rubygem.find(gem_name).update_attributes! updated_at: 2.days.ago
+      expect { do_perform }.to(change { Rubygem.find(gem_name).updated_at })
+    end
+
     it "enqueues a corresponding project update job" do
       expect(ProjectUpdateJob).to receive(:perform_async).with(gem_name)
       do_perform


### PR DESCRIPTION
This fixes an oversight in #55, in that gems that didn't change at all since the last update would obviously also not get an updated_at change by active record, and hence keep cropping up in the update schedule every hour. This adds an explicit updated_at timestamp on the update job which should fix this issue.