### PR TITLE
Project scores

### DIFF
--- a/app/jobs/project_score_job.rb
+++ b/app/jobs/project_score_job.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class ProjectScoreJob < ApplicationJob
+  def perform(permalink)
+    Project.find(permalink).tap do |project|
+      project.update_attributes! score: score_for_project(project)
+    end
+  end
+
+  private
+
+  def score_for_project(project)
+    scores = [rubygem_score(project.rubygem), github_repo_score(project.github_repo)].compact
+    return if scores.empty?
+    scores.sum / scores.count
+  end
+
+  def rubygem_score(rubygem)
+    return unless rubygem
+    rubygem.downloads * 100.0 / rubygem.class.maximum(:downloads)
+  end
+
+  def github_repo_score(github_repo)
+    return unless github_repo
+    (github_repo.stargazers_count + github_repo.forks_count * 5) * 100.0 /
+      (github_repo.class.maximum(:stargazers_count) + github_repo.class.maximum(:forks_count) * 5)
+  end
+end

--- a/app/jobs/project_update_job.rb
+++ b/app/jobs/project_update_job.rb
@@ -6,6 +6,7 @@ class ProjectUpdateJob < ApplicationJob
       project.rubygem = Rubygem.find_by(name: permalink)
       project.github_repo_path = detect_repo_path(project)
       project.save!
+      ProjectScoreJob.perform_async permalink
       enqueue_github_repo_sync project.github_repo_path
     end
   end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -14,7 +14,8 @@ class Category < ApplicationRecord
            inverse_of:  :category,
            dependent:   :destroy
 
-  has_many :projects, through: :categorizations
+  has_many :projects, -> { order(score: :desc) },
+           through: :categorizations
 
   def self.find_for_show!(permalink)
     includes(:category_group, projects: %i[rubygem]).find(permalink)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -30,12 +30,19 @@ class Project < ApplicationRecord
            allow_nil: true,
            prefix: :rubygem
 
+  delegate :stargazers_count,
+           :forks_count,
+           :description,
+           to: :github_repo,
+           allow_nil: true,
+           prefix: :github_repo
+
   def github_only?
     permalink.include? "/"
   end
 
   def description
-    rubygem_description || github_repo&.description
+    rubygem_description || github_repo_description
   end
 
   def github_repo_path=(github_repo_path)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -35,11 +35,7 @@ class Project < ApplicationRecord
   end
 
   def description
-    rubygem_description
-  end
-
-  def score
-    rand(100).round(2)
+    rubygem_description || github_repo&.description
   end
 
   def github_repo_path=(github_repo_path)

--- a/app/views/categories/show.html.slim
+++ b/app/views/categories/show.html.slim
@@ -27,6 +27,6 @@ section.section: .container: .columns
               | Popularity
           .column: .metrics
             = metric "Downloads", project.rubygem_downloads, icon: "download"
-            = metric "Stars", project.github_repo&.stargazers_count, icon: "star"
-            = metric "Forks", project.github_repo&.forks_count, icon: "code-fork"
-            = metric "Watchers", project.github_repo&.watchers_count, icon: "eye"
+            = metric "Stars", project.github_repo_stargazers_count, icon: "star"
+            = metric "Forks", project.github_repo_forks_count, icon: "code-fork"
+            = metric "Watchers", project.github_repo_watchers_count, icon: "eye"

--- a/db/migrate/20180104223026_add_score_to_projects.rb
+++ b/db/migrate/20180104223026_add_score_to_projects.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddScoreToProjects < ActiveRecord::Migration[5.1]
+  def change
+    add_column :projects, :score, :decimal, precision: 5, scale: 2
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -145,6 +145,7 @@ CREATE TABLE projects (
     updated_at timestamp without time zone NOT NULL,
     rubygem_name character varying,
     github_repo_path character varying,
+    score numeric(5,2),
     CONSTRAINT check_project_permalink_and_rubygem_name_parity CHECK (((rubygem_name IS NULL) OR ((rubygem_name)::text = (permalink)::text)))
 );
 
@@ -329,6 +330,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20171230223928'),
 ('20180103193038'),
 ('20180103194335'),
-('20180103233845');
+('20180103233845'),
+('20180104223026');
 
 

--- a/spec/cassettes/full-project-sync-from-gem.yml
+++ b/spec/cassettes/full-project-sync-from-gem.yml
@@ -1,0 +1,166 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://rubygems.org/api/v1/gems/rspec.json
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ruby-toolbox.com API client
+      Connection:
+      - close
+      Host:
+      - rubygems.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'self'; script-src 'self' https://secure.gaug.es; style-src 'self'
+        https://fonts.googleapis.com; img-src 'self' https://secure.gaug.es https://gravatar.com
+        https://secure.gravatar.com; font-src 'self' https://fonts.gstatic.com; connect-src
+        https://s3-us-west-2.amazonaws.com/rubygems-dumps/; frame-src https://ghbtns.com
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET
+      Access-Control-Max-Age:
+      - '1728000'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - c2f20956-bd96-451a-9a56-fa620d337081
+      X-Runtime:
+      - '0.015169'
+      Strict-Transport-Security:
+      - max-age=0
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      X-Backend:
+      - F_Rails 54.186.104.15:443
+      Transfer-Encoding:
+      - chunked
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Fri, 05 Jan 2018 22:18:50 GMT
+      Via:
+      - 1.1 varnish
+      Age:
+      - '0'
+      Connection:
+      - close
+      X-Served-By:
+      - cache-ams4135-AMS
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1515190731.587696,VS0,VE179
+      Vary:
+      - Accept-Encoding,Fastly-SSL
+      Etag:
+      - '"06eab95c8957ef2bc77e81db97fe00f1"'
+      Server:
+      - RubyGems.org
+    body:
+      encoding: UTF-8
+      string: '{"name":"rspec","downloads":147041200,"version":"3.7.0","version_downloads":21054219,"platform":"ruby","authors":"Steven
+        Baker, David Chelimsky, Myron Marston","info":"BDD for Ruby","licenses":["MIT"],"metadata":{},"sha":"0174cfbed780e42aa181227af623e2ae37511f20a2fdfec48b54f6cf4d7a6404","project_uri":"https://rubygems.org/gems/rspec","gem_uri":"https://rubygems.org/gems/rspec-3.7.0.gem","homepage_uri":"http://github.com/rspec","wiki_uri":"","documentation_uri":"http://relishapp.com/rspec","mailing_list_uri":"http://rubyforge.org/mailman/listinfo/rspec-users","source_code_uri":"http://github.com/rspec/rspec","bug_tracker_uri":"","changelog_uri":null,"dependencies":{"development":[],"runtime":[{"name":"rspec-core","requirements":"~\u003e
+        3.7.0"},{"name":"rspec-expectations","requirements":"~\u003e 3.7.0"},{"name":"rspec-mocks","requirements":"~\u003e
+        3.7.0"}]}}'
+    http_version: 
+  recorded_at: Fri, 05 Jan 2018 22:18:50 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/rspec/rspec?client_id=&client_secret=
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ruby-toolbox.com API client
+      Accept:
+      - application/vnd.github.v3+json
+      Connection:
+      - close
+      Host:
+      - api.github.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Fri, 05 Jan 2018 22:19:27 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '5363'
+      Connection:
+      - close
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '60'
+      X-Ratelimit-Remaining:
+      - '53'
+      X-Ratelimit-Reset:
+      - '1515191452'
+      Cache-Control:
+      - public, max-age=60, s-maxage=60
+      Vary:
+      - Accept
+      Etag:
+      - '"49379f15829c966ada9a46aa6e2659d3"'
+      Last-Modified:
+      - Tue, 02 Jan 2018 22:22:52 GMT
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Runtime-Rack:
+      - '0.039861'
+      X-Github-Request-Id:
+      - B405:6562:CD231A:18FEAF4:5A4FF9EF
+    body:
+      encoding: UTF-8
+      string: '{"id":239001,"name":"rspec","full_name":"rspec/rspec","owner":{"login":"rspec","id":22388,"avatar_url":"https://avatars0.githubusercontent.com/u/22388?v=4","gravatar_id":"","url":"https://api.github.com/users/rspec","html_url":"https://github.com/rspec","followers_url":"https://api.github.com/users/rspec/followers","following_url":"https://api.github.com/users/rspec/following{/other_user}","gists_url":"https://api.github.com/users/rspec/gists{/gist_id}","starred_url":"https://api.github.com/users/rspec/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/rspec/subscriptions","organizations_url":"https://api.github.com/users/rspec/orgs","repos_url":"https://api.github.com/users/rspec/repos","events_url":"https://api.github.com/users/rspec/events{/privacy}","received_events_url":"https://api.github.com/users/rspec/received_events","type":"Organization","site_admin":false},"private":false,"html_url":"https://github.com/rspec/rspec","description":"RSpec
+        meta-gem that depends on the other components","fork":false,"url":"https://api.github.com/repos/rspec/rspec","forks_url":"https://api.github.com/repos/rspec/rspec/forks","keys_url":"https://api.github.com/repos/rspec/rspec/keys{/key_id}","collaborators_url":"https://api.github.com/repos/rspec/rspec/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/rspec/rspec/teams","hooks_url":"https://api.github.com/repos/rspec/rspec/hooks","issue_events_url":"https://api.github.com/repos/rspec/rspec/issues/events{/number}","events_url":"https://api.github.com/repos/rspec/rspec/events","assignees_url":"https://api.github.com/repos/rspec/rspec/assignees{/user}","branches_url":"https://api.github.com/repos/rspec/rspec/branches{/branch}","tags_url":"https://api.github.com/repos/rspec/rspec/tags","blobs_url":"https://api.github.com/repos/rspec/rspec/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/rspec/rspec/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/rspec/rspec/git/refs{/sha}","trees_url":"https://api.github.com/repos/rspec/rspec/git/trees{/sha}","statuses_url":"https://api.github.com/repos/rspec/rspec/statuses/{sha}","languages_url":"https://api.github.com/repos/rspec/rspec/languages","stargazers_url":"https://api.github.com/repos/rspec/rspec/stargazers","contributors_url":"https://api.github.com/repos/rspec/rspec/contributors","subscribers_url":"https://api.github.com/repos/rspec/rspec/subscribers","subscription_url":"https://api.github.com/repos/rspec/rspec/subscription","commits_url":"https://api.github.com/repos/rspec/rspec/commits{/sha}","git_commits_url":"https://api.github.com/repos/rspec/rspec/git/commits{/sha}","comments_url":"https://api.github.com/repos/rspec/rspec/comments{/number}","issue_comment_url":"https://api.github.com/repos/rspec/rspec/issues/comments{/number}","contents_url":"https://api.github.com/repos/rspec/rspec/contents/{+path}","compare_url":"https://api.github.com/repos/rspec/rspec/compare/{base}...{head}","merges_url":"https://api.github.com/repos/rspec/rspec/merges","archive_url":"https://api.github.com/repos/rspec/rspec/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/rspec/rspec/downloads","issues_url":"https://api.github.com/repos/rspec/rspec/issues{/number}","pulls_url":"https://api.github.com/repos/rspec/rspec/pulls{/number}","milestones_url":"https://api.github.com/repos/rspec/rspec/milestones{/number}","notifications_url":"https://api.github.com/repos/rspec/rspec/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/rspec/rspec/labels{/name}","releases_url":"https://api.github.com/repos/rspec/rspec/releases{/id}","deployments_url":"https://api.github.com/repos/rspec/rspec/deployments","created_at":"2009-06-29T16:13:38Z","updated_at":"2018-01-02T22:22:52Z","pushed_at":"2017-11-20T03:41:36Z","git_url":"git://github.com/rspec/rspec.git","ssh_url":"git@github.com:rspec/rspec.git","clone_url":"https://github.com/rspec/rspec.git","svn_url":"https://github.com/rspec/rspec","homepage":"","size":118,"stargazers_count":2148,"watchers_count":2148,"language":"Ruby","has_issues":false,"has_projects":true,"has_downloads":false,"has_wiki":true,"has_pages":false,"forks_count":187,"mirror_url":null,"archived":false,"open_issues_count":0,"license":{"key":"mit","name":"MIT
+        License","spdx_id":"MIT","url":"https://api.github.com/licenses/mit"},"forks":187,"open_issues":0,"watchers":2148,"default_branch":"master","organization":{"login":"rspec","id":22388,"avatar_url":"https://avatars0.githubusercontent.com/u/22388?v=4","gravatar_id":"","url":"https://api.github.com/users/rspec","html_url":"https://github.com/rspec","followers_url":"https://api.github.com/users/rspec/followers","following_url":"https://api.github.com/users/rspec/following{/other_user}","gists_url":"https://api.github.com/users/rspec/gists{/gist_id}","starred_url":"https://api.github.com/users/rspec/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/rspec/subscriptions","organizations_url":"https://api.github.com/users/rspec/orgs","repos_url":"https://api.github.com/users/rspec/repos","events_url":"https://api.github.com/users/rspec/events{/privacy}","received_events_url":"https://api.github.com/users/rspec/received_events","type":"Organization","site_admin":false},"network_count":187,"subscribers_count":95}'
+    http_version: 
+  recorded_at: Fri, 05 Jan 2018 22:19:27 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/full-project-sync-from-github.yml
+++ b/spec/cassettes/full-project-sync-from-github.yml
@@ -1,0 +1,79 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.github.com/repos/postmodern/chruby?client_id=&client_secret=
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - ruby-toolbox.com API client
+      Accept:
+      - application/vnd.github.v3+json
+      Connection:
+      - close
+      Host:
+      - api.github.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Fri, 05 Jan 2018 23:30:35 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '4792'
+      Connection:
+      - close
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '60'
+      X-Ratelimit-Remaining:
+      - '59'
+      X-Ratelimit-Reset:
+      - '1515198635'
+      Cache-Control:
+      - public, max-age=60, s-maxage=60
+      Vary:
+      - Accept
+      Etag:
+      - '"9831597895138b77c57b515dcf9d3420"'
+      Last-Modified:
+      - Wed, 03 Jan 2018 07:35:58 GMT
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Runtime-Rack:
+      - '0.039771'
+      X-Github-Request-Id:
+      - B49D:6563:A69E33:1B9CBCA:5A500A9B
+    body:
+      encoding: UTF-8
+      string: '{"id":5266284,"name":"chruby","full_name":"postmodern/chruby","owner":{"login":"postmodern","id":12671,"avatar_url":"https://avatars2.githubusercontent.com/u/12671?v=4","gravatar_id":"","url":"https://api.github.com/users/postmodern","html_url":"https://github.com/postmodern","followers_url":"https://api.github.com/users/postmodern/followers","following_url":"https://api.github.com/users/postmodern/following{/other_user}","gists_url":"https://api.github.com/users/postmodern/gists{/gist_id}","starred_url":"https://api.github.com/users/postmodern/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/postmodern/subscriptions","organizations_url":"https://api.github.com/users/postmodern/orgs","repos_url":"https://api.github.com/users/postmodern/repos","events_url":"https://api.github.com/users/postmodern/events{/privacy}","received_events_url":"https://api.github.com/users/postmodern/received_events","type":"User","site_admin":false},"private":false,"html_url":"https://github.com/postmodern/chruby","description":"Changes
+        the current Ruby","fork":false,"url":"https://api.github.com/repos/postmodern/chruby","forks_url":"https://api.github.com/repos/postmodern/chruby/forks","keys_url":"https://api.github.com/repos/postmodern/chruby/keys{/key_id}","collaborators_url":"https://api.github.com/repos/postmodern/chruby/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/postmodern/chruby/teams","hooks_url":"https://api.github.com/repos/postmodern/chruby/hooks","issue_events_url":"https://api.github.com/repos/postmodern/chruby/issues/events{/number}","events_url":"https://api.github.com/repos/postmodern/chruby/events","assignees_url":"https://api.github.com/repos/postmodern/chruby/assignees{/user}","branches_url":"https://api.github.com/repos/postmodern/chruby/branches{/branch}","tags_url":"https://api.github.com/repos/postmodern/chruby/tags","blobs_url":"https://api.github.com/repos/postmodern/chruby/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/postmodern/chruby/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/postmodern/chruby/git/refs{/sha}","trees_url":"https://api.github.com/repos/postmodern/chruby/git/trees{/sha}","statuses_url":"https://api.github.com/repos/postmodern/chruby/statuses/{sha}","languages_url":"https://api.github.com/repos/postmodern/chruby/languages","stargazers_url":"https://api.github.com/repos/postmodern/chruby/stargazers","contributors_url":"https://api.github.com/repos/postmodern/chruby/contributors","subscribers_url":"https://api.github.com/repos/postmodern/chruby/subscribers","subscription_url":"https://api.github.com/repos/postmodern/chruby/subscription","commits_url":"https://api.github.com/repos/postmodern/chruby/commits{/sha}","git_commits_url":"https://api.github.com/repos/postmodern/chruby/git/commits{/sha}","comments_url":"https://api.github.com/repos/postmodern/chruby/comments{/number}","issue_comment_url":"https://api.github.com/repos/postmodern/chruby/issues/comments{/number}","contents_url":"https://api.github.com/repos/postmodern/chruby/contents/{+path}","compare_url":"https://api.github.com/repos/postmodern/chruby/compare/{base}...{head}","merges_url":"https://api.github.com/repos/postmodern/chruby/merges","archive_url":"https://api.github.com/repos/postmodern/chruby/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/postmodern/chruby/downloads","issues_url":"https://api.github.com/repos/postmodern/chruby/issues{/number}","pulls_url":"https://api.github.com/repos/postmodern/chruby/pulls{/number}","milestones_url":"https://api.github.com/repos/postmodern/chruby/milestones{/number}","notifications_url":"https://api.github.com/repos/postmodern/chruby/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/postmodern/chruby/labels{/name}","releases_url":"https://api.github.com/repos/postmodern/chruby/releases{/id}","deployments_url":"https://api.github.com/repos/postmodern/chruby/deployments","created_at":"2012-08-01T23:46:08Z","updated_at":"2018-01-03T07:35:58Z","pushed_at":"2017-11-07T18:11:20Z","git_url":"git://github.com/postmodern/chruby.git","ssh_url":"git@github.com:postmodern/chruby.git","clone_url":"https://github.com/postmodern/chruby.git","svn_url":"https://github.com/postmodern/chruby","homepage":"","size":547,"stargazers_count":2098,"watchers_count":2098,"language":"Shell","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":169,"mirror_url":null,"archived":false,"open_issues_count":73,"license":{"key":"mit","name":"MIT
+        License","spdx_id":"MIT","url":"https://api.github.com/licenses/mit"},"forks":169,"open_issues":73,"watchers":2098,"default_branch":"master","network_count":169,"subscribers_count":55}'
+    http_version: 
+  recorded_at: Fri, 05 Jan 2018 23:30:35 GMT
+recorded_with: VCR 4.0.0

--- a/spec/integration/project_sync_spec.rb
+++ b/spec/integration/project_sync_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Full Project Sync", :real_http, :sidekiq_inline do
+  describe "for Rubygem-based projects", vcr: { cassette_name: "full-project-sync-from-gem" } do
+    let(:do_perform) { RubygemUpdateJob.perform_async "rspec" }
+
+    it "creates the project" do
+      expect { do_perform }.to change { Project.where(permalink: "rspec").count }.from(0).to(1)
+    end
+
+    it "assigns the expected attributes to the resulting project" do
+      do_perform
+      expect(Project.find("rspec")).to have_attributes(
+        rubygem_name: "rspec",
+        github_repo_path: "rspec/rspec",
+        github_repo_stargazers_count: (a_value > 1500),
+        github_repo_forks_count: (a_value > 100),
+        rubygem_downloads: (a_value > 10_000_000),
+        score: 100.0
+      )
+    end
+  end
+
+  describe "for github-based projects", vcr: { cassette_name: "full-project-sync-from-github" } do
+    let(:do_perform) { ProjectUpdateJob.perform_async "postmodern/chruby" }
+
+    it "creates the project" do
+      expect { do_perform }.to change { Project.where(permalink: "postmodern/chruby").count }.from(0).to(1)
+    end
+
+    it "assigns the expected attributes to the resulting project" do
+      do_perform
+      expect(Project.find("postmodern/chruby")).to have_attributes(
+        rubygem_name: nil,
+        github_repo_path: "postmodern/chruby",
+        github_repo_stargazers_count: (a_value > 1500),
+        github_repo_forks_count: (a_value > 100),
+        score: 100.0
+      )
+    end
+  end
+end

--- a/spec/jobs/project_score_job_spec.rb
+++ b/spec/jobs/project_score_job_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ProjectScoreJob, type: :job do
+  let(:job) { described_class.new }
+
+  describe "#perform" do
+    def create_repos!
+      GithubRepo.create! path: "popular/repo", stargazers_count: 50_000, forks_count: 1_000, watchers_count: 100
+      GithubRepo.create! path: "rspec/rspec", stargazers_count: 5_000, forks_count: 100, watchers_count: 100
+    end
+
+    def create_gems!
+      Rubygem.create! name: "popular", current_version: "1.0", downloads: 1_000_000
+      Rubygem.create! name: "rspec", current_version: "1.0", downloads: 500_000,
+                      source_code_url: "https://github.com/rspec/rspec"
+    end
+
+    it "sets the expected score on projects with rubygem and github repo" do
+      create_repos!
+      create_gems!
+      ProjectUpdateJob.new.perform "rspec"
+
+      expect { job.perform "rspec" }.to change { Project.find("rspec").score }.from(nil).to(30.0)
+    end
+
+    it "sets the expected score on projects with just a github repo" do
+      create_repos!
+      ProjectUpdateJob.new.perform "rspec/rspec"
+
+      expect { job.perform "rspec/rspec" }.to change { Project.find("rspec/rspec").score }.from(nil).to(10.0)
+    end
+
+    it "sets the expected score on projects with just a rubygem" do
+      create_gems!
+      ProjectUpdateJob.new.perform "rspec"
+
+      expect { job.perform "rspec" }.to change { Project.find("rspec").score }.from(nil).to(50.0)
+    end
+
+    it "sets the score to nil on projects without anything" do
+      Project.create! permalink: "rspec", score: 2.0
+      expect { job.perform "rspec" }.to change { Project.find("rspec").score }.to(nil)
+    end
+  end
+end

--- a/spec/jobs/project_update_job_spec.rb
+++ b/spec/jobs/project_update_job_spec.rb
@@ -25,6 +25,11 @@ RSpec.describe ProjectUpdateJob, type: :job do
       expect { do_perform }.to change { project.reload.rubygem }.from(nil).to(rubygem)
     end
 
+    it "enqueues a ProjectScoreJob" do
+      expect(ProjectScoreJob).to receive(:perform_async).with(permalink)
+      do_perform
+    end
+
     describe "github repo detection" do
       let(:project) { Project.create! permalink: permalink }
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -3,12 +3,6 @@
 require "rails_helper"
 
 RSpec.describe Project, type: :model do
-  describe "#score" do
-    it "is a random number" do
-      expect(described_class.new.score).to be_an Integer
-    end
-  end
-
   describe "#description" do
     it "is nil by default" do
       expect(described_class.new.description).to be_nil

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -39,6 +39,7 @@ ActiveRecord::Migration.maintain_test_schema!
 
 VCR.configure do |c|
   c.cassette_library_dir = Rails.root.join("spec", "cassettes")
+  c.default_cassette_options = { record: :new_episodes }
   c.hook_into :webmock
   c.configure_rspec_metadata!
 end
@@ -54,6 +55,13 @@ RSpec.configure do |config|
 
   config.before do |example|
     Rails.configuration.http_connect = example.metadata[:real_http]
+  end
+
+  config.around do |example|
+    Sidekiq::Testing.inline! if example.metadata[:sidekiq_inline]
+    example.run
+  ensure
+    Sidekiq::Testing.fake!
   end
 
   # RSpec Rails can automatically mix in different behaviours to your tests


### PR DESCRIPTION
Now that the data for rubygems (#47 and following) and github repos (#59) is being synced, we need a way to display projects by popularity - this PR adds that. The calculation is the same as used on the old ruby toolbox site. This might change later on, but for the time being, let's stick to what's tried and tested :)