### PR TITLE
Add basic request spec for display of projects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,16 @@ addons:
   postgresql: '9.6'
 # Cache bundle between builds
 # See https://docs.travis-ci.com/user/caching/
-cache: bundler
+cache:
+  - yarn
+  - bundler
 jobs:
   include:
   - stage: test
     before_install:
     # See https://github.com/travis-ci/travis-ci/issues/8978
     - gem update --system
+    - yarn install
     before_script:
     - bin/rails db:setup
     script:

--- a/Gemfile
+++ b/Gemfile
@@ -71,6 +71,8 @@ group :development, :test do
 end
 
 group :test do
+  gem "capybara"
+
   gem "rails-controller-testing"
   gem "simplecov", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,13 @@ GEM
     bindex (0.5.0)
     builder (3.2.3)
     byebug (9.1.0)
+    capybara (2.17.0)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (>= 2.0, < 4.0)
     childprocess (0.8.0)
       ffi (~> 1.0, >= 1.0.11)
     coderay (1.1.2)
@@ -308,6 +315,8 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
+    xpath (3.0.0)
+      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
@@ -315,6 +324,7 @@ PLATFORMS
 DEPENDENCIES
   appsignal
   byebug
+  capybara
   coffee-rails (~> 4.2)
   dotenv-rails
   foreman

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -32,6 +32,7 @@ class Project < ApplicationRecord
 
   delegate :stargazers_count,
            :forks_count,
+           :watchers_count,
            :description,
            to: :github_repo,
            allow_nil: true,

--- a/spec/features/category_display_spec.rb
+++ b/spec/features/category_display_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Categories Display", type: :feature do
+  it "can display projects of a category" do
+    group = CategoryGroup.create! permalink: "group1", name: "Group"
+    category = Category.create! permalink: "widgets", name: "Widgets", category_group: group
+    category.projects << Project.create!(permalink: "rspec", score: 25)
+
+    visit "/categories/widgets"
+    within ".projects" do
+      expect(page).to have_text "rspec"
+    end
+  end
+end


### PR DESCRIPTION
Bugfix following #61 - I forgot to add a delegation for the watchers_count, and no tests covered that bit yet. Hence, this adds an rspec feature spec that makes that request and would have failed.