### PR TITLE
Add project details pages

### DIFF
--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -70,14 +70,14 @@ header.section
   a.button
     @extend .is-white, .is-fullwidth, .is-inline-block, .has-text-left
 
+.score
+  @extend .is-size-5, .has-text-right
+
 .project
-  @extend .box
   header
     @extend .columns, .is-mobile
     h3
       @extend .column, .is-size-4
-    .score
-      @extend .is-size-5, .is-pulled-right
 
   .description
     @extend .has-text-grey

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ProjectsController < ApplicationController
+  def show
+    @project = Project.find_for_show! params[:id]
+  end
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -18,6 +18,6 @@ class Category < ApplicationRecord
            through: :categorizations
 
   def self.find_for_show!(permalink)
-    includes(:category_group, projects: %i[rubygem]).find(permalink)
+    includes(:category_group, projects: %i[rubygem github_repo]).find(permalink)
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -38,6 +38,10 @@ class Project < ApplicationRecord
            allow_nil: true,
            prefix: :github_repo
 
+  def self.find_for_show!(permalink)
+    includes(:github_repo, :rubygem, :categories).find(permalink)
+  end
+
   def github_only?
     permalink.include? "/"
   end

--- a/app/views/categories/show.html.slim
+++ b/app/views/categories/show.html.slim
@@ -8,10 +8,12 @@
 section.section: .container: .columns
   .projects
     - @category.projects.each do |project|
-      .project
+      .project.box
         header
           h3.is-size-4
-            = project.permalink
+            // Note that rails url helpers escape slashes (as seen in github-based projects) and this breaks.
+            a href="/projects/#{project.permalink}"
+              = project.permalink
           .column: .score
             span.icon
               i.fa.fa-flask
@@ -20,13 +22,4 @@ section.section: .container: .columns
         .columns: .column.description
           = project.description
 
-        .metrics
-          .label
-            span &nbsp;
-            strong
-              | Popularity
-          .column: .metrics
-            = metric "Downloads", project.rubygem_downloads, icon: "download"
-            = metric "Stars", project.github_repo_stargazers_count, icon: "star"
-            = metric "Forks", project.github_repo_forks_count, icon: "code-fork"
-            = metric "Watchers", project.github_repo_watchers_count, icon: "eye"
+        = render partial: "projects/metrics", locals: { project: project }

--- a/app/views/projects/_metrics.html.slim
+++ b/app/views/projects/_metrics.html.slim
@@ -1,0 +1,10 @@
+.metrics
+  .label
+    span &nbsp;
+    strong
+      | Popularity
+  .column: .metrics
+    = metric "Downloads", project.rubygem_downloads, icon: "download"
+    = metric "Stars", project.github_repo_stargazers_count, icon: "star"
+    = metric "Forks", project.github_repo_forks_count, icon: "code-fork"
+    = metric "Watchers", project.github_repo_watchers_count, icon: "eye"

--- a/app/views/projects/show.html.slim
+++ b/app/views/projects/show.html.slim
@@ -1,0 +1,29 @@
+.hero
+  section.section: .container
+    .columns
+      .column
+        p.heading Project
+        h2
+          // Note that rails url helpers escape slashes (as seen in github-based projects) and this breaks.
+          a href="/projects/#{@project.permalink}"
+            = @project.permalink
+      .column.has-text-right
+        p.score
+          span.icon
+            i.fa.fa-flask
+          span= @project.score
+        p.categories
+          ul
+            - @project.categories.each do |category|
+              li
+                .control
+                  a href=category_path(category)
+                    span.icon: i.fa.fa-folder
+                    span= category.name
+
+
+    .description= @project.description
+
+
+section.section: .container: .project
+  = render partial: "projects/metrics", locals: { project: @project }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,14 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
+  # Ripped from https://github.com/rubygems/rubygems.org/blob/master/lib/patterns.rb and enhanced
+  # to also allow slashes as per github
+  SPECIAL_CHARACTERS    = ".-_/"
+  ALLOWED_CHARACTERS    = "[A-Za-z0-9#{Regexp.escape(SPECIAL_CHARACTERS)}]+"
+  ROUTE_PATTERN         = /#{ALLOWED_CHARACTERS}/
+
   resources :categories, only: %i[show]
+  resources :projects, only: %i[show], constraints: { id: ROUTE_PATTERN }
 
   root "welcome#home"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,16 +1,12 @@
 # frozen_string_literal: true
 
+require "patterns"
+
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
-  # Ripped from https://github.com/rubygems/rubygems.org/blob/master/lib/patterns.rb and enhanced
-  # to also allow slashes as per github
-  SPECIAL_CHARACTERS    = ".-_/"
-  ALLOWED_CHARACTERS    = "[A-Za-z0-9#{Regexp.escape(SPECIAL_CHARACTERS)}]+"
-  ROUTE_PATTERN         = /#{ALLOWED_CHARACTERS}/
-
   resources :categories, only: %i[show]
-  resources :projects, only: %i[show], constraints: { id: ROUTE_PATTERN }
+  resources :projects, only: %i[show], constraints: { id: Patterns::ROUTE_PATTERN }
 
   root "welcome#home"
 end

--- a/lib/patterns.rb
+++ b/lib/patterns.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Patterns
+  # Ripped from https://github.com/rubygems/rubygems.org/blob/master/lib/patterns.rb and enhanced
+  # to also allow slashes as per github
+  SPECIAL_CHARACTERS    = ".-_/"
+  ALLOWED_CHARACTERS    = "[A-Za-z0-9#{Regexp.escape(SPECIAL_CHARACTERS)}]+"
+  ROUTE_PATTERN         = /#{ALLOWED_CHARACTERS}/
+end

--- a/spec/controllers/categories_controller_spec.rb
+++ b/spec/controllers/categories_controller_spec.rb
@@ -30,9 +30,9 @@ RSpec.describe CategoriesController, type: :controller do
       end
 
       it "assigns Category.find_for_show!" do
-        allow(Category).to receive(:find_for_show!).and_return("The Category")
+        allow(Category).to receive(:find_for_show!).and_return(category)
         do_request
-        expect(assigns(:category)).to be == "The Category"
+        expect(assigns(:category)).to be == category
       end
     end
   end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ProjectsController, type: :controller do
+  describe "GET show" do
+    describe "for unknown project" do
+      let(:do_request) { get :show, params: { id: "foobar" } }
+
+      it "raises ActiveRecord::RecordNotFound" do
+        expect { do_request }.to raise_error ActiveRecord::RecordNotFound
+      end
+    end
+
+    describe "for known project" do
+      let(:do_request) { get :show, params: { id: project.permalink } }
+
+      let(:project) do
+        Project.create! permalink: "category"
+      end
+
+      it "responds with success" do
+        expect(do_request).to have_http_status :success
+      end
+
+      it "renders template show" do
+        expect(do_request).to render_template :show
+      end
+
+      it "assigns Project.find_for_show!" do
+        allow(Project).to receive(:find_for_show!).and_return(project)
+        do_request
+        expect(assigns(:project)).to be == project
+      end
+    end
+  end
+end

--- a/spec/routes/project_routes_spec.rb
+++ b/spec/routes/project_routes_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Project routes", type: :routing do
+  it "routes rubygems-based projects to the project page" do
+    expect(get("/projects/simplecov")).to route_to(
+      controller: "projects",
+      action: "show",
+      id: "simplecov"
+    )
+  end
+
+  it "routes rubygems-based projects with dots to the project page" do
+    expect(get("/projects/simplecov.rb")).to route_to(
+      controller: "projects",
+      action: "show",
+      id: "simplecov.rb"
+    )
+  end
+
+  it "routes github-based projects to the project page" do
+    expect(get("/projects/postmodern/chruby")).to route_to(
+      controller: "projects",
+      action: "show",
+      id: "postmodern/chruby"
+    )
+  end
+end


### PR DESCRIPTION
This adds a very basic page for each project. This can later be expanded to hold further details in addition to what is already shown in category (and later search) overview listings

![project-pages](https://user-images.githubusercontent.com/13972/34895335-9401ebf8-f7e5-11e7-9c87-a818a46d89ee.png)
