### PR TITLE
Cron job for syncing catalog

### DIFF
--- a/app/jobs/catalog_import_job.rb
+++ b/app/jobs/catalog_import_job.rb
@@ -5,7 +5,7 @@ class CatalogImportJob < ApplicationJob
     response = http_client.get catalog_url
     raise "Failed to fetch catalog, response status was #{response.status}" unless response.status == 200
     catalog_data = JSON.parse response.body
-    CatalogImport.new(catalog_data).perform
+    CatalogImport.perform(catalog_data)
   end
 
   def catalog_url

--- a/app/jobs/catalog_import_job.rb
+++ b/app/jobs/catalog_import_job.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CatalogImportJob < ApplicationJob
+  def perform
+    response = http_client.get catalog_url
+    raise "Failed to fetch catalog, response status was #{response.status}" unless response.status == 200
+    catalog_data = JSON.parse response.body
+    CatalogImport.new(catalog_data).perform
+  end
+
+  def catalog_url
+    "https://rubytoolbox.github.io/catalog/catalog.json"
+  end
+
+  def http_client
+    @http_client ||= HttpService.client
+  end
+end

--- a/app/services/catalog_import.rb
+++ b/app/services/catalog_import.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 class CatalogImport
+  # A shorthand for `new(data).perform`, mostly to ease
+  # spec call assertions
+  def self.perform(catalog_data)
+    new(catalog_data).perform
+  end
+
   attr_accessor :catalog_data
   private :catalog_data=
 

--- a/app/services/cron.rb
+++ b/app/services/cron.rb
@@ -8,6 +8,7 @@
 class Cron
   def run(time: Time.current.utc)
     RemoteUpdateSchedulerJob.perform_async
+    CatalogImportJob.perform_async
 
     case time.hour
     when 0

--- a/spec/jobs/catalog_import_job_spec.rb
+++ b/spec/jobs/catalog_import_job_spec.rb
@@ -33,18 +33,9 @@ RSpec.describe CatalogImportJob, type: :job do
       expect { job.perform }.to raise_error(/response status was 502/)
     end
 
-    it "passes the parsed body to the import" do
+    it "passes the parsed body to CatalogImport.perform" do
       stub_response
-      import_double = instance_double CatalogImport, perform: nil
-      expect(CatalogImport).to receive(:new).with(JSON.parse(catalog_body)).and_return(import_double)
-      job.perform
-    end
-
-    it "performs the import" do
-      stub_response
-      import_double = instance_double CatalogImport, perform: nil
-      allow(CatalogImport).to receive(:new).and_return(import_double)
-      expect(import_double).to receive(:perform)
+      expect(CatalogImport).to receive(:perform).with(JSON.parse(catalog_body))
       job.perform
     end
   end

--- a/spec/services/catalog_import_spec.rb
+++ b/spec/services/catalog_import_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CatalogImport, type: :service do
+  describe ".perform" do
+    let(:import) do
+      instance_double(described_class, perform: nil)
+    end
+
+    it "initializes a new instance with given catalog data" do
+      expect(described_class).to receive(:new).with("data").and_return(import)
+      described_class.perform "data"
+    end
+
+    it "calls perform on the import instance" do
+      allow(described_class).to receive(:new).and_return(import)
+      expect(import).to receive(:perform)
+      described_class.perform "data"
+    end
+  end
+end

--- a/spec/services/cron_spec.rb
+++ b/spec/services/cron_spec.rb
@@ -14,6 +14,11 @@ RSpec.describe Cron, type: :service do
     cron.run time: time_at(rand(24))
   end
 
+  it "queues CatalogImportJob every hour" do
+    expect(CatalogImportJob).to receive(:perform_async)
+    cron.run time: time_at(rand(24))
+  end
+
   it "enqueues RubygemsSyncJob at 0 am" do
     expect(RubygemsSyncJob).to receive(:perform_async)
     cron.run time: time_at(0)


### PR DESCRIPTION
This adds a background job for fetching the [catalog](https://github.com/rubytoolbox/catalog) and syncing it up with the local db. It's scheduled for an hourly cron run.

At a later point, this shall be converted to a webhook whenever the catalog actually changed. The job itself can remain untouched, only the cron job would be superseded by that.