### PR TITLE
Convert to GitHub graphql API

### DIFF
--- a/app/graphql-queries/github/repo.erb
+++ b/app/graphql-queries/github/repo.erb
@@ -1,5 +1,5 @@
 {
-  repository(owner: "rails", name: "rails") {
+  repository(owner: <%= owner.inspect %>, name: <%= name.inspect %>) {
     nameWithOwner
     forks {
       totalCount
@@ -15,13 +15,10 @@
       name
       target {
         ... on Commit {
-          history(first: 30) {
+          history(first: 50) {
             edges {
               node {
-                oid
                 authoredDate
-                committedDate
-                pushedDate
               }
             }
           }

--- a/app/graphql-queries/github/repo.graphql
+++ b/app/graphql-queries/github/repo.graphql
@@ -1,0 +1,68 @@
+{
+  repository(owner: "rails", name: "rails") {
+    nameWithOwner
+    forks {
+      totalCount
+    }
+    stargazers {
+      totalCount
+    }
+    watchers {
+      totalCount
+    }
+    createdAt
+    defaultBranchRef {
+      name
+      target {
+        ... on Commit {
+          history(first: 30) {
+            edges {
+              node {
+                oid
+                authoredDate
+                committedDate
+                pushedDate
+              }
+            }
+          }
+        }
+      }
+    }
+    description
+    hasIssuesEnabled
+    hasWikiEnabled
+    homepageUrl
+    isArchived
+    isFork
+    isMirror
+    licenseInfo {
+      key
+    }
+    primaryLanguage {
+      name
+    }
+    pushedAt
+    closedIssues: issues(states: CLOSED) {
+      totalCount
+    }
+    openIssues: issues(states: OPEN) {
+      totalCount
+    }
+    closedPullRequests: pullRequests(states: CLOSED) {
+      totalCount
+    }
+    openPullRequests: pullRequests(states: OPEN) {
+      totalCount
+    }
+    mergedPullRequests: pullRequests(states: MERGED) {
+      totalCount
+    }
+  }
+
+  rateLimit {
+    limit
+    cost
+    remaining
+    resetAt
+  }
+}

--- a/app/jobs/github_repo_update_job.rb
+++ b/app/jobs/github_repo_update_job.rb
@@ -27,15 +27,26 @@ class GithubRepoUpdateJob < ApplicationJob
 
   ATTRIBUTE_MAPPING = {
     archived?: :archived,
+    average_recent_committed_at: :average_recent_committed_at,
+    closed_issues_count: :closed_issues_count,
+    closed_pull_requests_count: :closed_pull_requests_count,
     created_at: :repo_created_at,
+    default_branch: :default_branch,
     description: :description,
+    fork?: :is_fork,
     forks_count: :forks_count,
-    issues?: :has_issues,
-    wiki?: :has_wiki,
     homepage_url: :homepage_url,
+    issues?: :has_issues,
+    license: :license,
+    merged_pull_requests_count: :merged_pull_requests_count,
+    mirror?: :is_mirror,
+    open_issues_count: :open_issues_count,
+    open_pull_requests_count: :open_pull_requests_count,
+    primary_language: :primary_language,
     pushed_at: :repo_pushed_at,
     stargazers_count: :stargazers_count,
     watchers_count: :watchers_count,
+    wiki?: :has_wiki,
   }.freeze
 
   def mapped_attributes(info)

--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class GithubClient
+  class InvalidResponse < StandardError; end
+
+  REPOSITORY_QUERY_TEMPLATE = Tilt.new(Rails.root.join("app", "graphql-queries", "github", "repo.erb"))
+
+  attr_accessor :token, :http_client
+  private :token=, :http_client=
+
+  # Acquire token via https://developer.github.com/v4/guides/forming-calls/#authenticating-with-graphql
+  # and https://github.com/settings/tokens
+  #
+  # No OAuth scopes are needed at all.
+  def initialize(token: ENV["GITHUB_TOKEN"])
+    self.token = token
+    self.http_client = HTTP
+                       .headers(authorization: "bearer #{token}", "User-Agent" => HttpService::USER_AGENT)
+                       .timeout(connect: 3, write: 3, read: 3)
+  end
+
+  def fetch_repository(path)
+    owner, name = path.split("/")
+    query = REPOSITORY_QUERY_TEMPLATE.render(OpenStruct.new(owner: owner, name: name))
+    response = http_client.post("https://api.github.com/graphql", body: { query: query }.to_json)
+    handle_response response
+  end
+
+  private
+
+  def handle_response(response)
+    parsed_body = Oj.load(response.body)
+    raise InvalidResponse, parsed_body["errors"].map { |e| e["message"] }.join(", ") if parsed_body["errors"]
+    RepositoryData.new parsed_body
+  end
+end

--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -36,6 +36,11 @@ class GithubClient
     case response.status
     when 200
       path
+    # Instead of following 301s, the broken github path
+    # (either coming from the catalog for github-only projects,
+    # or from a rubygems urls) should somehow be flagged and
+    # remapped locally, but this needs some more consideration
+    # regarding the various possible cases
     when 301, 302
       Github.detect_repo_name response.headers["Location"]
     else

--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -2,6 +2,7 @@
 
 class GithubClient
   class InvalidResponse < StandardError; end
+  class UnknownRepoError < StandardError; end
 
   REPOSITORY_QUERY_TEMPLATE = Tilt.new(Rails.root.join("app", "graphql-queries", "github", "repo.erb"))
 
@@ -15,22 +16,43 @@ class GithubClient
   def initialize(token: ENV["GITHUB_TOKEN"])
     self.token = token
     self.http_client = HTTP
-                       .headers(authorization: "bearer #{token}", "User-Agent" => HttpService::USER_AGENT)
                        .timeout(connect: 3, write: 3, read: 3)
   end
 
   def fetch_repository(path)
-    owner, name = path.split("/")
+    owner, name = real_path(path).split("/")
     query = REPOSITORY_QUERY_TEMPLATE.render(OpenStruct.new(owner: owner, name: name))
-    response = http_client.post("https://api.github.com/graphql", body: { query: query }.to_json)
+    response = authenticated_client.post("https://api.github.com/graphql", body: { query: query }.to_json)
     handle_response response
   end
 
   private
 
+  # Unfortunate hack for a limitation in github's graphql API.
+  # See https://github.com/rubytoolbox/rubytoolbox/pull/94#issuecomment-372489342
+  # and https://platform.github.community/t/repository-redirects-in-api-v4-graphql/4417
+  def real_path(path)
+    response = http_client.head File.join("https://github.com", path)
+    case response.status
+    when 200
+      path
+    when 301, 302
+      Github.detect_repo_name response.headers["Location"]
+    else
+      raise UnknownRepoError, "Cannot find repo #{path} on github :("
+    end
+  end
+
   def handle_response(response)
     parsed_body = Oj.load(response.body)
     raise InvalidResponse, parsed_body["errors"].map { |e| e["message"] }.join(", ") if parsed_body["errors"]
     RepositoryData.new parsed_body
+  end
+
+  def authenticated_client
+    @authenticated_client ||= http_client.headers(
+      authorization: "bearer #{token}",
+      "User-Agent" => HttpService::USER_AGENT
+    )
   end
 end

--- a/app/services/github_client/repository_data.rb
+++ b/app/services/github_client/repository_data.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+class GithubClient
+  class RepositoryData
+    attr_accessor :raw_data
+    private :raw_data=
+
+    def initialize(raw_data)
+      self.raw_data = raw_data.dig("data", "repository")
+    end
+
+    def path
+      value "nameWithOwner"
+    end
+
+    def description
+      value "description"
+    end
+
+    def homepage_url
+      value "homepageUrl"
+    end
+
+    def primary_language
+      raw_data.dig("primaryLanguage", "name").presence
+    end
+
+    def license
+      raw_data.dig("licenseInfo", "key").presence
+    end
+
+    def issues?
+      flag "hasIssuesEnabled"
+    end
+
+    def wiki?
+      flag "hasWikiEnabled"
+    end
+
+    def archived?
+      flag "isArchived"
+    end
+
+    def fork?
+      flag "isFork"
+    end
+
+    def mirror?
+      flag "isMirror"
+    end
+
+    def forks_count
+      count "forks"
+    end
+
+    def stargazers_count
+      count "stargazers"
+    end
+
+    def watchers_count
+      count "watchers"
+    end
+
+    def open_issues_count
+      count "openIssues"
+    end
+
+    def closed_issues_count
+      count "closedIssues"
+    end
+
+    def merged_pull_requests_count
+      count "mergedPullRequests"
+    end
+
+    def open_pull_requests_count
+      count "openPullRequests"
+    end
+
+    def closed_pull_requests_count
+      count "closedPullRequests"
+    end
+
+    def default_branch
+      raw_data.dig("defaultBranchRef", "name").presence
+    end
+
+    def created_at
+      time "createdAt"
+    end
+
+    def pushed_at
+      time "pushedAt"
+    end
+
+    def average_recent_committed_at
+      edges = raw_data.dig("defaultBranchRef", "target", "history", "edges")
+      dates = edges.map { |edge| Time.zone.parse edge.dig("node", "authoredDate") }
+      Time.zone.at dates.map(&:to_i).sum / dates.count
+    end
+
+    private
+
+    def count(key)
+      raw_data.dig(key.to_s, "totalCount").presence
+    end
+
+    def value(key)
+      raw_data.dig(key).presence
+    end
+
+    def flag(key)
+      !!raw_data.dig(key)
+    end
+
+    def time(key)
+      Time.zone.parse raw_data.dig(key.to_s).presence
+    end
+  end
+end

--- a/app/services/http_service.rb
+++ b/app/services/http_service.rb
@@ -37,14 +37,6 @@ module HttpService
       HTTP::Response.new(status: response["status"], body: response["body"], version: "1.1")
     end
 
-    def headers(*_args)
-      self
-    end
-
-    def follow
-      self
-    end
-
     def responses
       YAML.load_file responses_source_file_path
     end

--- a/db/migrate/20180322231205_drop_outdated_github_columns.rb
+++ b/db/migrate/20180322231205_drop_outdated_github_columns.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class DropOutdatedGithubColumns < ActiveRecord::Migration[5.1]
+  def change
+    # Removes some columns that are not available or deprecated in github
+    # graphql API and have limited value to the toolbox anyway.
+    remove_column :github_repos, :has_downloads, type: :boolean
+    remove_column :github_repos, :has_pages, type: :boolean
+    remove_column :github_repos, :has_projects, type: :boolean
+    remove_column :github_repos, :repo_updated_at, type: :datetime
+  end
+end

--- a/db/migrate/20180322231848_add_new_github_columns.rb
+++ b/db/migrate/20180322231848_add_new_github_columns.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class AddNewGithubColumns < ActiveRecord::Migration[5.1]
+  def change
+    add_column :github_repos, :primary_language, :string
+    add_column :github_repos, :license, :string
+    add_column :github_repos, :default_branch, :string
+
+    add_column :github_repos, :is_fork, :boolean
+    add_column :github_repos, :is_mirror, :boolean
+
+    add_column :github_repos, :open_issues_count, :integer
+    add_column :github_repos, :closed_issues_count, :integer
+    add_column :github_repos, :open_pull_requests_count, :integer
+    add_column :github_repos, :merged_pull_requests_count, :integer
+    add_column :github_repos, :closed_pull_requests_count, :integer
+
+    add_column :github_repos, :average_recent_committed_at, :datetime
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -178,13 +178,9 @@ CREATE TABLE public.github_repos (
     description character varying,
     homepage_url character varying,
     repo_created_at timestamp without time zone,
-    repo_updated_at timestamp without time zone,
     repo_pushed_at timestamp without time zone,
     has_issues boolean,
-    has_projects boolean,
-    has_downloads boolean,
     has_wiki boolean,
-    has_pages boolean,
     archived boolean,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL
@@ -444,6 +440,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180126214714'),
 ('20180127203832'),
 ('20180127211755'),
-('20180221214013');
+('20180221214013'),
+('20180322231205');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -183,7 +183,18 @@ CREATE TABLE public.github_repos (
     has_wiki boolean,
     archived boolean,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    primary_language character varying,
+    license character varying,
+    default_branch character varying,
+    is_fork boolean,
+    is_mirror boolean,
+    open_issues_count integer,
+    closed_issues_count integer,
+    open_pull_requests_count integer,
+    merged_pull_requests_count integer,
+    closed_pull_requests_count integer,
+    average_recent_committed_at timestamp without time zone
 );
 
 
@@ -441,6 +452,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180127203832'),
 ('20180127211755'),
 ('20180221214013'),
-('20180322231205');
+('20180322231205'),
+('20180322231848');
 
 

--- a/spec/cassettes/full-project-sync-from-gem.yml
+++ b/spec/cassettes/full-project-sync-from-gem.yml
@@ -44,9 +44,9 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - e9399dae-6d33-4f7b-a23e-2638e631c033
+      - d0fd225f-5eca-4e43-9366-0d774c94d3b8
       X-Runtime:
-      - '0.012465'
+      - '0.015303'
       Strict-Transport-Security:
       - max-age=0
       X-Ua-Compatible:
@@ -58,7 +58,7 @@ http_interactions:
       Accept-Ranges:
       - bytes
       Date:
-      - Tue, 16 Jan 2018 20:14:41 GMT
+      - Thu, 22 Mar 2018 23:15:22 GMT
       Via:
       - 1.1 varnish
       Age:
@@ -66,28 +66,28 @@ http_interactions:
       Connection:
       - close
       X-Served-By:
-      - cache-ams4138-AMS
+      - cache-ams4125-AMS
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1516133681.003206,VS0,VE195
+      - S1521760523.521263,VS0,VE198
       Vary:
       - Accept-Encoding,Fastly-SSL
       Etag:
-      - '"5bf5b1998cfb0796b91cd8d4932f56dd"'
+      - '"018ba1b55a8c5bed5e439aa1efa5823d"'
       Server:
       - RubyGems.org
     body:
       encoding: UTF-8
-      string: '{"name":"thread_safe","downloads":116338126,"version":"0.3.6","version_downloads":24843666,"platform":"ruby","authors":"Charles
+      string: '{"name":"thread_safe","downloads":125922046,"version":"0.3.6","version_downloads":32885325,"platform":"ruby","authors":"Charles
         Oliver Nutter, thedarkone","info":"A collection of data structures and utilities
         to make thread-safe programming in Ruby easier","licenses":["Apache-2.0"],"metadata":{},"sha":"9ed7072821b51c57e8d6b7011a8e282e25aeea3a4065eab326e43f66f063b05a","project_uri":"https://rubygems.org/gems/thread_safe","gem_uri":"https://rubygems.org/gems/thread_safe-0.3.6.gem","homepage_uri":"https://github.com/ruby-concurrency/thread_safe","wiki_uri":"","documentation_uri":"http://ruby-concurrency.github.io/thread_safe/frames.html","mailing_list_uri":"https://groups.google.com/forum/#!forum/concurrent-ruby","source_code_uri":"https://github.com/ruby-concurrency/thread_safe","bug_tracker_uri":"https://github.com/ruby-concurrency/thread_safe/issues","changelog_uri":null,"dependencies":{"development":[{"name":"atomic","requirements":"=
         1.1.16"},{"name":"rake","requirements":"\u003c 12.0"},{"name":"rspec","requirements":"~\u003e
         3.2"}],"runtime":[]}}'
     http_version: 
-  recorded_at: Tue, 16 Jan 2018 20:14:40 GMT
+  recorded_at: Thu, 22 Mar 2018 23:15:22 GMT
 - request:
     method: get
     uri: https://rubygems.org/api/v1/versions/thread_safe.json
@@ -128,9 +128,9 @@ http_interactions:
       Cache-Control:
       - max-age=0, public
       X-Request-Id:
-      - 6957a204-37d4-411a-8306-162eacaa2758
+      - 7b5d3ff0-1a5e-4837-9da6-5d81d3221797
       X-Runtime:
-      - '0.044680'
+      - '0.050672'
       Strict-Transport-Security:
       - max-age=0
       X-Ua-Compatible:
@@ -142,21 +142,21 @@ http_interactions:
       Accept-Ranges:
       - bytes
       Date:
-      - Tue, 16 Jan 2018 20:14:41 GMT
+      - Thu, 22 Mar 2018 23:15:22 GMT
       Via:
       - 1.1 varnish
       Age:
-      - '15'
+      - '1'
       Connection:
       - close
       X-Served-By:
-      - cache-ams4437-AMS
+      - cache-ams4421-AMS
       X-Cache:
       - HIT
       X-Cache-Hits:
       - '1'
       X-Timer:
-      - S1516133681.287978,VS0,VE1
+      - S1521760523.797774,VS0,VE0
       Vary:
       - Accept-Encoding,Fastly-SSL
       Etag:
@@ -167,114 +167,114 @@ http_interactions:
       encoding: UTF-8
       string: '[{"authors":"Charles Oliver Nutter, thedarkone","built_at":"2017-02-22T00:00:00.000Z","created_at":"2017-02-22T19:51:15.835Z","description":"A
         collection of data structures and utilities to make thread-safe programming
-        in Ruby easier","downloads_count":1023129,"metadata":{},"number":"0.3.6","summary":"Thread-safe
+        in Ruby easier","downloads_count":1254028,"metadata":{},"number":"0.3.6","summary":"Thread-safe
         collections and utilities for Ruby","platform":"java","rubygems_version":"\u003e=
         0","ruby_version":"\u003e= 0","prerelease":false,"licenses":["Apache-2.0"],"requirements":[],"sha":"bb28394cd0924c068981adee71f36a81c85c92e7d74d3f62372bd51489a0e0c2"},{"authors":"Charles
         Oliver Nutter, thedarkone","built_at":"2017-02-22T00:00:00.000Z","created_at":"2017-02-22T19:50:54.397Z","description":"A
         collection of data structures and utilities to make thread-safe programming
-        in Ruby easier","downloads_count":24843666,"metadata":{},"number":"0.3.6","summary":"Thread-safe
+        in Ruby easier","downloads_count":32885325,"metadata":{},"number":"0.3.6","summary":"Thread-safe
         collections and utilities for Ruby","platform":"ruby","rubygems_version":"\u003e=
         0","ruby_version":"\u003e= 0","prerelease":false,"licenses":["Apache-2.0"],"requirements":[],"sha":"9ed7072821b51c57e8d6b7011a8e282e25aeea3a4065eab326e43f66f063b05a"},{"authors":"Charles
         Oliver Nutter, thedarkone","built_at":"2015-03-11T00:00:00.000Z","created_at":"2015-03-11T15:00:52.728Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":6932543,"metadata":{},"number":"0.3.5","summary":"A
+        collections and utilities for Ruby","downloads_count":6977588,"metadata":{},"number":"0.3.5","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"java","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
         0","prerelease":false,"licenses":["Apache-2.0"],"requirements":[],"sha":"52976573c9934c696a0c577ea57f51e38714191cc6bd0fac499f9ad5843e060c"},{"authors":"Charles
         Oliver Nutter, thedarkone","built_at":"2015-03-11T00:00:00.000Z","created_at":"2015-03-11T15:00:41.140Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":42224424,"metadata":{},"number":"0.3.5","summary":"A
+        collections and utilities for Ruby","downloads_count":43198343,"metadata":{},"number":"0.3.5","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
         0","prerelease":false,"licenses":["Apache-2.0"],"requirements":[],"sha":"993da065f98b8575c537ebf984ffb79eecdb6064559a3b9d2a9d7aaf313704c3"},{"authors":"Charles
         Oliver Nutter, thedarkone","built_at":"2014-05-27T00:00:00.000Z","created_at":"2014-05-27T20:10:29.698Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":31846703,"metadata":{},"number":"0.3.4","summary":"A
+        collections and utilities for Ruby","downloads_count":32104263,"metadata":{},"number":"0.3.4","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
         0","prerelease":false,"licenses":["Apache-2.0"],"requirements":[],"sha":"16315baa971c48d00104bcd35e8934e3f9ccfd3b8f429e3fca7ee2dfd81734b2"},{"authors":"Charles
         Oliver Nutter, thedarkone","built_at":"2014-05-27T00:00:00.000Z","created_at":"2014-05-27T20:10:16.778Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":402480,"metadata":{},"number":"0.3.4","summary":"A
+        collections and utilities for Ruby","downloads_count":404491,"metadata":{},"number":"0.3.4","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"java","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
         0","prerelease":false,"licenses":["Apache-2.0"],"requirements":[],"sha":"903716024d787ea90b6647c81f3ff3710721279f1ed435fc0e219582ca851ba0"},{"authors":"Charles
         Oliver Nutter, thedarkone","built_at":"2014-04-07T00:00:00.000Z","created_at":"2014-04-07T10:05:01.221Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":61512,"metadata":{},"number":"0.3.3","summary":"A
+        collections and utilities for Ruby","downloads_count":62245,"metadata":{},"number":"0.3.3","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"java","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
         0","prerelease":false,"licenses":["Apache-2.0"],"requirements":[],"sha":"e8122caeee98b9294f36760ca1fcf5589b4e27ead202296ffef6854b01693731"},{"authors":"Charles
         Oliver Nutter, thedarkone","built_at":"2014-04-07T00:00:00.000Z","created_at":"2014-04-07T10:04:43.000Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":1652137,"metadata":{},"number":"0.3.3","summary":"A
+        collections and utilities for Ruby","downloads_count":1655478,"metadata":{},"number":"0.3.3","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
         0","prerelease":false,"licenses":["Apache-2.0"],"requirements":[],"sha":"f0f4307ea85d6eff7f9c304587073e3465da58beb198ea686bf69ec87f2ddb7e"},{"authors":"Charles
         Oliver Nutter, thedarkone","built_at":"2014-04-05T00:00:00.000Z","created_at":"2014-04-05T12:15:16.825Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":3269,"metadata":{},"number":"0.3.2","summary":"A
+        collections and utilities for Ruby","downloads_count":3376,"metadata":{},"number":"0.3.2","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"java","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
         0","prerelease":false,"licenses":["Apache-2.0"],"requirements":[],"sha":"a475303101015f279b2791ddcb821e275d0f76cbce46251359a15d39dfb69117"},{"authors":"Charles
         Oliver Nutter, thedarkone","built_at":"2014-04-05T00:00:00.000Z","created_at":"2014-04-05T12:14:51.531Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":46769,"metadata":{},"number":"0.3.2","summary":"A
+        collections and utilities for Ruby","downloads_count":46816,"metadata":{},"number":"0.3.2","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
         0","prerelease":false,"licenses":["Apache-2.0"],"requirements":[],"sha":"e66e8c03414aa0e1982a5f505d659ed5fd1a411fee71b8e852ab57e0eb9e4853"},{"authors":"Charles
         Oliver Nutter, thedarkone","built_at":"2014-03-21T00:00:00.000Z","created_at":"2014-03-21T07:24:51.143Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":474763,"metadata":{},"number":"0.3.1","summary":"A
+        collections and utilities for Ruby","downloads_count":475319,"metadata":{},"number":"0.3.1","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
         0","prerelease":false,"licenses":["Apache-2.0"],"requirements":[],"sha":"aff0cf52e87876f46767c5327b8c4332381c6f6f832dff36679e928c30b82f3d"},{"authors":"Charles
         Oliver Nutter, thedarkone","built_at":"2014-03-21T00:00:00.000Z","created_at":"2014-03-21T07:24:24.214Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":29116,"metadata":{},"number":"0.3.1","summary":"A
+        collections and utilities for Ruby","downloads_count":29875,"metadata":{},"number":"0.3.1","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"java","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
         0","prerelease":false,"licenses":["Apache-2.0"],"requirements":[],"sha":"d71d0686a011d478562460c7734694c750afb03f769445bd46c6da740e869020"},{"authors":"Charles
         Oliver Nutter, thedarkone","built_at":"2014-02-26T00:00:00.000Z","created_at":"2014-02-26T17:43:22.372Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":29136,"metadata":{},"number":"0.2.0","summary":"A
+        collections and utilities for Ruby","downloads_count":29196,"metadata":{},"number":"0.2.0","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"java","rubygems_version":"\u003e= 0","ruby_version":null,"prerelease":false,"licenses":["Apache-2.0"],"requirements":[],"sha":"a184903697075973c6959e48ab28b8f6c3ad628728bb2817c2b0d0bc6aa67433"},{"authors":"Charles
         Oliver Nutter, thedarkone","built_at":"2014-02-26T00:00:00.000Z","created_at":"2014-02-26T17:40:40.192Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":662261,"metadata":{},"number":"0.2.0","summary":"A
+        collections and utilities for Ruby","downloads_count":663522,"metadata":{},"number":"0.2.0","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":null,"prerelease":false,"licenses":["Apache-2.0"],"requirements":[],"sha":"a85f7f14c3269fd6c77514aa4fdeef20bef19eee91839762b3b4a4f8cf323145"},{"authors":"Charles
         Oliver Nutter, thedarkone","built_at":"2013-09-10T00:00:00.000Z","created_at":"2013-09-10T14:35:21.960Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":4146136,"metadata":{},"number":"0.1.3","summary":"A
+        collections and utilities for Ruby","downloads_count":4160454,"metadata":{},"number":"0.1.3","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":null,"prerelease":false,"licenses":["Apache-2.0"],"requirements":[],"sha":"f8b9f8db0889aa97676b4a1efe919b1e76601ed9c9662a986825755bba305c38"},{"authors":"Charles
         Oliver Nutter, thedarkone","built_at":"2013-09-10T00:00:00.000Z","created_at":"2013-09-10T14:34:01.740Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":148657,"metadata":{},"number":"0.1.3","summary":"A
+        collections and utilities for Ruby","downloads_count":149141,"metadata":{},"number":"0.1.3","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"java","rubygems_version":"\u003e= 0","ruby_version":null,"prerelease":false,"licenses":["Apache-2.0"],"requirements":[],"sha":"24905e6433a692412ddfeb2105c4768266ef693b7e51d9b9dcdb789141b5a7e1"},{"authors":"Charles
         Oliver Nutter","built_at":"2013-07-24T00:00:00.000Z","created_at":"2013-07-24T00:12:01.379Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":929854,"metadata":{},"number":"0.1.2","summary":"A
+        collections and utilities for Ruby","downloads_count":939589,"metadata":{},"number":"0.1.2","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":null,"prerelease":false,"licenses":["Apache-2.0"],"requirements":[],"sha":"7e2b957c28f2676b0a5ba5c0ad3a92988887922edfcb7be66acac6106881beaf"},{"authors":"Charles
         Oliver Nutter","built_at":"2013-07-24T00:00:00.000Z","created_at":"2013-07-24T00:11:38.470Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":97167,"metadata":{},"number":"0.1.2","summary":"A
+        collections and utilities for Ruby","downloads_count":97278,"metadata":{},"number":"0.1.2","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"java","rubygems_version":"\u003e= 0","ruby_version":null,"prerelease":false,"licenses":["Apache-2.0"],"requirements":[],"sha":"d31bb9b0cafd67510f9d5d026064e00c99dcd2935fe310a9deba987788146da7"},{"authors":"Charles
         Oliver Nutter","built_at":"2013-07-23T00:00:00.000Z","created_at":"2013-07-23T19:40:30.776Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":5064,"metadata":{},"number":"0.1.1","summary":"A
+        collections and utilities for Ruby","downloads_count":5095,"metadata":{},"number":"0.1.1","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":null,"prerelease":false,"licenses":["Apache-2.0"],"requirements":[],"sha":"3102637a5f58ebb8adfbffad76acd9d40b2f0889c3fb4959a9b5e45b6f82942b"},{"authors":"Charles
         Oliver Nutter","built_at":"2013-07-23T00:00:00.000Z","created_at":"2013-07-23T19:39:55.576Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":1347,"metadata":{},"number":"0.1.1","summary":"A
+        collections and utilities for Ruby","downloads_count":1377,"metadata":{},"number":"0.1.1","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"java","rubygems_version":"\u003e= 0","ruby_version":null,"prerelease":false,"licenses":["Apache-2.0"],"requirements":[],"sha":"787f8084a847cbe26a9aad685a6e7b46ae113cd87aa144d78a9c3e4f631161db"},{"authors":"Charles
         Oliver Nutter, thedarkone","built_at":"2012-12-12T23:00:00.000Z","created_at":"2012-12-13T12:37:46.787Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":741215,"metadata":{},"number":"0.1.0","summary":"A
+        collections and utilities for Ruby","downloads_count":742385,"metadata":{},"number":"0.1.0","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":null,"prerelease":false,"licenses":[],"requirements":null,"sha":"4ee7605080ea11b1bfd8a5d7ddeef97a73609d1ad8355e648c91d00842201d3a"},{"authors":"Charles
         Oliver Nutter","built_at":"2012-04-27T00:00:00.000Z","created_at":"2012-04-27T16:52:19.721Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":3582,"metadata":{},"number":"0.0.3","summary":"A
+        collections and utilities for Ruby","downloads_count":3609,"metadata":{},"number":"0.0.3","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"d4fac31142dd3262bcf4e66f730e8ef5d0f058e4f5bc43d510fc4db92a4085e9"},{"authors":"Charles
         Oliver Nutter","built_at":"2012-04-26T00:00:00.000Z","created_at":"2012-04-26T00:12:31.448Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":1806,"metadata":{},"number":"0.0.2","summary":"A
+        collections and utilities for Ruby","downloads_count":1834,"metadata":{},"number":"0.0.2","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"bd74ee7ad95567721f7cd5757d6fb5a6cbf21e6613cf6f187ad3d72c245c2b39"},{"authors":"Charles
         Oliver Nutter","built_at":"2012-04-26T00:00:00.000Z","created_at":"2012-04-26T00:02:37.807Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":1788,"metadata":{},"number":"0.0.1","summary":"A
+        collections and utilities for Ruby","downloads_count":1816,"metadata":{},"number":"0.0.1","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"b1f7dfeb8bc765e421a90836c6a7e7dbe587abe238b2f660a89c6ad6e8e4975d"}]'
     http_version: 
-  recorded_at: Tue, 16 Jan 2018 20:14:40 GMT
+  recorded_at: Thu, 22 Mar 2018 23:15:22 GMT
 - request:
     method: get
     uri: https://rubygems.org/api/v1/gems/thread_safe/reverse_dependencies.json
@@ -313,9 +313,9 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - b77028e7-88b4-46a2-80cc-c491dc75d743
+      - 1167cebd-58b8-44ea-bac2-84b34675a84f
       X-Runtime:
-      - '0.030573'
+      - '0.028130'
       Strict-Transport-Security:
       - max-age=0
       X-Ua-Compatible:
@@ -327,7 +327,7 @@ http_interactions:
       Accept-Ranges:
       - bytes
       Date:
-      - Tue, 16 Jan 2018 20:14:41 GMT
+      - Thu, 22 Mar 2018 23:15:23 GMT
       Via:
       - 1.1 varnish
       Age:
@@ -335,37 +335,116 @@ http_interactions:
       Connection:
       - close
       X-Served-By:
-      - cache-ams4138-AMS
+      - cache-ams4129-AMS
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1516133681.381222,VS0,VE198
+      - S1521760523.887147,VS0,VE199
       Vary:
       - Accept-Encoding,Fastly-SSL
       Etag:
-      - '"cccee33f2e7f9909d8b82cfe39b92db6"'
+      - '"d38483f52e86f34ead7b98a2f81f20ef"'
       Server:
       - RubyGems.org
     body:
       encoding: UTF-8
-      string: '["r4s","cache_digests","tickr_client","racing-sprockets","clasp","gemerald_beanstalk","ruby_skynet","autodeps","dskiplist","barker","memoizable","descendants_tracker","axiom-types","devise-bootstrap","devbootsrap","axiom-memory-adapter","mongoid_connection_pool","cap_proxy","jirabas","gene_pool","metrics_logger","ruby_nsq","multi_connection","brainsome_devise","postamt","devision","venet-backup","mock_dns_server","whisperer","thread_hazardous","deviseOne","aws_student_accounts","colossus","vigilem-core","pd-blender","hexx-storage","stapfen","prepor-protobuf","persie","rom-generated_id","pagseguro-transparente","smelter","faraday_persistent_excon","persistent_excon","ruby_storm","email_crawler","backup_zh","collectr","ruby-dovado","dry-data","hermann","hermann","turbot-ruby-gems","pg_helper","asciidoctor-bespoke","fluent-plugin-multiline-parser","iplan-appsignal","wet-command_bus","arkency-command_bus","fleck","sliday_backup","neo4j_legacy","rester","slack-cli","sportweb","rohbau","killbill-payu-latam","killbill-firstdata_e4","killbill-securenet","killbill-chartmogul","s3reamer","datashift","elastics","peastash","shuttle_cli","asciidoctor-htmlbook","mixture","asciidoctor-accelerated-mobile-pages","asciidoctor-instant-articles","backup-ssh","asciidoctor-epub3","docli","protobuffy","killbill-litle","killbill-stripe","wechat_client","killbill-braintree_blue","nexpose_pxgrid","killbill-payment-test","gooddata-edge","asciidoctor","asciidoctor-pdf","asciidoctor-doctest","asciidoctor-html5s","killbill-cybersource","protobuf","tzinfo","killbill-orbital","logstash-filter-metrics","logstash-filter-throttle","asciidoctor-rfc","zapnito-cli","lines-engine","killbill-paypal-express","sequent","logstash-input-syslog","asciidoctor-iso","splitclient-rb","asciidoctor-revealjs","gooddata","gooddata","logstash-input-beats","killbill","ldclient-rb","easy_translate","hu","logstash-core"]'
+      string: '["killbill-cybersource","logstash-core","asciidoctor","datashift","asciidoctor-iso","isodoc","html2doc","killbill","hu","logstash-input-beats","gooddata","gooddata","asciidoctor-gb","ldclient-rb","asciidoctor-html5s","splitclient-rb","protobuf","asciidoctor-epub3","logstash-input-syslog","tzinfo","asciidoctor-revealjs","asciidoctor-csd","easy_translate","killbill-chartmogul","killbill-securenet","killbill-firstdata_e4","killbill-payu-latam","rohbau","sportweb","slack-cli","rester","neo4j_legacy","sliday_backup","iplan-appsignal","fluent-plugin-multiline-parser","asciidoctor-bespoke","asciidoctor-pdf","gooddata-edge","killbill-payment-test","nexpose_pxgrid","wechat_client","killbill-braintree_blue","killbill-litle","killbill-stripe","protobuffy","docli","backup-ssh","asciidoctor-instant-articles","asciidoctor-accelerated-mobile-pages","mixture","asciidoctor-htmlbook","shuttle_cli","peastash","elastics","s3reamer","pg_helper","turbot-ruby-gems","dry-data","ruby-dovado","collectr","sequent","killbill-paypal-express","lines-engine","asciidoctor-rfc","zapnito-cli","logstash-filter-throttle","logstash-filter-metrics","killbill-orbital","asciidoctor-doctest","fleck","arkency-command_bus","wet-command_bus","rom-generated_id","persie","prepor-protobuf","stapfen","hexx-storage","pd-blender","vigilem-core","hermann","hermann","colossus","aws_student_accounts","deviseOne","thread_hazardous","whisperer","mock_dns_server","venet-backup","devision","postamt","brainsome_devise","multi_connection","backup_zh","email_crawler","ruby_storm","persistent_excon","faraday_persistent_excon","smelter","pagseguro-transparente","ruby_nsq","r4s","cache_digests","tickr_client","racing-sprockets","clasp","gemerald_beanstalk","ruby_skynet","autodeps","dskiplist","barker","memoizable","descendants_tracker","axiom-types","devise-bootstrap","devbootsrap","axiom-memory-adapter","mongoid_connection_pool","cap_proxy","jirabas","gene_pool","metrics_logger"]'
     http_version: 
-  recorded_at: Tue, 16 Jan 2018 20:14:41 GMT
+  recorded_at: Thu, 22 Mar 2018 23:15:23 GMT
 - request:
-    method: get
-    uri: https://api.github.com/repos/ruby-concurrency/thread_safe?client_id=&client_secret=
+    method: head
+    uri: https://github.com/ruby-concurrency/thread_safe
     body:
       encoding: UTF-8
       string: ''
     headers:
+      Connection:
+      - close
+      Host:
+      - github.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Thu, 22 Mar 2018 23:15:23 GMT
       Content-Type:
-      - application/json
+      - text/html; charset=utf-8
+      Connection:
+      - close
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Cache-Control:
+      - no-cache
+      Vary:
+      - X-PJAX
+      Set-Cookie:
+      - _gh_sess=aWxvajlrOGh2ZzdEUjZWek43enRwdG1hQkk2d0crTC9YdHN5M0EzMDIvOEpsYlAyV1hwUXNsZUYzR1RzT1FpSlFxU3hldFhPK05hK0ZSeklYR0NubmVvTG1TSk9jQnM0aGtGRzJrVGRYSjJ0ODZxM2JWeDFyMWJQNTk3dDhMME14cGJBZ2pCRldCWXhnZ0EyV1N2OFE3NldVQkpvMUJRekd1cGk5bmpWalErSWVDSEN0akNOMm1oOFRtT0ZGeGlHRlJWQ1FxTkYyYlFMSXBOUzBEczJkZlJnR1NFUmFaU2NHejVJTHJZOW9vWkx3ZE9wVjI1ckJNTGJleVltT1p6Y1Y0OWpCaXVJbyt4OHJCbnlGNm9ML0dUVWtaL1FWQ25PbTMxVkNabXpNTkJTTlQ0ZTNYaGEyRTlIZWhicG9QNWtiQXIwSVk4MU8zeDB2cHQwRmR2Qk10cTZHZXQyYjFxcE5ZS3NqVloyRm04ZFFQNXNEdFV2dlFXR1pyb2taWUp4Yko3VEM0ZTNJWUR1ZW40TEUvb2ZYQ2dPR2FCUVZLdzd0QUdSb2lKcEt2OD0tLVExbXY4SmhMYlJmTkllUWFMdjhXUnc9PQ%3D%3D--f7c14d59f2fb14491e988957e91070bcaaf4b91d;
+        path=/; secure; HttpOnly
+      - logged_in=no; domain=.github.com; path=/; expires=Mon, 22 Mar 2038 23:15:23
+        -0000; secure; HttpOnly
+      X-Request-Id:
+      - cce82281-489a-4eec-88a2-081a963ab099
+      X-Runtime:
+      - '0.298562'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Expect-Ct:
+      - max-age=2592000, report-uri="https://api.github.com/_private/browser/errors"
+      Content-Security-Policy:
+      - 'default-src ''none''; base-uri ''self''; block-all-mixed-content; child-src
+        render.githubusercontent.com; connect-src ''self'' uploads.github.com status.github.com
+        collector.githubapp.com api.github.com www.google-analytics.com github-cloud.s3.amazonaws.com
+        github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com
+        github-production-user-asset-6210df.s3.amazonaws.com wss://live.github.com;
+        font-src assets-cdn.github.com; form-action ''self'' github.com gist.github.com;
+        frame-ancestors ''none''; img-src ''self'' data: assets-cdn.github.com identicons.github.com
+        collector.githubapp.com github-cloud.s3.amazonaws.com *.githubusercontent.com;
+        manifest-src ''self''; media-src ''none''; script-src assets-cdn.github.com;
+        style-src ''unsafe-inline'' assets-cdn.github.com; worker-src ''self'''
+      X-Runtime-Rack:
+      - '0.306961'
+      X-Github-Request-Id:
+      - ED30:3520:2471F5D:3B72E15:5AB4390B
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 22 Mar 2018 23:15:23 GMT
+- request:
+    method: post
+    uri: https://api.github.com/graphql
+    body:
+      encoding: UTF-8
+      string: '{"query":"{\n  repository(owner: \"ruby-concurrency\", name: \"thread_safe\")
+        {\n    nameWithOwner\n    forks {\n      totalCount\n    }\n    stargazers
+        {\n      totalCount\n    }\n    watchers {\n      totalCount\n    }\n    createdAt\n    defaultBranchRef
+        {\n      name\n      target {\n        ... on Commit {\n          history(first:
+        50) {\n            edges {\n              node {\n                authoredDate\n              }\n            }\n          }\n        }\n      }\n    }\n    description\n    hasIssuesEnabled\n    hasWikiEnabled\n    homepageUrl\n    isArchived\n    isFork\n    isMirror\n    licenseInfo
+        {\n      key\n    }\n    primaryLanguage {\n      name\n    }\n    pushedAt\n    closedIssues:
+        issues(states: CLOSED) {\n      totalCount\n    }\n    openIssues: issues(states:
+        OPEN) {\n      totalCount\n    }\n    closedPullRequests: pullRequests(states:
+        CLOSED) {\n      totalCount\n    }\n    openPullRequests: pullRequests(states:
+        OPEN) {\n      totalCount\n    }\n    mergedPullRequests: pullRequests(states:
+        MERGED) {\n      totalCount\n    }\n  }\n\n  rateLimit {\n    limit\n    cost\n    remaining\n    resetAt\n  }\n}\n"}'
+    headers:
+      Authorization:
+      - bearer <GITHUB_TOKEN>
       User-Agent:
       - ruby-toolbox.com API client
-      Accept:
-      - application/vnd.github.v3+json
       Connection:
       - close
       Host:
@@ -378,55 +457,54 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Tue, 16 Jan 2018 20:14:42 GMT
+      - Thu, 22 Mar 2018 23:15:24 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '6443'
+      - '3311'
       Connection:
       - close
       Status:
       - 200 OK
       X-Ratelimit-Limit:
-      - '60'
+      - '5000'
       X-Ratelimit-Remaining:
-      - '50'
+      - '4993'
       X-Ratelimit-Reset:
-      - '1516136899'
+      - '1521763907'
       Cache-Control:
-      - public, max-age=60, s-maxage=60
-      Vary:
-      - Accept
-      Etag:
-      - '"a36e762413f838b8d6d3765d762ca9f5"'
-      Last-Modified:
-      - Fri, 08 Dec 2017 22:13:51 GMT
+      - no-cache
+      X-Oauth-Scopes:
+      - public_repo
+      X-Accepted-Oauth-Scopes:
+      - repo
       X-Github-Media-Type:
-      - github.v3; format=json
+      - github.v4; format=json
       Access-Control-Expose-Headers:
       - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
         X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
       Access-Control-Allow-Origin:
       - "*"
-      Content-Security-Policy:
-      - default-src 'none'
       Strict-Transport-Security:
       - max-age=31536000; includeSubdomains; preload
-      X-Content-Type-Options:
-      - nosniff
       X-Frame-Options:
       - deny
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
       X-Runtime-Rack:
-      - '0.036687'
+      - '0.115483'
       X-Github-Request-Id:
-      - 7EC9:1B97:1159B6:219C1A:5A5E5D31
+      - EDE5:4B96:18CA2D3:36323C8:5AB4390B
     body:
       encoding: UTF-8
-      string: '{"id":20579727,"name":"thread_safe","full_name":"ruby-concurrency/thread_safe","owner":{"login":"ruby-concurrency","id":5462766,"avatar_url":"https://avatars3.githubusercontent.com/u/5462766?v=4","gravatar_id":"","url":"https://api.github.com/users/ruby-concurrency","html_url":"https://github.com/ruby-concurrency","followers_url":"https://api.github.com/users/ruby-concurrency/followers","following_url":"https://api.github.com/users/ruby-concurrency/following{/other_user}","gists_url":"https://api.github.com/users/ruby-concurrency/gists{/gist_id}","starred_url":"https://api.github.com/users/ruby-concurrency/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ruby-concurrency/subscriptions","organizations_url":"https://api.github.com/users/ruby-concurrency/orgs","repos_url":"https://api.github.com/users/ruby-concurrency/repos","events_url":"https://api.github.com/users/ruby-concurrency/events{/privacy}","received_events_url":"https://api.github.com/users/ruby-concurrency/received_events","type":"Organization","site_admin":false},"private":false,"html_url":"https://github.com/ruby-concurrency/thread_safe","description":"[DEPRECATED]
-        Thread-safe collections for Ruby (merged with concurrent-ruby)","fork":false,"url":"https://api.github.com/repos/ruby-concurrency/thread_safe","forks_url":"https://api.github.com/repos/ruby-concurrency/thread_safe/forks","keys_url":"https://api.github.com/repos/ruby-concurrency/thread_safe/keys{/key_id}","collaborators_url":"https://api.github.com/repos/ruby-concurrency/thread_safe/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/ruby-concurrency/thread_safe/teams","hooks_url":"https://api.github.com/repos/ruby-concurrency/thread_safe/hooks","issue_events_url":"https://api.github.com/repos/ruby-concurrency/thread_safe/issues/events{/number}","events_url":"https://api.github.com/repos/ruby-concurrency/thread_safe/events","assignees_url":"https://api.github.com/repos/ruby-concurrency/thread_safe/assignees{/user}","branches_url":"https://api.github.com/repos/ruby-concurrency/thread_safe/branches{/branch}","tags_url":"https://api.github.com/repos/ruby-concurrency/thread_safe/tags","blobs_url":"https://api.github.com/repos/ruby-concurrency/thread_safe/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/ruby-concurrency/thread_safe/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/ruby-concurrency/thread_safe/git/refs{/sha}","trees_url":"https://api.github.com/repos/ruby-concurrency/thread_safe/git/trees{/sha}","statuses_url":"https://api.github.com/repos/ruby-concurrency/thread_safe/statuses/{sha}","languages_url":"https://api.github.com/repos/ruby-concurrency/thread_safe/languages","stargazers_url":"https://api.github.com/repos/ruby-concurrency/thread_safe/stargazers","contributors_url":"https://api.github.com/repos/ruby-concurrency/thread_safe/contributors","subscribers_url":"https://api.github.com/repos/ruby-concurrency/thread_safe/subscribers","subscription_url":"https://api.github.com/repos/ruby-concurrency/thread_safe/subscription","commits_url":"https://api.github.com/repos/ruby-concurrency/thread_safe/commits{/sha}","git_commits_url":"https://api.github.com/repos/ruby-concurrency/thread_safe/git/commits{/sha}","comments_url":"https://api.github.com/repos/ruby-concurrency/thread_safe/comments{/number}","issue_comment_url":"https://api.github.com/repos/ruby-concurrency/thread_safe/issues/comments{/number}","contents_url":"https://api.github.com/repos/ruby-concurrency/thread_safe/contents/{+path}","compare_url":"https://api.github.com/repos/ruby-concurrency/thread_safe/compare/{base}...{head}","merges_url":"https://api.github.com/repos/ruby-concurrency/thread_safe/merges","archive_url":"https://api.github.com/repos/ruby-concurrency/thread_safe/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/ruby-concurrency/thread_safe/downloads","issues_url":"https://api.github.com/repos/ruby-concurrency/thread_safe/issues{/number}","pulls_url":"https://api.github.com/repos/ruby-concurrency/thread_safe/pulls{/number}","milestones_url":"https://api.github.com/repos/ruby-concurrency/thread_safe/milestones{/number}","notifications_url":"https://api.github.com/repos/ruby-concurrency/thread_safe/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/ruby-concurrency/thread_safe/labels{/name}","releases_url":"https://api.github.com/repos/ruby-concurrency/thread_safe/releases{/id}","deployments_url":"https://api.github.com/repos/ruby-concurrency/thread_safe/deployments","created_at":"2014-06-06T22:13:43Z","updated_at":"2017-12-08T22:13:51Z","pushed_at":"2017-07-23T14:05:44Z","git_url":"git://github.com/ruby-concurrency/thread_safe.git","ssh_url":"git@github.com:ruby-concurrency/thread_safe.git","clone_url":"https://github.com/ruby-concurrency/thread_safe.git","svn_url":"https://github.com/ruby-concurrency/thread_safe","homepage":"http://concurrent-ruby.com","size":526,"stargazers_count":189,"watchers_count":189,"language":"Java","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":true,"forks_count":19,"mirror_url":null,"archived":false,"open_issues_count":1,"license":{"key":"apache-2.0","name":"Apache
-        License 2.0","spdx_id":"Apache-2.0","url":"https://api.github.com/licenses/apache-2.0"},"forks":19,"open_issues":1,"watchers":189,"default_branch":"master","organization":{"login":"ruby-concurrency","id":5462766,"avatar_url":"https://avatars3.githubusercontent.com/u/5462766?v=4","gravatar_id":"","url":"https://api.github.com/users/ruby-concurrency","html_url":"https://github.com/ruby-concurrency","followers_url":"https://api.github.com/users/ruby-concurrency/followers","following_url":"https://api.github.com/users/ruby-concurrency/following{/other_user}","gists_url":"https://api.github.com/users/ruby-concurrency/gists{/gist_id}","starred_url":"https://api.github.com/users/ruby-concurrency/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ruby-concurrency/subscriptions","organizations_url":"https://api.github.com/users/ruby-concurrency/orgs","repos_url":"https://api.github.com/users/ruby-concurrency/repos","events_url":"https://api.github.com/users/ruby-concurrency/events{/privacy}","received_events_url":"https://api.github.com/users/ruby-concurrency/received_events","type":"Organization","site_admin":false},"network_count":19,"subscribers_count":14}'
+      string: '{"data":{"repository":{"nameWithOwner":"ruby-concurrency/thread_safe","forks":{"totalCount":16},"stargazers":{"totalCount":189},"watchers":{"totalCount":14},"createdAt":"2014-06-06T22:13:43Z","defaultBranchRef":{"name":"master","target":{"history":{"edges":[{"node":{"authoredDate":"2017-07-23T14:05:43Z"}},{"node":{"authoredDate":"2017-07-03T16:42:54Z"}},{"node":{"authoredDate":"2017-02-22T19:45:05Z"}},{"node":{"authoredDate":"2017-01-28T23:20:05Z"}},{"node":{"authoredDate":"2017-01-22T18:38:37Z"}},{"node":{"authoredDate":"2017-01-06T13:23:43Z"}},{"node":{"authoredDate":"2016-06-07T13:16:04Z"}},{"node":{"authoredDate":"2016-06-06T12:06:31Z"}},{"node":{"authoredDate":"2015-04-28T02:01:09Z"}},{"node":{"authoredDate":"2015-04-28T01:49:03Z"}},{"node":{"authoredDate":"2015-04-28T01:36:49Z"}},{"node":{"authoredDate":"2015-04-27T20:59:17Z"}},{"node":{"authoredDate":"2015-04-26T20:21:05Z"}},{"node":{"authoredDate":"2015-04-26T19:05:43Z"}},{"node":{"authoredDate":"2015-04-19T13:37:09Z"}},{"node":{"authoredDate":"2015-04-16T22:52:02Z"}},{"node":{"authoredDate":"2015-03-27T21:41:27Z"}},{"node":{"authoredDate":"2015-03-25T23:52:19Z"}},{"node":{"authoredDate":"2015-03-25T22:44:54Z"}},{"node":{"authoredDate":"2015-03-25T22:43:58Z"}},{"node":{"authoredDate":"2015-03-24T22:38:37Z"}},{"node":{"authoredDate":"2015-03-24T20:51:16Z"}},{"node":{"authoredDate":"2015-03-11T14:53:29Z"}},{"node":{"authoredDate":"2015-03-11T13:06:08Z"}},{"node":{"authoredDate":"2015-03-10T02:53:22Z"}},{"node":{"authoredDate":"2015-03-10T01:57:54Z"}},{"node":{"authoredDate":"2015-03-09T15:32:09Z"}},{"node":{"authoredDate":"2015-03-09T14:58:58Z"}},{"node":{"authoredDate":"2015-03-09T14:46:32Z"}},{"node":{"authoredDate":"2015-03-09T14:45:27Z"}},{"node":{"authoredDate":"2015-03-09T14:45:07Z"}},{"node":{"authoredDate":"2015-03-09T14:44:32Z"}},{"node":{"authoredDate":"2015-03-09T13:43:43Z"}},{"node":{"authoredDate":"2015-03-09T03:12:17Z"}},{"node":{"authoredDate":"2015-03-08T22:10:06Z"}},{"node":{"authoredDate":"2015-03-08T22:03:48Z"}},{"node":{"authoredDate":"2015-03-08T21:50:50Z"}},{"node":{"authoredDate":"2015-03-08T20:02:49Z"}},{"node":{"authoredDate":"2015-03-08T19:47:17Z"}},{"node":{"authoredDate":"2015-03-06T12:22:37Z"}},{"node":{"authoredDate":"2015-03-06T12:15:26Z"}},{"node":{"authoredDate":"2015-02-15T13:43:02Z"}},{"node":{"authoredDate":"2015-02-15T00:19:11Z"}},{"node":{"authoredDate":"2014-05-27T19:48:23Z"}},{"node":{"authoredDate":"2014-05-27T19:54:14Z"}},{"node":{"authoredDate":"2014-05-27T19:47:37Z"}},{"node":{"authoredDate":"2014-05-27T19:45:13Z"}},{"node":{"authoredDate":"2014-04-12T17:48:35Z"}},{"node":{"authoredDate":"2014-04-12T17:47:24Z"}},{"node":{"authoredDate":"2014-04-12T17:46:44Z"}}]}}},"description":"[DEPRECATED]
+        Thread-safe collections for Ruby (merged with concurrent-ruby)","hasIssuesEnabled":true,"hasWikiEnabled":true,"homepageUrl":"http://concurrent-ruby.com","isArchived":false,"isFork":false,"isMirror":false,"licenseInfo":{"key":"apache-2.0"},"primaryLanguage":{"name":"Java"},"pushedAt":"2018-01-29T06:45:29Z","closedIssues":{"totalCount":12},"openIssues":{"totalCount":1},"closedPullRequests":{"totalCount":3},"openPullRequests":{"totalCount":0},"mergedPullRequests":{"totalCount":16}},"rateLimit":{"limit":5000,"cost":1,"remaining":4993,"resetAt":"2018-03-23T00:11:47Z"}}}'
     http_version: 
-  recorded_at: Tue, 16 Jan 2018 20:14:41 GMT
+  recorded_at: Thu, 22 Mar 2018 23:15:24 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/full-project-sync-from-github.yml
+++ b/spec/cassettes/full-project-sync-from-github.yml
@@ -1,18 +1,97 @@
 ---
 http_interactions:
 - request:
-    method: get
-    uri: https://api.github.com/repos/postmodern/chruby?client_id=&client_secret=
+    method: head
+    uri: https://github.com/postmodern/chruby
     body:
       encoding: UTF-8
       string: ''
     headers:
+      Connection:
+      - close
+      Host:
+      - github.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Thu, 22 Mar 2018 23:15:25 GMT
       Content-Type:
-      - application/json
+      - text/html; charset=utf-8
+      Connection:
+      - close
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Cache-Control:
+      - no-cache
+      Vary:
+      - X-PJAX
+      Set-Cookie:
+      - _gh_sess=QXJBY2Q2eWgxSmdJdTUvdXdSR2V2aC9rWTJ2M1d3b2xHQU5sY25pRHo0VlZlSUFJTFd0OUJUZ0I5MExSQXo1by9OR25tZ2RXYXkrRUhWVlRkVXd3MkhQV3R1NEx5RE5FWlhIZkVVWm5kYndFRExtVE1WVFJQODkvOW5nRTJyTU9PY21IM1hMWXpnTHpDNWFGenMwWXNLNklFRUlqRmF4d3BkYW5zbnR6MjJFT1RQTmJKS2ovOXJDUTBnSkFXMmtQT1doYmZoVXpMdHZicmpNck9odGtBUXpUcVQ2WUlNMVZkWmpSMTc1OHJCdXBLT3grTEZUMGo2YWwrZ1JLV2RmK0FHelJHUWVRekJ2SnVVTmlrQmIrWjJ5M21BV2NJeFFvNXJYeWpoTTR5WVBEZzJ2VW5ETktVSlBIRmVYNFZpSTJ3dUpFWUtuS0tyYWZOd1BOOE9CWDVoOHN5WDFZS3pmTjFHVno1T1ZMZ2Z4d3BBdEFnUDhIZCsxRWxIK0ZYYlljdFljSGh1WHdXK29VbmtHbVZ5ZUV6UT09LS1ZWExHMVVjK1F2MzFIei96VHo5dUtRPT0%3D--e4495a9e007b2669cc2fb6cb478e7777fe22bb14;
+        path=/; secure; HttpOnly
+      - logged_in=no; domain=.github.com; path=/; expires=Mon, 22 Mar 2038 23:15:25
+        -0000; secure; HttpOnly
+      X-Request-Id:
+      - 99f6a6b1-5c0e-4e31-ab78-ec4b72ece4fe
+      X-Runtime:
+      - '0.218279'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Expect-Ct:
+      - max-age=2592000, report-uri="https://api.github.com/_private/browser/errors"
+      Content-Security-Policy:
+      - 'default-src ''none''; base-uri ''self''; block-all-mixed-content; child-src
+        render.githubusercontent.com; connect-src ''self'' uploads.github.com status.github.com
+        collector.githubapp.com api.github.com www.google-analytics.com github-cloud.s3.amazonaws.com
+        github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com
+        github-production-user-asset-6210df.s3.amazonaws.com wss://live.github.com;
+        font-src assets-cdn.github.com; form-action ''self'' github.com gist.github.com;
+        frame-ancestors ''none''; img-src ''self'' data: assets-cdn.github.com identicons.github.com
+        collector.githubapp.com github-cloud.s3.amazonaws.com *.githubusercontent.com;
+        manifest-src ''self''; media-src ''none''; script-src assets-cdn.github.com;
+        style-src ''unsafe-inline'' assets-cdn.github.com; worker-src ''self'''
+      X-Runtime-Rack:
+      - '0.225821'
+      X-Github-Request-Id:
+      - ED47:351F:1A39148:2E62F9B:5AB4390C
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 22 Mar 2018 23:15:25 GMT
+- request:
+    method: post
+    uri: https://api.github.com/graphql
+    body:
+      encoding: UTF-8
+      string: '{"query":"{\n  repository(owner: \"postmodern\", name: \"chruby\")
+        {\n    nameWithOwner\n    forks {\n      totalCount\n    }\n    stargazers
+        {\n      totalCount\n    }\n    watchers {\n      totalCount\n    }\n    createdAt\n    defaultBranchRef
+        {\n      name\n      target {\n        ... on Commit {\n          history(first:
+        50) {\n            edges {\n              node {\n                authoredDate\n              }\n            }\n          }\n        }\n      }\n    }\n    description\n    hasIssuesEnabled\n    hasWikiEnabled\n    homepageUrl\n    isArchived\n    isFork\n    isMirror\n    licenseInfo
+        {\n      key\n    }\n    primaryLanguage {\n      name\n    }\n    pushedAt\n    closedIssues:
+        issues(states: CLOSED) {\n      totalCount\n    }\n    openIssues: issues(states:
+        OPEN) {\n      totalCount\n    }\n    closedPullRequests: pullRequests(states:
+        CLOSED) {\n      totalCount\n    }\n    openPullRequests: pullRequests(states:
+        OPEN) {\n      totalCount\n    }\n    mergedPullRequests: pullRequests(states:
+        MERGED) {\n      totalCount\n    }\n  }\n\n  rateLimit {\n    limit\n    cost\n    remaining\n    resetAt\n  }\n}\n"}'
+    headers:
+      Authorization:
+      - bearer <GITHUB_TOKEN>
       User-Agent:
       - ruby-toolbox.com API client
-      Accept:
-      - application/vnd.github.v3+json
       Connection:
       - close
       Host:
@@ -25,55 +104,54 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Tue, 16 Jan 2018 20:14:42 GMT
+      - Thu, 22 Mar 2018 23:15:25 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '4792'
+      - '3223'
       Connection:
       - close
       Status:
       - 200 OK
       X-Ratelimit-Limit:
-      - '60'
+      - '5000'
       X-Ratelimit-Remaining:
-      - '49'
+      - '4992'
       X-Ratelimit-Reset:
-      - '1516136899'
+      - '1521763907'
       Cache-Control:
-      - public, max-age=60, s-maxage=60
-      Vary:
-      - Accept
-      Etag:
-      - '"4984cbbbcbe0661a2f8928796dfc06e2"'
-      Last-Modified:
-      - Fri, 12 Jan 2018 04:16:38 GMT
+      - no-cache
+      X-Oauth-Scopes:
+      - public_repo
+      X-Accepted-Oauth-Scopes:
+      - repo
       X-Github-Media-Type:
-      - github.v3; format=json
+      - github.v4; format=json
       Access-Control-Expose-Headers:
       - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
         X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
       Access-Control-Allow-Origin:
       - "*"
-      Content-Security-Policy:
-      - default-src 'none'
       Strict-Transport-Security:
       - max-age=31536000; includeSubdomains; preload
-      X-Content-Type-Options:
-      - nosniff
       X-Frame-Options:
       - deny
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
       X-Runtime-Rack:
-      - '0.040167'
+      - '0.172062'
       X-Github-Request-Id:
-      - 7EDC:1B97:115A12:219CC0:5A5E5D32
+      - ED75:4B91:12471AA:28EB59B:5AB4390D
     body:
       encoding: UTF-8
-      string: '{"id":5266284,"name":"chruby","full_name":"postmodern/chruby","owner":{"login":"postmodern","id":12671,"avatar_url":"https://avatars2.githubusercontent.com/u/12671?v=4","gravatar_id":"","url":"https://api.github.com/users/postmodern","html_url":"https://github.com/postmodern","followers_url":"https://api.github.com/users/postmodern/followers","following_url":"https://api.github.com/users/postmodern/following{/other_user}","gists_url":"https://api.github.com/users/postmodern/gists{/gist_id}","starred_url":"https://api.github.com/users/postmodern/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/postmodern/subscriptions","organizations_url":"https://api.github.com/users/postmodern/orgs","repos_url":"https://api.github.com/users/postmodern/repos","events_url":"https://api.github.com/users/postmodern/events{/privacy}","received_events_url":"https://api.github.com/users/postmodern/received_events","type":"User","site_admin":false},"private":false,"html_url":"https://github.com/postmodern/chruby","description":"Changes
-        the current Ruby","fork":false,"url":"https://api.github.com/repos/postmodern/chruby","forks_url":"https://api.github.com/repos/postmodern/chruby/forks","keys_url":"https://api.github.com/repos/postmodern/chruby/keys{/key_id}","collaborators_url":"https://api.github.com/repos/postmodern/chruby/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/postmodern/chruby/teams","hooks_url":"https://api.github.com/repos/postmodern/chruby/hooks","issue_events_url":"https://api.github.com/repos/postmodern/chruby/issues/events{/number}","events_url":"https://api.github.com/repos/postmodern/chruby/events","assignees_url":"https://api.github.com/repos/postmodern/chruby/assignees{/user}","branches_url":"https://api.github.com/repos/postmodern/chruby/branches{/branch}","tags_url":"https://api.github.com/repos/postmodern/chruby/tags","blobs_url":"https://api.github.com/repos/postmodern/chruby/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/postmodern/chruby/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/postmodern/chruby/git/refs{/sha}","trees_url":"https://api.github.com/repos/postmodern/chruby/git/trees{/sha}","statuses_url":"https://api.github.com/repos/postmodern/chruby/statuses/{sha}","languages_url":"https://api.github.com/repos/postmodern/chruby/languages","stargazers_url":"https://api.github.com/repos/postmodern/chruby/stargazers","contributors_url":"https://api.github.com/repos/postmodern/chruby/contributors","subscribers_url":"https://api.github.com/repos/postmodern/chruby/subscribers","subscription_url":"https://api.github.com/repos/postmodern/chruby/subscription","commits_url":"https://api.github.com/repos/postmodern/chruby/commits{/sha}","git_commits_url":"https://api.github.com/repos/postmodern/chruby/git/commits{/sha}","comments_url":"https://api.github.com/repos/postmodern/chruby/comments{/number}","issue_comment_url":"https://api.github.com/repos/postmodern/chruby/issues/comments{/number}","contents_url":"https://api.github.com/repos/postmodern/chruby/contents/{+path}","compare_url":"https://api.github.com/repos/postmodern/chruby/compare/{base}...{head}","merges_url":"https://api.github.com/repos/postmodern/chruby/merges","archive_url":"https://api.github.com/repos/postmodern/chruby/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/postmodern/chruby/downloads","issues_url":"https://api.github.com/repos/postmodern/chruby/issues{/number}","pulls_url":"https://api.github.com/repos/postmodern/chruby/pulls{/number}","milestones_url":"https://api.github.com/repos/postmodern/chruby/milestones{/number}","notifications_url":"https://api.github.com/repos/postmodern/chruby/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/postmodern/chruby/labels{/name}","releases_url":"https://api.github.com/repos/postmodern/chruby/releases{/id}","deployments_url":"https://api.github.com/repos/postmodern/chruby/deployments","created_at":"2012-08-01T23:46:08Z","updated_at":"2018-01-12T04:16:38Z","pushed_at":"2017-11-07T18:11:20Z","git_url":"git://github.com/postmodern/chruby.git","ssh_url":"git@github.com:postmodern/chruby.git","clone_url":"https://github.com/postmodern/chruby.git","svn_url":"https://github.com/postmodern/chruby","homepage":"","size":547,"stargazers_count":2106,"watchers_count":2106,"language":"Shell","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":171,"mirror_url":null,"archived":false,"open_issues_count":74,"license":{"key":"mit","name":"MIT
-        License","spdx_id":"MIT","url":"https://api.github.com/licenses/mit"},"forks":171,"open_issues":74,"watchers":2106,"default_branch":"master","network_count":171,"subscribers_count":55}'
+      string: '{"data":{"repository":{"nameWithOwner":"postmodern/chruby","forks":{"totalCount":158},"stargazers":{"totalCount":2122},"watchers":{"totalCount":55},"createdAt":"2012-08-01T23:46:08Z","defaultBranchRef":{"name":"master","target":{"history":{"edges":[{"node":{"authoredDate":"2017-07-18T20:59:40Z"}},{"node":{"authoredDate":"2017-07-09T19:50:51Z"}},{"node":{"authoredDate":"2017-03-02T01:45:48Z"}},{"node":{"authoredDate":"2016-12-25T03:54:09Z"}},{"node":{"authoredDate":"2016-12-23T09:48:19Z"}},{"node":{"authoredDate":"2016-12-18T22:38:58Z"}},{"node":{"authoredDate":"2016-12-16T01:10:03Z"}},{"node":{"authoredDate":"2016-12-04T06:10:17Z"}},{"node":{"authoredDate":"2016-11-11T23:42:43Z"}},{"node":{"authoredDate":"2016-11-07T18:38:18Z"}},{"node":{"authoredDate":"2016-11-05T02:07:52Z"}},{"node":{"authoredDate":"2016-04-08T21:31:14Z"}},{"node":{"authoredDate":"2016-01-05T23:06:35Z"}},{"node":{"authoredDate":"2015-12-27T23:49:55Z"}},{"node":{"authoredDate":"2015-12-27T23:49:04Z"}},{"node":{"authoredDate":"2015-12-27T23:48:06Z"}},{"node":{"authoredDate":"2015-12-27T10:11:10Z"}},{"node":{"authoredDate":"2015-12-27T09:58:26Z"}},{"node":{"authoredDate":"2015-12-27T09:49:42Z"}},{"node":{"authoredDate":"2015-12-24T02:31:18Z"}},{"node":{"authoredDate":"2015-11-20T02:15:21Z"}},{"node":{"authoredDate":"2015-09-17T18:24:21Z"}},{"node":{"authoredDate":"2015-07-09T20:16:56Z"}},{"node":{"authoredDate":"2015-06-22T17:38:25Z"}},{"node":{"authoredDate":"2015-05-03T23:10:07Z"}},{"node":{"authoredDate":"2015-05-02T05:29:47Z"}},{"node":{"authoredDate":"2015-05-02T04:10:43Z"}},{"node":{"authoredDate":"2015-05-02T03:50:25Z"}},{"node":{"authoredDate":"2015-05-02T03:49:31Z"}},{"node":{"authoredDate":"2015-04-26T22:45:54Z"}},{"node":{"authoredDate":"2015-04-26T22:44:28Z"}},{"node":{"authoredDate":"2015-03-26T21:56:43Z"}},{"node":{"authoredDate":"2015-03-21T21:01:47Z"}},{"node":{"authoredDate":"2015-03-18T22:35:02Z"}},{"node":{"authoredDate":"2015-03-14T02:01:58Z"}},{"node":{"authoredDate":"2015-03-13T23:39:22Z"}},{"node":{"authoredDate":"2015-03-13T23:09:30Z"}},{"node":{"authoredDate":"2015-03-13T23:07:08Z"}},{"node":{"authoredDate":"2015-03-13T23:05:48Z"}},{"node":{"authoredDate":"2015-03-13T22:56:45Z"}},{"node":{"authoredDate":"2015-03-02T21:02:52Z"}},{"node":{"authoredDate":"2014-12-30T00:11:34Z"}},{"node":{"authoredDate":"2014-12-30T00:06:47Z"}},{"node":{"authoredDate":"2014-12-30T00:04:12Z"}},{"node":{"authoredDate":"2014-02-07T20:39:04Z"}},{"node":{"authoredDate":"2014-12-22T20:53:29Z"}},{"node":{"authoredDate":"2014-12-19T16:59:13Z"}},{"node":{"authoredDate":"2014-12-18T05:02:50Z"}},{"node":{"authoredDate":"2014-12-18T04:50:08Z"}},{"node":{"authoredDate":"2014-11-23T19:04:59Z"}}]}}},"description":"Changes
+        the current Ruby","hasIssuesEnabled":true,"hasWikiEnabled":true,"homepageUrl":"","isArchived":false,"isFork":false,"isMirror":false,"licenseInfo":{"key":"mit"},"primaryLanguage":{"name":"Shell"},"pushedAt":"2017-11-07T18:11:20Z","closedIssues":{"totalCount":194},"openIssues":{"totalCount":52},"closedPullRequests":{"totalCount":62},"openPullRequests":{"totalCount":19},"mergedPullRequests":{"totalCount":72}},"rateLimit":{"limit":5000,"cost":1,"remaining":4992,"resetAt":"2018-03-23T00:11:47Z"}}}'
     http_version: 
-  recorded_at: Tue, 16 Jan 2018 20:14:42 GMT
+  recorded_at: Thu, 22 Mar 2018 23:15:25 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/graphql/carrierwave.yml
+++ b/spec/cassettes/graphql/carrierwave.yml
@@ -21,7 +21,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Thu, 22 Mar 2018 22:14:07 GMT
+      - Thu, 22 Mar 2018 23:15:17 GMT
       Content-Type:
       - text/html; charset=utf-8
       Connection:
@@ -41,12 +41,12 @@ http_interactions:
       Location:
       - https://github.com/carrierwaveuploader/carrierwave
       Set-Cookie:
-      - _gh_sess=d2pxRE9UcGhNYUM0Z1pBMEFJS0ZWbWxJVXdRendyWlVaNWxoNGpuU2RhRnRFbGFsSjd5SHJyVWJ6cWZYZUREL2NJR011eENlbjdHQjh6TWFDOUZSVjIwRWFFNjVPdExyVGZmZXZtb0NBSlU9LS1KQi9FQzJLcm5QN3ZYQ2JQbStrUFB3PT0%3D--08af9011db28e974dab87aaf7bb6cd742b7652ab;
+      - _gh_sess=NWhUa1pDSmMxclFKM3kvaHdnTExhRmc0bWdxQ3pzMVRVN2w0UUtlNVhhK1hsa0N1RHVYa1ZrandKUEgyb1hOcXB6QzdPL0g1ZW0rb1U0Mm96aEJ5MXQ4d2h2THp1anUwa3JZT2I5NkJzVlE9LS1hd21WQXRBRVRPMFlnZlZObFRvZXZRPT0%3D--69f0ba09d7d8b4e8356a468042eea9fff8c50643;
         path=/; secure; HttpOnly
       X-Request-Id:
-      - e06c3ca9-32c8-4181-ac04-ac390ed12417
+      - 94bc5f58-f53e-43c7-bc50-e879c0cae74d
       X-Runtime:
-      - '0.020095'
+      - '0.022630'
       Strict-Transport-Security:
       - max-age=31536000; includeSubdomains; preload
       Referrer-Policy:
@@ -65,14 +65,14 @@ http_interactions:
         manifest-src ''self''; media-src ''none''; script-src assets-cdn.github.com;
         style-src ''unsafe-inline'' assets-cdn.github.com; worker-src ''self'''
       X-Runtime-Rack:
-      - '0.025276'
+      - '0.028138'
       X-Github-Request-Id:
-      - ED58:3521:1B5569C:337C148:5AB42AAF
+      - ED46:351F:1A38D8B:2E6294E:5AB43905
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 22 Mar 2018 22:14:07 GMT
+  recorded_at: Thu, 22 Mar 2018 23:15:17 GMT
 - request:
     method: post
     uri: https://api.github.com/graphql
@@ -106,7 +106,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Thu, 22 Mar 2018 22:14:07 GMT
+      - Thu, 22 Mar 2018 23:15:18 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
@@ -118,9 +118,9 @@ http_interactions:
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4996'
+      - '4994'
       X-Ratelimit-Reset:
-      - '1521759633'
+      - '1521763907'
       Cache-Control:
       - no-cache
       X-Oauth-Scopes:
@@ -147,13 +147,13 @@ http_interactions:
       Content-Security-Policy:
       - default-src 'none'
       X-Runtime-Rack:
-      - '0.182142'
+      - '0.267369'
       X-Github-Request-Id:
-      - ED14:4B95:16079BD:2F7EF9D:5AB42AAF
+      - EDE6:4B96:18CA14A:3631F77:5AB43905
     body:
       encoding: UTF-8
       string: '{"data":{"repository":{"nameWithOwner":"carrierwaveuploader/carrierwave","forks":{"totalCount":1370},"stargazers":{"totalCount":7901},"watchers":{"totalCount":156},"createdAt":"2008-08-28T18:39:49Z","defaultBranchRef":{"name":"master","target":{"history":{"edges":[{"node":{"authoredDate":"2018-02-23T01:37:44Z"}},{"node":{"authoredDate":"2018-02-16T16:48:00Z"}},{"node":{"authoredDate":"2018-02-13T10:54:25Z"}},{"node":{"authoredDate":"2018-02-13T10:54:02Z"}},{"node":{"authoredDate":"2018-02-13T10:37:04Z"}},{"node":{"authoredDate":"2018-02-13T07:00:10Z"}},{"node":{"authoredDate":"2018-02-13T10:35:51Z"}},{"node":{"authoredDate":"2018-02-13T10:17:08Z"}},{"node":{"authoredDate":"2018-02-13T10:48:04Z"}},{"node":{"authoredDate":"2018-02-13T10:14:41Z"}},{"node":{"authoredDate":"2018-02-13T08:57:51Z"}},{"node":{"authoredDate":"2018-02-13T08:56:10Z"}},{"node":{"authoredDate":"2018-02-10T07:17:06Z"}},{"node":{"authoredDate":"2018-02-10T06:56:26Z"}},{"node":{"authoredDate":"2018-02-10T06:13:56Z"}},{"node":{"authoredDate":"2018-02-09T08:20:08Z"}},{"node":{"authoredDate":"2018-02-08T10:33:45Z"}},{"node":{"authoredDate":"2018-01-18T08:51:01Z"}},{"node":{"authoredDate":"2018-01-18T06:00:34Z"}},{"node":{"authoredDate":"2018-01-02T09:20:23Z"}},{"node":{"authoredDate":"2018-01-02T06:20:10Z"}},{"node":{"authoredDate":"2018-01-02T06:18:21Z"}},{"node":{"authoredDate":"2017-12-31T13:44:15Z"}},{"node":{"authoredDate":"2017-12-29T14:44:08Z"}},{"node":{"authoredDate":"2017-12-29T13:21:09Z"}},{"node":{"authoredDate":"2017-11-29T01:26:38Z"}},{"node":{"authoredDate":"2017-11-23T01:03:23Z"}},{"node":{"authoredDate":"2017-11-15T08:23:28Z"}},{"node":{"authoredDate":"2017-10-30T13:57:30Z"}},{"node":{"authoredDate":"2017-10-19T02:21:42Z"}},{"node":{"authoredDate":"2017-10-18T13:18:22Z"}},{"node":{"authoredDate":"2017-10-09T02:13:27Z"}},{"node":{"authoredDate":"2017-10-06T18:11:55Z"}},{"node":{"authoredDate":"2017-10-04T01:49:40Z"}},{"node":{"authoredDate":"2017-10-03T09:50:23Z"}},{"node":{"authoredDate":"2017-09-30T08:57:16Z"}},{"node":{"authoredDate":"2017-09-30T08:12:58Z"}},{"node":{"authoredDate":"2017-09-30T05:04:39Z"}},{"node":{"authoredDate":"2017-09-30T05:00:06Z"}},{"node":{"authoredDate":"2017-09-30T04:53:16Z"}},{"node":{"authoredDate":"2017-09-30T04:17:29Z"}},{"node":{"authoredDate":"2017-09-21T16:40:17Z"}},{"node":{"authoredDate":"2017-09-12T10:36:09Z"}},{"node":{"authoredDate":"2017-09-03T03:30:04Z"}},{"node":{"authoredDate":"2017-09-01T02:51:27Z"}},{"node":{"authoredDate":"2017-08-19T08:02:00Z"}},{"node":{"authoredDate":"2017-07-12T02:11:22Z"}},{"node":{"authoredDate":"2017-07-12T01:48:26Z"}},{"node":{"authoredDate":"2017-07-10T06:32:28Z"}},{"node":{"authoredDate":"2017-07-09T10:44:11Z"}}]}}},"description":"Classier
-        solution for file uploads for Rails, Sinatra and other Ruby web frameworks","hasIssuesEnabled":true,"hasWikiEnabled":true,"homepageUrl":"https://github.com/carrierwaveuploader/carrierwave","isArchived":false,"isFork":false,"isMirror":false,"licenseInfo":null,"primaryLanguage":{"name":"Ruby"},"pushedAt":"2018-03-11T18:17:04Z","closedIssues":{"totalCount":1383},"openIssues":{"totalCount":208},"closedPullRequests":{"totalCount":233},"openPullRequests":{"totalCount":13},"mergedPullRequests":{"totalCount":457}},"rateLimit":{"limit":5000,"cost":1,"remaining":4996,"resetAt":"2018-03-22T23:00:33Z"}}}'
+        solution for file uploads for Rails, Sinatra and other Ruby web frameworks","hasIssuesEnabled":true,"hasWikiEnabled":true,"homepageUrl":"https://github.com/carrierwaveuploader/carrierwave","isArchived":false,"isFork":false,"isMirror":false,"licenseInfo":null,"primaryLanguage":{"name":"Ruby"},"pushedAt":"2018-03-11T18:17:04Z","closedIssues":{"totalCount":1383},"openIssues":{"totalCount":208},"closedPullRequests":{"totalCount":233},"openPullRequests":{"totalCount":13},"mergedPullRequests":{"totalCount":457}},"rateLimit":{"limit":5000,"cost":1,"remaining":4994,"resetAt":"2018-03-23T00:11:47Z"}}}'
     http_version: 
-  recorded_at: Thu, 22 Mar 2018 22:14:07 GMT
+  recorded_at: Thu, 22 Mar 2018 23:15:18 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/graphql/carrierwave.yml
+++ b/spec/cassettes/graphql/carrierwave.yml
@@ -1,0 +1,159 @@
+---
+http_interactions:
+- request:
+    method: head
+    uri: https://github.com/jnicklas/carrierwave
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - github.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Thu, 22 Mar 2018 22:14:07 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Connection:
+      - close
+      Status:
+      - 301 Moved Permanently
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Cache-Control:
+      - no-cache
+      Vary:
+      - X-PJAX
+      Location:
+      - https://github.com/carrierwaveuploader/carrierwave
+      Set-Cookie:
+      - _gh_sess=d2pxRE9UcGhNYUM0Z1pBMEFJS0ZWbWxJVXdRendyWlVaNWxoNGpuU2RhRnRFbGFsSjd5SHJyVWJ6cWZYZUREL2NJR011eENlbjdHQjh6TWFDOUZSVjIwRWFFNjVPdExyVGZmZXZtb0NBSlU9LS1KQi9FQzJLcm5QN3ZYQ2JQbStrUFB3PT0%3D--08af9011db28e974dab87aaf7bb6cd742b7652ab;
+        path=/; secure; HttpOnly
+      X-Request-Id:
+      - e06c3ca9-32c8-4181-ac04-ac390ed12417
+      X-Runtime:
+      - '0.020095'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Expect-Ct:
+      - max-age=2592000, report-uri="https://api.github.com/_private/browser/errors"
+      Content-Security-Policy:
+      - 'default-src ''none''; base-uri ''self''; block-all-mixed-content; child-src
+        render.githubusercontent.com; connect-src ''self'' uploads.github.com status.github.com
+        collector.githubapp.com api.github.com www.google-analytics.com github-cloud.s3.amazonaws.com
+        github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com
+        github-production-user-asset-6210df.s3.amazonaws.com wss://live.github.com;
+        font-src assets-cdn.github.com; form-action ''self'' github.com gist.github.com;
+        frame-ancestors ''none''; img-src ''self'' data: assets-cdn.github.com identicons.github.com
+        collector.githubapp.com github-cloud.s3.amazonaws.com *.githubusercontent.com;
+        manifest-src ''self''; media-src ''none''; script-src assets-cdn.github.com;
+        style-src ''unsafe-inline'' assets-cdn.github.com; worker-src ''self'''
+      X-Runtime-Rack:
+      - '0.025276'
+      X-Github-Request-Id:
+      - ED58:3521:1B5569C:337C148:5AB42AAF
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 22 Mar 2018 22:14:07 GMT
+- request:
+    method: post
+    uri: https://api.github.com/graphql
+    body:
+      encoding: UTF-8
+      string: '{"query":"{\n  repository(owner: \"carrierwaveuploader\", name: \"carrierwave\")
+        {\n    nameWithOwner\n    forks {\n      totalCount\n    }\n    stargazers
+        {\n      totalCount\n    }\n    watchers {\n      totalCount\n    }\n    createdAt\n    defaultBranchRef
+        {\n      name\n      target {\n        ... on Commit {\n          history(first:
+        50) {\n            edges {\n              node {\n                authoredDate\n              }\n            }\n          }\n        }\n      }\n    }\n    description\n    hasIssuesEnabled\n    hasWikiEnabled\n    homepageUrl\n    isArchived\n    isFork\n    isMirror\n    licenseInfo
+        {\n      key\n    }\n    primaryLanguage {\n      name\n    }\n    pushedAt\n    closedIssues:
+        issues(states: CLOSED) {\n      totalCount\n    }\n    openIssues: issues(states:
+        OPEN) {\n      totalCount\n    }\n    closedPullRequests: pullRequests(states:
+        CLOSED) {\n      totalCount\n    }\n    openPullRequests: pullRequests(states:
+        OPEN) {\n      totalCount\n    }\n    mergedPullRequests: pullRequests(states:
+        MERGED) {\n      totalCount\n    }\n  }\n\n  rateLimit {\n    limit\n    cost\n    remaining\n    resetAt\n  }\n}\n"}'
+    headers:
+      Authorization:
+      - bearer <GITHUB_TOKEN>
+      User-Agent:
+      - ruby-toolbox.com API client
+      Connection:
+      - close
+      Host:
+      - api.github.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Thu, 22 Mar 2018 22:14:07 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '3342'
+      Connection:
+      - close
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4996'
+      X-Ratelimit-Reset:
+      - '1521759633'
+      Cache-Control:
+      - no-cache
+      X-Oauth-Scopes:
+      - public_repo
+      X-Accepted-Oauth-Scopes:
+      - repo
+      X-Github-Media-Type:
+      - github.v4; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Runtime-Rack:
+      - '0.182142'
+      X-Github-Request-Id:
+      - ED14:4B95:16079BD:2F7EF9D:5AB42AAF
+    body:
+      encoding: UTF-8
+      string: '{"data":{"repository":{"nameWithOwner":"carrierwaveuploader/carrierwave","forks":{"totalCount":1370},"stargazers":{"totalCount":7901},"watchers":{"totalCount":156},"createdAt":"2008-08-28T18:39:49Z","defaultBranchRef":{"name":"master","target":{"history":{"edges":[{"node":{"authoredDate":"2018-02-23T01:37:44Z"}},{"node":{"authoredDate":"2018-02-16T16:48:00Z"}},{"node":{"authoredDate":"2018-02-13T10:54:25Z"}},{"node":{"authoredDate":"2018-02-13T10:54:02Z"}},{"node":{"authoredDate":"2018-02-13T10:37:04Z"}},{"node":{"authoredDate":"2018-02-13T07:00:10Z"}},{"node":{"authoredDate":"2018-02-13T10:35:51Z"}},{"node":{"authoredDate":"2018-02-13T10:17:08Z"}},{"node":{"authoredDate":"2018-02-13T10:48:04Z"}},{"node":{"authoredDate":"2018-02-13T10:14:41Z"}},{"node":{"authoredDate":"2018-02-13T08:57:51Z"}},{"node":{"authoredDate":"2018-02-13T08:56:10Z"}},{"node":{"authoredDate":"2018-02-10T07:17:06Z"}},{"node":{"authoredDate":"2018-02-10T06:56:26Z"}},{"node":{"authoredDate":"2018-02-10T06:13:56Z"}},{"node":{"authoredDate":"2018-02-09T08:20:08Z"}},{"node":{"authoredDate":"2018-02-08T10:33:45Z"}},{"node":{"authoredDate":"2018-01-18T08:51:01Z"}},{"node":{"authoredDate":"2018-01-18T06:00:34Z"}},{"node":{"authoredDate":"2018-01-02T09:20:23Z"}},{"node":{"authoredDate":"2018-01-02T06:20:10Z"}},{"node":{"authoredDate":"2018-01-02T06:18:21Z"}},{"node":{"authoredDate":"2017-12-31T13:44:15Z"}},{"node":{"authoredDate":"2017-12-29T14:44:08Z"}},{"node":{"authoredDate":"2017-12-29T13:21:09Z"}},{"node":{"authoredDate":"2017-11-29T01:26:38Z"}},{"node":{"authoredDate":"2017-11-23T01:03:23Z"}},{"node":{"authoredDate":"2017-11-15T08:23:28Z"}},{"node":{"authoredDate":"2017-10-30T13:57:30Z"}},{"node":{"authoredDate":"2017-10-19T02:21:42Z"}},{"node":{"authoredDate":"2017-10-18T13:18:22Z"}},{"node":{"authoredDate":"2017-10-09T02:13:27Z"}},{"node":{"authoredDate":"2017-10-06T18:11:55Z"}},{"node":{"authoredDate":"2017-10-04T01:49:40Z"}},{"node":{"authoredDate":"2017-10-03T09:50:23Z"}},{"node":{"authoredDate":"2017-09-30T08:57:16Z"}},{"node":{"authoredDate":"2017-09-30T08:12:58Z"}},{"node":{"authoredDate":"2017-09-30T05:04:39Z"}},{"node":{"authoredDate":"2017-09-30T05:00:06Z"}},{"node":{"authoredDate":"2017-09-30T04:53:16Z"}},{"node":{"authoredDate":"2017-09-30T04:17:29Z"}},{"node":{"authoredDate":"2017-09-21T16:40:17Z"}},{"node":{"authoredDate":"2017-09-12T10:36:09Z"}},{"node":{"authoredDate":"2017-09-03T03:30:04Z"}},{"node":{"authoredDate":"2017-09-01T02:51:27Z"}},{"node":{"authoredDate":"2017-08-19T08:02:00Z"}},{"node":{"authoredDate":"2017-07-12T02:11:22Z"}},{"node":{"authoredDate":"2017-07-12T01:48:26Z"}},{"node":{"authoredDate":"2017-07-10T06:32:28Z"}},{"node":{"authoredDate":"2017-07-09T10:44:11Z"}}]}}},"description":"Classier
+        solution for file uploads for Rails, Sinatra and other Ruby web frameworks","hasIssuesEnabled":true,"hasWikiEnabled":true,"homepageUrl":"https://github.com/carrierwaveuploader/carrierwave","isArchived":false,"isFork":false,"isMirror":false,"licenseInfo":null,"primaryLanguage":{"name":"Ruby"},"pushedAt":"2018-03-11T18:17:04Z","closedIssues":{"totalCount":1383},"openIssues":{"totalCount":208},"closedPullRequests":{"totalCount":233},"openPullRequests":{"totalCount":13},"mergedPullRequests":{"totalCount":457}},"rateLimit":{"limit":5000,"cost":1,"remaining":4996,"resetAt":"2018-03-22T23:00:33Z"}}}'
+    http_version: 
+  recorded_at: Thu, 22 Mar 2018 22:14:07 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/graphql/fails.yml
+++ b/spec/cassettes/graphql/fails.yml
@@ -21,7 +21,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Thu, 22 Mar 2018 22:14:10 GMT
+      - Thu, 22 Mar 2018 23:15:16 GMT
       Content-Type:
       - text/html; charset=utf-8
       Connection:
@@ -39,12 +39,12 @@ http_interactions:
       Vary:
       - X-PJAX
       Set-Cookie:
-      - _gh_sess=ZCtRM2s1RG94RVhlZjQySS9qMFFVTHBMcHRSeStQclZDZmVmekp0d0VyVnRaTkxBbS9KUFVyM0gvdjZJQVMwVmNkWjY2c2YyWXdLNVpDTm1TdGNKeDRlS1d4TnlQTGdXbldGMjV1Q1I3Z1U9LS1TeHFyL3pMY2NQN1o1V0ovSEhJQ3JnPT0%3D--433bb5d86b4768a7daa4c4ec75f37eb71ac3a48f;
+      - _gh_sess=KzdVaVkxMUl5S21sbnNQTVRJTEF6ckJSRTFyQ2dtalZidU9GOER4c0Voa2l6UEJmN2R0NGxDZTlrSi8rVWcvNjBLK1RZR2UyNWM1Qm4zYWtRQnhKU2ozN0VqeElqamI5a040VDVhNFVmbmM9LS15bEw4VTBsNmhKMHUrSVFVQ2pkZnFRPT0%3D--de450de9937dcfe851105df9d63104c91e083f02;
         path=/; secure; HttpOnly
       X-Request-Id:
-      - dbbba5f1-3dd6-4e12-a54d-dea30af30c5e
+      - 48e07c1a-b285-4249-ae6a-fdef9ed10b67
       X-Runtime:
-      - '0.012018'
+      - '0.019271'
       Strict-Transport-Security:
       - max-age=31536000; includeSubdomains; preload
       Referrer-Policy:
@@ -55,12 +55,12 @@ http_interactions:
       - default-src 'none'; base-uri 'self'; connect-src 'self'; form-action 'self';
         img-src data:; script-src 'self'; style-src 'unsafe-inline'
       X-Runtime-Rack:
-      - '0.017010'
+      - '0.025812'
       X-Github-Request-Id:
-      - EDF7:351E:137AB5F:24562F0:5AB42AB2
+      - EDDD:3521:1BB9190:3440574:5AB43904
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 22 Mar 2018 22:14:10 GMT
+  recorded_at: Thu, 22 Mar 2018 23:15:16 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/graphql/fails.yml
+++ b/spec/cassettes/graphql/fails.yml
@@ -1,0 +1,84 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.github.com/graphql
+    body:
+      encoding: UTF-8
+      string: '{"query":"{\n  repository(owner: \"thisverylikely\", name: \"fails\")
+        {\n    nameWithOwner\n    forks {\n      totalCount\n    }\n    stargazers
+        {\n      totalCount\n    }\n    watchers {\n      totalCount\n    }\n    createdAt\n    defaultBranchRef
+        {\n      name\n      target {\n        ... on Commit {\n          history(first:
+        50) {\n            edges {\n              node {\n                authoredDate\n              }\n            }\n          }\n        }\n      }\n    }\n    description\n    hasIssuesEnabled\n    hasWikiEnabled\n    homepageUrl\n    isArchived\n    isFork\n    isMirror\n    licenseInfo
+        {\n      key\n    }\n    primaryLanguage {\n      name\n    }\n    pushedAt\n    closedIssues:
+        issues(states: CLOSED) {\n      totalCount\n    }\n    openIssues: issues(states:
+        OPEN) {\n      totalCount\n    }\n    closedPullRequests: pullRequests(states:
+        CLOSED) {\n      totalCount\n    }\n    openPullRequests: pullRequests(states:
+        OPEN) {\n      totalCount\n    }\n    mergedPullRequests: pullRequests(states:
+        MERGED) {\n      totalCount\n    }\n  }\n\n  rateLimit {\n    limit\n    cost\n    remaining\n    resetAt\n  }\n}\n"}'
+    headers:
+      Authorization:
+      - bearer <GITHUB_TOKEN>
+      User-Agent:
+      - ruby-toolbox.com API client
+      Connection:
+      - close
+      Host:
+      - api.github.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Mon, 12 Mar 2018 22:17:39 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '280'
+      Connection:
+      - close
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4999'
+      X-Ratelimit-Reset:
+      - '1520896659'
+      Cache-Control:
+      - no-cache
+      X-Oauth-Scopes:
+      - public_repo
+      X-Accepted-Oauth-Scopes:
+      - repo
+      X-Github-Media-Type:
+      - github.v4; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Runtime-Rack:
+      - '0.051332'
+      X-Github-Request-Id:
+      - 412E:7473:375968F:6D30E15:5AA6FC82
+    body:
+      encoding: UTF-8
+      string: '{"data":{"repository":null,"rateLimit":{"limit":5000,"cost":1,"remaining":4999,"resetAt":"2018-03-12T23:17:39Z"}},"errors":[{"message":"Could
+        not resolve to a User with the username ''thisverylikely''.","type":"NOT_FOUND","path":["repository"],"locations":[{"line":2,"column":3}]}]}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 22:17:39 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/graphql/fails.yml
+++ b/spec/cassettes/graphql/fails.yml
@@ -1,84 +1,66 @@
 ---
 http_interactions:
 - request:
-    method: post
-    uri: https://api.github.com/graphql
+    method: head
+    uri: https://github.com/thisverylikely/fails
     body:
       encoding: UTF-8
-      string: '{"query":"{\n  repository(owner: \"thisverylikely\", name: \"fails\")
-        {\n    nameWithOwner\n    forks {\n      totalCount\n    }\n    stargazers
-        {\n      totalCount\n    }\n    watchers {\n      totalCount\n    }\n    createdAt\n    defaultBranchRef
-        {\n      name\n      target {\n        ... on Commit {\n          history(first:
-        50) {\n            edges {\n              node {\n                authoredDate\n              }\n            }\n          }\n        }\n      }\n    }\n    description\n    hasIssuesEnabled\n    hasWikiEnabled\n    homepageUrl\n    isArchived\n    isFork\n    isMirror\n    licenseInfo
-        {\n      key\n    }\n    primaryLanguage {\n      name\n    }\n    pushedAt\n    closedIssues:
-        issues(states: CLOSED) {\n      totalCount\n    }\n    openIssues: issues(states:
-        OPEN) {\n      totalCount\n    }\n    closedPullRequests: pullRequests(states:
-        CLOSED) {\n      totalCount\n    }\n    openPullRequests: pullRequests(states:
-        OPEN) {\n      totalCount\n    }\n    mergedPullRequests: pullRequests(states:
-        MERGED) {\n      totalCount\n    }\n  }\n\n  rateLimit {\n    limit\n    cost\n    remaining\n    resetAt\n  }\n}\n"}'
+      string: ''
     headers:
-      Authorization:
-      - bearer <GITHUB_TOKEN>
-      User-Agent:
-      - ruby-toolbox.com API client
       Connection:
       - close
       Host:
-      - api.github.com
+      - github.com
+      User-Agent:
+      - http.rb/3.0.0
   response:
     status:
-      code: 200
-      message: OK
+      code: 404
+      message: Not Found
     headers:
       Server:
       - GitHub.com
       Date:
-      - Mon, 12 Mar 2018 22:17:39 GMT
+      - Thu, 22 Mar 2018 22:14:10 GMT
       Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '280'
+      - text/html; charset=utf-8
       Connection:
       - close
       Status:
-      - 200 OK
-      X-Ratelimit-Limit:
-      - '5000'
-      X-Ratelimit-Remaining:
-      - '4999'
-      X-Ratelimit-Reset:
-      - '1520896659'
-      Cache-Control:
-      - no-cache
-      X-Oauth-Scopes:
-      - public_repo
-      X-Accepted-Oauth-Scopes:
-      - repo
-      X-Github-Media-Type:
-      - github.v4; format=json
-      Access-Control-Expose-Headers:
-      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
-        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
-      Access-Control-Allow-Origin:
-      - "*"
-      Content-Security-Policy:
-      - default-src 'none'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubdomains; preload
-      X-Content-Type-Options:
-      - nosniff
+      - 404 Not Found
       X-Frame-Options:
       - deny
       X-Xss-Protection:
       - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Cache-Control:
+      - no-cache
+      Vary:
+      - X-PJAX
+      Set-Cookie:
+      - _gh_sess=ZCtRM2s1RG94RVhlZjQySS9qMFFVTHBMcHRSeStQclZDZmVmekp0d0VyVnRaTkxBbS9KUFVyM0gvdjZJQVMwVmNkWjY2c2YyWXdLNVpDTm1TdGNKeDRlS1d4TnlQTGdXbldGMjV1Q1I3Z1U9LS1TeHFyL3pMY2NQN1o1V0ovSEhJQ3JnPT0%3D--433bb5d86b4768a7daa4c4ec75f37eb71ac3a48f;
+        path=/; secure; HttpOnly
+      X-Request-Id:
+      - dbbba5f1-3dd6-4e12-a54d-dea30af30c5e
+      X-Runtime:
+      - '0.012018'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Expect-Ct:
+      - max-age=2592000, report-uri="https://api.github.com/_private/browser/errors"
+      Content-Security-Policy:
+      - default-src 'none'; base-uri 'self'; connect-src 'self'; form-action 'self';
+        img-src data:; script-src 'self'; style-src 'unsafe-inline'
       X-Runtime-Rack:
-      - '0.051332'
+      - '0.017010'
       X-Github-Request-Id:
-      - 412E:7473:375968F:6D30E15:5AA6FC82
+      - EDF7:351E:137AB5F:24562F0:5AB42AB2
     body:
       encoding: UTF-8
-      string: '{"data":{"repository":null,"rateLimit":{"limit":5000,"cost":1,"remaining":4999,"resetAt":"2018-03-12T23:17:39Z"}},"errors":[{"message":"Could
-        not resolve to a User with the username ''thisverylikely''.","type":"NOT_FOUND","path":["repository"],"locations":[{"line":2,"column":3}]}]}'
+      string: ''
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 22:17:39 GMT
+  recorded_at: Thu, 22 Mar 2018 22:14:10 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/graphql/rails.yml
+++ b/spec/cassettes/graphql/rails.yml
@@ -21,7 +21,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Thu, 22 Mar 2018 22:14:08 GMT
+      - Thu, 22 Mar 2018 23:15:15 GMT
       Content-Type:
       - text/html; charset=utf-8
       Connection:
@@ -39,14 +39,14 @@ http_interactions:
       Vary:
       - X-PJAX
       Set-Cookie:
-      - _gh_sess=Z1prcnpISmtaa0M4dlNhRDdCVWhrendPdUlaa0w2TVdBZzN1ZW93Z3ZEcFZhZ0wxWlQ0R24vTFZEVGVCTWJMTDk1YkRBSG9rUmdyaTFmV2ltRjlZMmxHTGdDdlFDMkdzUmM2ajJmY1E4c251YVVSQ0NGWEFUWmxtc1pzOFZRaVdmNFJSbnoxeXBpR2dUQWxDYlV1Z3RBUGlaTHQ5YksrQmNOZUpGMTg4QjZEaEV0U2VtUXI4QkNrcWxHSmdWZE9RRHZiTm1rVWdHNmlyRGNUMHVmalBOUnlaaGhyMGlBTlZUVEdwRUJUTTM5cmpjNDh1RHhGVkNQVVFxQ0FlUmZWbDhSR2EyQkxDYzRpSUhwUW1uWnBBSlMxdFpDZWxteXFSZUJxcElRNXBNdCs2WHFsWWlwcmJqTTJEc085MDlaaitUSS84QXpRemFTU0pvTmJpWVNRNlpZVmF2R0N3MCtvOEI3MVcydnJYSDlPc1FsRnpyanJJRHV3NHpZLzBuV2FDQzdUVk9nTjIyUmJoZzBzdlIxV0pUZz09LS1FQmFzK082aDFxNExEdDNGRW1uUTJRPT0%3D--4dac50735fbacf072c36e38b828582e10da04d9c;
+      - _gh_sess=RnpyRVdNVGQvZGJTejVQamFRNjI0ZWo4VUpHVERieHFoSEE1Zmxyd21GelFNQlhZblN5cUp5RHlmKytqbldaQ3BYZnhaWVk1cHRyQzZSUzlDbnJpRUF0UHJzL2phWlRNVFhKcTFvQUtZczgwUE9PMWxuellVRW5Ua0RVQ1FIQVB5bnFBaFFPZmtjeWRYcVdtRXJiT253cGs4SzB6U1dnL25rNldiWENjWmgzUWcveHRwZHJVWmFCdHMzNTVVR1hpOWVFREFnRkxsdDdHS2xLMjdZTW05WXJ4OWhHNGJLK2NtcHNDVU96aXFkVzkxckJCdDJRUWhCamtHSnlqa09tVnZ6ZmdMYkVNSzcrN2lncFFaMkxGRmdsZnJZRVp4VWxoemhoMVFkdU1ETkNGWWRkSFQwMTRDcHNRa0VhSlpZK2RZOCtOaWhIWGdDQnpmMlFNeDFIOTMzSWZRVGJITjlKWDZOSFhKOE5ZblcveUFzVFBQODlVWE00U1V5ZWtNYTZwaVVEZ1Vxdk15eEpaN01NUGJaaGNSUT09LS1FcDczVWNHM05jR1lGVExKZHhUeVR3PT0%3D--694ef93263b3dd9decb1b9f235086a5c9b3ca4b3;
         path=/; secure; HttpOnly
-      - logged_in=no; domain=.github.com; path=/; expires=Mon, 22 Mar 2038 22:14:08
+      - logged_in=no; domain=.github.com; path=/; expires=Mon, 22 Mar 2038 23:15:15
         -0000; secure; HttpOnly
       X-Request-Id:
-      - 2b0b032b-a3ce-4edc-a7a1-3d14adce4270
+      - a929fdf0-87be-468f-a384-f092a7ee21b5
       X-Runtime:
-      - '0.275794'
+      - '0.319381'
       Strict-Transport-Security:
       - max-age=31536000; includeSubdomains; preload
       Expect-Ct:
@@ -63,14 +63,14 @@ http_interactions:
         manifest-src ''self''; media-src ''none''; script-src assets-cdn.github.com;
         style-src ''unsafe-inline'' assets-cdn.github.com; worker-src ''self'''
       X-Runtime-Rack:
-      - '0.281688'
+      - '0.325791'
       X-Github-Request-Id:
-      - EDCC:351F:19CECBB:2DAB30F:5AB42AB0
+      - EDEE:351E:13C01C4:24D243D:5AB43902
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 22 Mar 2018 22:14:08 GMT
+  recorded_at: Thu, 22 Mar 2018 23:15:15 GMT
 - request:
     method: post
     uri: https://api.github.com/graphql
@@ -104,7 +104,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Thu, 22 Mar 2018 22:14:10 GMT
+      - Thu, 22 Mar 2018 23:15:16 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
@@ -118,7 +118,7 @@ http_interactions:
       X-Ratelimit-Remaining:
       - '4995'
       X-Ratelimit-Reset:
-      - '1521759633'
+      - '1521763907'
       Cache-Control:
       - no-cache
       X-Oauth-Scopes:
@@ -145,13 +145,13 @@ http_interactions:
       Content-Security-Policy:
       - default-src 'none'
       X-Runtime-Rack:
-      - '1.267134'
+      - '0.673721'
       X-Github-Request-Id:
-      - ED77:4B8D:F0B8AD:221B690:5AB42AB0
+      - EDE3:4B95:1652C3D:301244B:5AB43903
     body:
       encoding: UTF-8
-      string: '{"data":{"repository":{"nameWithOwner":"rails/rails","forks":{"totalCount":15303},"stargazers":{"totalCount":39070},"watchers":{"totalCount":2623},"createdAt":"2008-04-11T02:19:47Z","defaultBranchRef":{"name":"master","target":{"history":{"edges":[{"node":{"authoredDate":"2018-03-22T21:44:38Z"}},{"node":{"authoredDate":"2018-03-22T21:43:48Z"}},{"node":{"authoredDate":"2018-03-22T21:39:35Z"}},{"node":{"authoredDate":"2018-03-22T11:46:20Z"}},{"node":{"authoredDate":"2018-03-21T16:33:36Z"}},{"node":{"authoredDate":"2018-03-21T21:52:33Z"}},{"node":{"authoredDate":"2018-03-21T20:02:36Z"}},{"node":{"authoredDate":"2018-03-21T18:20:04Z"}},{"node":{"authoredDate":"2018-03-12T18:43:41Z"}},{"node":{"authoredDate":"2018-03-21T18:09:46Z"}},{"node":{"authoredDate":"2018-03-21T18:03:23Z"}},{"node":{"authoredDate":"2018-03-21T17:58:57Z"}},{"node":{"authoredDate":"2018-03-21T16:48:47Z"}},{"node":{"authoredDate":"2018-03-21T13:38:52Z"}},{"node":{"authoredDate":"2018-03-21T10:19:10Z"}},{"node":{"authoredDate":"2018-03-21T00:59:43Z"}},{"node":{"authoredDate":"2018-03-20T15:58:14Z"}},{"node":{"authoredDate":"2018-03-20T15:42:31Z"}},{"node":{"authoredDate":"2018-03-20T04:15:16Z"}},{"node":{"authoredDate":"2018-03-20T14:17:35Z"}},{"node":{"authoredDate":"2018-03-20T01:36:03Z"}},{"node":{"authoredDate":"2018-03-20T11:36:26Z"}},{"node":{"authoredDate":"2018-03-18T13:59:47Z"}},{"node":{"authoredDate":"2018-03-19T21:47:23Z"}},{"node":{"authoredDate":"2018-03-19T20:25:39Z"}},{"node":{"authoredDate":"2018-03-19T18:46:07Z"}},{"node":{"authoredDate":"2018-03-19T15:30:23Z"}},{"node":{"authoredDate":"2018-03-19T15:25:40Z"}},{"node":{"authoredDate":"2018-03-19T13:29:30Z"}},{"node":{"authoredDate":"2018-03-19T12:07:23Z"}},{"node":{"authoredDate":"2018-03-19T12:06:42Z"}},{"node":{"authoredDate":"2018-03-19T10:16:31Z"}},{"node":{"authoredDate":"2018-03-18T23:03:39Z"}},{"node":{"authoredDate":"2018-03-18T23:43:01Z"}},{"node":{"authoredDate":"2018-03-18T21:07:12Z"}},{"node":{"authoredDate":"2018-03-18T16:48:46Z"}},{"node":{"authoredDate":"2018-03-14T14:33:33Z"}},{"node":{"authoredDate":"2018-03-17T20:26:03Z"}},{"node":{"authoredDate":"2018-03-17T17:45:30Z"}},{"node":{"authoredDate":"2018-03-16T23:41:34Z"}},{"node":{"authoredDate":"2018-03-16T22:02:48Z"}},{"node":{"authoredDate":"2018-03-16T19:18:26Z"}},{"node":{"authoredDate":"2018-03-16T16:40:34Z"}},{"node":{"authoredDate":"2018-03-09T22:14:39Z"}},{"node":{"authoredDate":"2018-03-16T05:22:49Z"}},{"node":{"authoredDate":"2018-03-16T05:19:40Z"}},{"node":{"authoredDate":"2018-03-15T21:32:20Z"}},{"node":{"authoredDate":"2018-03-15T21:29:21Z"}},{"node":{"authoredDate":"2018-03-15T19:49:21Z"}},{"node":{"authoredDate":"2018-03-15T19:36:51Z"}}]}}},"description":"Ruby
-        on Rails","hasIssuesEnabled":true,"hasWikiEnabled":false,"homepageUrl":"http://rubyonrails.org","isArchived":false,"isFork":false,"isMirror":false,"licenseInfo":{"key":"mit"},"primaryLanguage":{"name":"Ruby"},"pushedAt":"2018-03-22T21:45:47Z","closedIssues":{"totalCount":10866},"openIssues":{"totalCount":350},"closedPullRequests":{"totalCount":6623},"openPullRequests":{"totalCount":715},"mergedPullRequests":{"totalCount":13728}},"rateLimit":{"limit":5000,"cost":1,"remaining":4995,"resetAt":"2018-03-22T23:00:33Z"}}}'
+      string: '{"data":{"repository":{"nameWithOwner":"rails/rails","forks":{"totalCount":15303},"stargazers":{"totalCount":39072},"watchers":{"totalCount":2624},"createdAt":"2008-04-11T02:19:47Z","defaultBranchRef":{"name":"master","target":{"history":{"edges":[{"node":{"authoredDate":"2018-03-22T23:09:21Z"}},{"node":{"authoredDate":"2018-03-22T21:44:38Z"}},{"node":{"authoredDate":"2018-03-22T21:43:48Z"}},{"node":{"authoredDate":"2018-03-22T21:39:35Z"}},{"node":{"authoredDate":"2018-03-22T11:46:20Z"}},{"node":{"authoredDate":"2018-03-21T16:33:36Z"}},{"node":{"authoredDate":"2018-03-21T21:52:33Z"}},{"node":{"authoredDate":"2018-03-21T20:02:36Z"}},{"node":{"authoredDate":"2018-03-21T18:20:04Z"}},{"node":{"authoredDate":"2018-03-12T18:43:41Z"}},{"node":{"authoredDate":"2018-03-21T18:09:46Z"}},{"node":{"authoredDate":"2018-03-21T18:03:23Z"}},{"node":{"authoredDate":"2018-03-21T17:58:57Z"}},{"node":{"authoredDate":"2018-03-21T16:48:47Z"}},{"node":{"authoredDate":"2018-03-21T13:38:52Z"}},{"node":{"authoredDate":"2018-03-21T10:19:10Z"}},{"node":{"authoredDate":"2018-03-21T00:59:43Z"}},{"node":{"authoredDate":"2018-03-21T06:16:00Z"}},{"node":{"authoredDate":"2018-03-20T15:58:14Z"}},{"node":{"authoredDate":"2018-03-20T15:42:31Z"}},{"node":{"authoredDate":"2018-03-20T04:15:16Z"}},{"node":{"authoredDate":"2018-03-20T14:17:35Z"}},{"node":{"authoredDate":"2018-03-20T01:36:03Z"}},{"node":{"authoredDate":"2018-03-20T11:36:26Z"}},{"node":{"authoredDate":"2018-03-18T13:59:47Z"}},{"node":{"authoredDate":"2018-03-19T21:47:23Z"}},{"node":{"authoredDate":"2018-03-19T20:25:39Z"}},{"node":{"authoredDate":"2018-03-19T18:46:07Z"}},{"node":{"authoredDate":"2018-03-19T15:30:23Z"}},{"node":{"authoredDate":"2018-03-19T15:25:40Z"}},{"node":{"authoredDate":"2018-03-19T13:29:30Z"}},{"node":{"authoredDate":"2018-03-19T12:07:23Z"}},{"node":{"authoredDate":"2018-03-19T12:06:42Z"}},{"node":{"authoredDate":"2018-03-19T10:16:31Z"}},{"node":{"authoredDate":"2018-03-18T23:03:39Z"}},{"node":{"authoredDate":"2018-03-18T23:43:01Z"}},{"node":{"authoredDate":"2018-03-18T21:07:12Z"}},{"node":{"authoredDate":"2018-03-18T16:48:46Z"}},{"node":{"authoredDate":"2018-03-14T14:33:33Z"}},{"node":{"authoredDate":"2018-03-17T20:26:03Z"}},{"node":{"authoredDate":"2018-03-17T17:45:30Z"}},{"node":{"authoredDate":"2018-03-16T23:41:34Z"}},{"node":{"authoredDate":"2018-03-16T22:02:48Z"}},{"node":{"authoredDate":"2018-03-16T19:18:26Z"}},{"node":{"authoredDate":"2018-03-16T16:40:34Z"}},{"node":{"authoredDate":"2018-03-09T22:14:39Z"}},{"node":{"authoredDate":"2018-03-16T05:22:49Z"}},{"node":{"authoredDate":"2018-03-16T05:19:40Z"}},{"node":{"authoredDate":"2018-03-15T21:32:20Z"}},{"node":{"authoredDate":"2018-03-15T21:29:21Z"}}]}}},"description":"Ruby
+        on Rails","hasIssuesEnabled":true,"hasWikiEnabled":false,"homepageUrl":"http://rubyonrails.org","isArchived":false,"isFork":false,"isMirror":false,"licenseInfo":{"key":"mit"},"primaryLanguage":{"name":"Ruby"},"pushedAt":"2018-03-22T23:11:08Z","closedIssues":{"totalCount":10866},"openIssues":{"totalCount":350},"closedPullRequests":{"totalCount":6623},"openPullRequests":{"totalCount":714},"mergedPullRequests":{"totalCount":13729}},"rateLimit":{"limit":5000,"cost":1,"remaining":4995,"resetAt":"2018-03-23T00:11:47Z"}}}'
     http_version: 
-  recorded_at: Thu, 22 Mar 2018 22:14:10 GMT
+  recorded_at: Thu, 22 Mar 2018 23:15:16 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/graphql/rails.yml
+++ b/spec/cassettes/graphql/rails.yml
@@ -1,0 +1,84 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.github.com/graphql
+    body:
+      encoding: UTF-8
+      string: '{"query":"{\n  repository(owner: \"rails\", name: \"rails\") {\n    nameWithOwner\n    forks
+        {\n      totalCount\n    }\n    stargazers {\n      totalCount\n    }\n    watchers
+        {\n      totalCount\n    }\n    createdAt\n    defaultBranchRef {\n      name\n      target
+        {\n        ... on Commit {\n          history(first: 50) {\n            edges
+        {\n              node {\n                authoredDate\n              }\n            }\n          }\n        }\n      }\n    }\n    description\n    hasIssuesEnabled\n    hasWikiEnabled\n    homepageUrl\n    isArchived\n    isFork\n    isMirror\n    licenseInfo
+        {\n      key\n    }\n    primaryLanguage {\n      name\n    }\n    pushedAt\n    closedIssues:
+        issues(states: CLOSED) {\n      totalCount\n    }\n    openIssues: issues(states:
+        OPEN) {\n      totalCount\n    }\n    closedPullRequests: pullRequests(states:
+        CLOSED) {\n      totalCount\n    }\n    openPullRequests: pullRequests(states:
+        OPEN) {\n      totalCount\n    }\n    mergedPullRequests: pullRequests(states:
+        MERGED) {\n      totalCount\n    }\n  }\n\n  rateLimit {\n    limit\n    cost\n    remaining\n    resetAt\n  }\n}\n"}'
+    headers:
+      Authorization:
+      - bearer <GITHUB_TOKEN>
+      User-Agent:
+      - ruby-toolbox.com API client
+      Connection:
+      - close
+      Host:
+      - api.github.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Mon, 12 Mar 2018 21:26:08 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '3242'
+      Connection:
+      - close
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4994'
+      X-Ratelimit-Reset:
+      - '1520891517'
+      Cache-Control:
+      - no-cache
+      X-Oauth-Scopes:
+      - public_repo
+      X-Accepted-Oauth-Scopes:
+      - repo
+      X-Github-Media-Type:
+      - github.v4; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Runtime-Rack:
+      - '0.657690'
+      X-Github-Request-Id:
+      - 4122:7473:36EDCF2:6C5706F:5AA6F06F
+    body:
+      encoding: UTF-8
+      string: '{"data":{"repository":{"nameWithOwner":"rails/rails","forks":{"totalCount":15265},"stargazers":{"totalCount":38930},"watchers":{"totalCount":2613},"createdAt":"2008-04-11T02:19:47Z","defaultBranchRef":{"name":"master","target":{"history":{"edges":[{"node":{"authoredDate":"2018-03-12T17:34:42Z"}},{"node":{"authoredDate":"2018-03-12T13:55:58Z"}},{"node":{"authoredDate":"2018-03-12T13:41:12Z"}},{"node":{"authoredDate":"2018-03-12T13:02:27Z"}},{"node":{"authoredDate":"2018-03-12T11:39:24Z"}},{"node":{"authoredDate":"2018-03-12T10:43:22Z"}},{"node":{"authoredDate":"2018-03-11T20:22:20Z"}},{"node":{"authoredDate":"2018-03-11T19:48:50Z"}},{"node":{"authoredDate":"2018-03-11T01:00:26Z"}},{"node":{"authoredDate":"2018-03-10T10:43:31Z"}},{"node":{"authoredDate":"2018-03-09T21:13:11Z"}},{"node":{"authoredDate":"2018-03-09T20:14:36Z"}},{"node":{"authoredDate":"2018-03-09T16:55:46Z"}},{"node":{"authoredDate":"2018-03-09T10:51:30Z"}},{"node":{"authoredDate":"2018-03-09T08:41:43Z"}},{"node":{"authoredDate":"2018-03-09T08:28:38Z"}},{"node":{"authoredDate":"2018-03-09T07:33:41Z"}},{"node":{"authoredDate":"2018-03-09T07:04:56Z"}},{"node":{"authoredDate":"2018-03-09T02:31:48Z"}},{"node":{"authoredDate":"2018-03-09T01:23:47Z"}},{"node":{"authoredDate":"2018-03-09T00:27:15Z"}},{"node":{"authoredDate":"2018-03-08T14:14:09Z"}},{"node":{"authoredDate":"2018-03-08T14:01:15Z"}},{"node":{"authoredDate":"2018-03-05T12:42:49Z"}},{"node":{"authoredDate":"2018-03-08T11:55:01Z"}},{"node":{"authoredDate":"2018-03-08T09:59:52Z"}},{"node":{"authoredDate":"2018-03-08T09:49:36Z"}},{"node":{"authoredDate":"2018-03-07T16:18:54Z"}},{"node":{"authoredDate":"2018-03-07T03:06:03Z"}},{"node":{"authoredDate":"2018-03-07T00:41:46Z"}},{"node":{"authoredDate":"2018-03-05T19:24:11Z"}},{"node":{"authoredDate":"2018-03-06T22:09:34Z"}},{"node":{"authoredDate":"2018-03-06T22:07:24Z"}},{"node":{"authoredDate":"2018-02-06T01:33:35Z"}},{"node":{"authoredDate":"2018-03-06T18:09:22Z"}},{"node":{"authoredDate":"2018-02-12T11:29:18Z"}},{"node":{"authoredDate":"2018-03-06T14:17:59Z"}},{"node":{"authoredDate":"2018-03-06T12:41:49Z"}},{"node":{"authoredDate":"2018-02-26T19:20:43Z"}},{"node":{"authoredDate":"2018-03-06T02:57:49Z"}},{"node":{"authoredDate":"2018-03-06T01:53:28Z"}},{"node":{"authoredDate":"2018-03-06T01:44:39Z"}},{"node":{"authoredDate":"2018-03-06T01:27:16Z"}},{"node":{"authoredDate":"2018-03-05T22:01:31Z"}},{"node":{"authoredDate":"2018-03-05T20:57:52Z"}},{"node":{"authoredDate":"2018-03-05T20:12:04Z"}},{"node":{"authoredDate":"2018-03-05T18:27:14Z"}},{"node":{"authoredDate":"2018-03-04T19:14:51Z"}},{"node":{"authoredDate":"2018-03-05T16:53:31Z"}},{"node":{"authoredDate":"2018-03-05T16:23:20Z"}}]}}},"description":"Ruby
+        on Rails","hasIssuesEnabled":true,"hasWikiEnabled":false,"homepageUrl":"http://rubyonrails.org","isArchived":false,"isFork":false,"isMirror":false,"licenseInfo":{"key":"mit"},"primaryLanguage":{"name":"Ruby"},"pushedAt":"2018-03-12T19:56:09Z","closedIssues":{"totalCount":10829},"openIssues":{"totalCount":352},"closedPullRequests":{"totalCount":6604},"openPullRequests":{"totalCount":709},"mergedPullRequests":{"totalCount":13695}},"rateLimit":{"limit":5000,"cost":1,"remaining":4994,"resetAt":"2018-03-12T21:51:57Z"}}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 21:26:08 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/graphql/rails.yml
+++ b/spec/cassettes/graphql/rails.yml
@@ -1,6 +1,77 @@
 ---
 http_interactions:
 - request:
+    method: head
+    uri: https://github.com/rails/rails
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - github.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Thu, 22 Mar 2018 22:14:08 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Connection:
+      - close
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Cache-Control:
+      - no-cache
+      Vary:
+      - X-PJAX
+      Set-Cookie:
+      - _gh_sess=Z1prcnpISmtaa0M4dlNhRDdCVWhrendPdUlaa0w2TVdBZzN1ZW93Z3ZEcFZhZ0wxWlQ0R24vTFZEVGVCTWJMTDk1YkRBSG9rUmdyaTFmV2ltRjlZMmxHTGdDdlFDMkdzUmM2ajJmY1E4c251YVVSQ0NGWEFUWmxtc1pzOFZRaVdmNFJSbnoxeXBpR2dUQWxDYlV1Z3RBUGlaTHQ5YksrQmNOZUpGMTg4QjZEaEV0U2VtUXI4QkNrcWxHSmdWZE9RRHZiTm1rVWdHNmlyRGNUMHVmalBOUnlaaGhyMGlBTlZUVEdwRUJUTTM5cmpjNDh1RHhGVkNQVVFxQ0FlUmZWbDhSR2EyQkxDYzRpSUhwUW1uWnBBSlMxdFpDZWxteXFSZUJxcElRNXBNdCs2WHFsWWlwcmJqTTJEc085MDlaaitUSS84QXpRemFTU0pvTmJpWVNRNlpZVmF2R0N3MCtvOEI3MVcydnJYSDlPc1FsRnpyanJJRHV3NHpZLzBuV2FDQzdUVk9nTjIyUmJoZzBzdlIxV0pUZz09LS1FQmFzK082aDFxNExEdDNGRW1uUTJRPT0%3D--4dac50735fbacf072c36e38b828582e10da04d9c;
+        path=/; secure; HttpOnly
+      - logged_in=no; domain=.github.com; path=/; expires=Mon, 22 Mar 2038 22:14:08
+        -0000; secure; HttpOnly
+      X-Request-Id:
+      - 2b0b032b-a3ce-4edc-a7a1-3d14adce4270
+      X-Runtime:
+      - '0.275794'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Expect-Ct:
+      - max-age=2592000, report-uri="https://api.github.com/_private/browser/errors"
+      Content-Security-Policy:
+      - 'default-src ''none''; base-uri ''self''; block-all-mixed-content; child-src
+        render.githubusercontent.com; connect-src ''self'' uploads.github.com status.github.com
+        collector.githubapp.com api.github.com www.google-analytics.com github-cloud.s3.amazonaws.com
+        github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com
+        github-production-user-asset-6210df.s3.amazonaws.com wss://live.github.com;
+        font-src assets-cdn.github.com; form-action ''self'' github.com gist.github.com;
+        frame-ancestors ''none''; img-src ''self'' data: assets-cdn.github.com identicons.github.com
+        collector.githubapp.com github-cloud.s3.amazonaws.com *.githubusercontent.com;
+        manifest-src ''self''; media-src ''none''; script-src assets-cdn.github.com;
+        style-src ''unsafe-inline'' assets-cdn.github.com; worker-src ''self'''
+      X-Runtime-Rack:
+      - '0.281688'
+      X-Github-Request-Id:
+      - EDCC:351F:19CECBB:2DAB30F:5AB42AB0
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 22 Mar 2018 22:14:08 GMT
+- request:
     method: post
     uri: https://api.github.com/graphql
     body:
@@ -33,7 +104,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Mon, 12 Mar 2018 21:26:08 GMT
+      - Thu, 22 Mar 2018 22:14:10 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
@@ -45,9 +116,9 @@ http_interactions:
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4994'
+      - '4995'
       X-Ratelimit-Reset:
-      - '1520891517'
+      - '1521759633'
       Cache-Control:
       - no-cache
       X-Oauth-Scopes:
@@ -61,24 +132,26 @@ http_interactions:
         X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
       Access-Control-Allow-Origin:
       - "*"
-      Content-Security-Policy:
-      - default-src 'none'
       Strict-Transport-Security:
       - max-age=31536000; includeSubdomains; preload
-      X-Content-Type-Options:
-      - nosniff
       X-Frame-Options:
       - deny
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
       X-Runtime-Rack:
-      - '0.657690'
+      - '1.267134'
       X-Github-Request-Id:
-      - 4122:7473:36EDCF2:6C5706F:5AA6F06F
+      - ED77:4B8D:F0B8AD:221B690:5AB42AB0
     body:
       encoding: UTF-8
-      string: '{"data":{"repository":{"nameWithOwner":"rails/rails","forks":{"totalCount":15265},"stargazers":{"totalCount":38930},"watchers":{"totalCount":2613},"createdAt":"2008-04-11T02:19:47Z","defaultBranchRef":{"name":"master","target":{"history":{"edges":[{"node":{"authoredDate":"2018-03-12T17:34:42Z"}},{"node":{"authoredDate":"2018-03-12T13:55:58Z"}},{"node":{"authoredDate":"2018-03-12T13:41:12Z"}},{"node":{"authoredDate":"2018-03-12T13:02:27Z"}},{"node":{"authoredDate":"2018-03-12T11:39:24Z"}},{"node":{"authoredDate":"2018-03-12T10:43:22Z"}},{"node":{"authoredDate":"2018-03-11T20:22:20Z"}},{"node":{"authoredDate":"2018-03-11T19:48:50Z"}},{"node":{"authoredDate":"2018-03-11T01:00:26Z"}},{"node":{"authoredDate":"2018-03-10T10:43:31Z"}},{"node":{"authoredDate":"2018-03-09T21:13:11Z"}},{"node":{"authoredDate":"2018-03-09T20:14:36Z"}},{"node":{"authoredDate":"2018-03-09T16:55:46Z"}},{"node":{"authoredDate":"2018-03-09T10:51:30Z"}},{"node":{"authoredDate":"2018-03-09T08:41:43Z"}},{"node":{"authoredDate":"2018-03-09T08:28:38Z"}},{"node":{"authoredDate":"2018-03-09T07:33:41Z"}},{"node":{"authoredDate":"2018-03-09T07:04:56Z"}},{"node":{"authoredDate":"2018-03-09T02:31:48Z"}},{"node":{"authoredDate":"2018-03-09T01:23:47Z"}},{"node":{"authoredDate":"2018-03-09T00:27:15Z"}},{"node":{"authoredDate":"2018-03-08T14:14:09Z"}},{"node":{"authoredDate":"2018-03-08T14:01:15Z"}},{"node":{"authoredDate":"2018-03-05T12:42:49Z"}},{"node":{"authoredDate":"2018-03-08T11:55:01Z"}},{"node":{"authoredDate":"2018-03-08T09:59:52Z"}},{"node":{"authoredDate":"2018-03-08T09:49:36Z"}},{"node":{"authoredDate":"2018-03-07T16:18:54Z"}},{"node":{"authoredDate":"2018-03-07T03:06:03Z"}},{"node":{"authoredDate":"2018-03-07T00:41:46Z"}},{"node":{"authoredDate":"2018-03-05T19:24:11Z"}},{"node":{"authoredDate":"2018-03-06T22:09:34Z"}},{"node":{"authoredDate":"2018-03-06T22:07:24Z"}},{"node":{"authoredDate":"2018-02-06T01:33:35Z"}},{"node":{"authoredDate":"2018-03-06T18:09:22Z"}},{"node":{"authoredDate":"2018-02-12T11:29:18Z"}},{"node":{"authoredDate":"2018-03-06T14:17:59Z"}},{"node":{"authoredDate":"2018-03-06T12:41:49Z"}},{"node":{"authoredDate":"2018-02-26T19:20:43Z"}},{"node":{"authoredDate":"2018-03-06T02:57:49Z"}},{"node":{"authoredDate":"2018-03-06T01:53:28Z"}},{"node":{"authoredDate":"2018-03-06T01:44:39Z"}},{"node":{"authoredDate":"2018-03-06T01:27:16Z"}},{"node":{"authoredDate":"2018-03-05T22:01:31Z"}},{"node":{"authoredDate":"2018-03-05T20:57:52Z"}},{"node":{"authoredDate":"2018-03-05T20:12:04Z"}},{"node":{"authoredDate":"2018-03-05T18:27:14Z"}},{"node":{"authoredDate":"2018-03-04T19:14:51Z"}},{"node":{"authoredDate":"2018-03-05T16:53:31Z"}},{"node":{"authoredDate":"2018-03-05T16:23:20Z"}}]}}},"description":"Ruby
-        on Rails","hasIssuesEnabled":true,"hasWikiEnabled":false,"homepageUrl":"http://rubyonrails.org","isArchived":false,"isFork":false,"isMirror":false,"licenseInfo":{"key":"mit"},"primaryLanguage":{"name":"Ruby"},"pushedAt":"2018-03-12T19:56:09Z","closedIssues":{"totalCount":10829},"openIssues":{"totalCount":352},"closedPullRequests":{"totalCount":6604},"openPullRequests":{"totalCount":709},"mergedPullRequests":{"totalCount":13695}},"rateLimit":{"limit":5000,"cost":1,"remaining":4994,"resetAt":"2018-03-12T21:51:57Z"}}}'
+      string: '{"data":{"repository":{"nameWithOwner":"rails/rails","forks":{"totalCount":15303},"stargazers":{"totalCount":39070},"watchers":{"totalCount":2623},"createdAt":"2008-04-11T02:19:47Z","defaultBranchRef":{"name":"master","target":{"history":{"edges":[{"node":{"authoredDate":"2018-03-22T21:44:38Z"}},{"node":{"authoredDate":"2018-03-22T21:43:48Z"}},{"node":{"authoredDate":"2018-03-22T21:39:35Z"}},{"node":{"authoredDate":"2018-03-22T11:46:20Z"}},{"node":{"authoredDate":"2018-03-21T16:33:36Z"}},{"node":{"authoredDate":"2018-03-21T21:52:33Z"}},{"node":{"authoredDate":"2018-03-21T20:02:36Z"}},{"node":{"authoredDate":"2018-03-21T18:20:04Z"}},{"node":{"authoredDate":"2018-03-12T18:43:41Z"}},{"node":{"authoredDate":"2018-03-21T18:09:46Z"}},{"node":{"authoredDate":"2018-03-21T18:03:23Z"}},{"node":{"authoredDate":"2018-03-21T17:58:57Z"}},{"node":{"authoredDate":"2018-03-21T16:48:47Z"}},{"node":{"authoredDate":"2018-03-21T13:38:52Z"}},{"node":{"authoredDate":"2018-03-21T10:19:10Z"}},{"node":{"authoredDate":"2018-03-21T00:59:43Z"}},{"node":{"authoredDate":"2018-03-20T15:58:14Z"}},{"node":{"authoredDate":"2018-03-20T15:42:31Z"}},{"node":{"authoredDate":"2018-03-20T04:15:16Z"}},{"node":{"authoredDate":"2018-03-20T14:17:35Z"}},{"node":{"authoredDate":"2018-03-20T01:36:03Z"}},{"node":{"authoredDate":"2018-03-20T11:36:26Z"}},{"node":{"authoredDate":"2018-03-18T13:59:47Z"}},{"node":{"authoredDate":"2018-03-19T21:47:23Z"}},{"node":{"authoredDate":"2018-03-19T20:25:39Z"}},{"node":{"authoredDate":"2018-03-19T18:46:07Z"}},{"node":{"authoredDate":"2018-03-19T15:30:23Z"}},{"node":{"authoredDate":"2018-03-19T15:25:40Z"}},{"node":{"authoredDate":"2018-03-19T13:29:30Z"}},{"node":{"authoredDate":"2018-03-19T12:07:23Z"}},{"node":{"authoredDate":"2018-03-19T12:06:42Z"}},{"node":{"authoredDate":"2018-03-19T10:16:31Z"}},{"node":{"authoredDate":"2018-03-18T23:03:39Z"}},{"node":{"authoredDate":"2018-03-18T23:43:01Z"}},{"node":{"authoredDate":"2018-03-18T21:07:12Z"}},{"node":{"authoredDate":"2018-03-18T16:48:46Z"}},{"node":{"authoredDate":"2018-03-14T14:33:33Z"}},{"node":{"authoredDate":"2018-03-17T20:26:03Z"}},{"node":{"authoredDate":"2018-03-17T17:45:30Z"}},{"node":{"authoredDate":"2018-03-16T23:41:34Z"}},{"node":{"authoredDate":"2018-03-16T22:02:48Z"}},{"node":{"authoredDate":"2018-03-16T19:18:26Z"}},{"node":{"authoredDate":"2018-03-16T16:40:34Z"}},{"node":{"authoredDate":"2018-03-09T22:14:39Z"}},{"node":{"authoredDate":"2018-03-16T05:22:49Z"}},{"node":{"authoredDate":"2018-03-16T05:19:40Z"}},{"node":{"authoredDate":"2018-03-15T21:32:20Z"}},{"node":{"authoredDate":"2018-03-15T21:29:21Z"}},{"node":{"authoredDate":"2018-03-15T19:49:21Z"}},{"node":{"authoredDate":"2018-03-15T19:36:51Z"}}]}}},"description":"Ruby
+        on Rails","hasIssuesEnabled":true,"hasWikiEnabled":false,"homepageUrl":"http://rubyonrails.org","isArchived":false,"isFork":false,"isMirror":false,"licenseInfo":{"key":"mit"},"primaryLanguage":{"name":"Ruby"},"pushedAt":"2018-03-22T21:45:47Z","closedIssues":{"totalCount":10866},"openIssues":{"totalCount":350},"closedPullRequests":{"totalCount":6623},"openPullRequests":{"totalCount":715},"mergedPullRequests":{"totalCount":13728}},"rateLimit":{"limit":5000,"cost":1,"remaining":4995,"resetAt":"2018-03-22T23:00:33Z"}}}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 21:26:08 GMT
+  recorded_at: Thu, 22 Mar 2018 22:14:10 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/rails/rails.yml
+++ b/spec/cassettes/rails/rails.yml
@@ -1,18 +1,97 @@
 ---
 http_interactions:
 - request:
-    method: get
-    uri: https://api.github.com/repos/rails/rails?client_id=&client_secret=
+    method: head
+    uri: https://github.com/rails/rails
     body:
       encoding: UTF-8
       string: ''
     headers:
+      Connection:
+      - close
+      Host:
+      - github.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Thu, 22 Mar 2018 23:15:12 GMT
       Content-Type:
-      - application/json
+      - text/html; charset=utf-8
+      Connection:
+      - close
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Cache-Control:
+      - no-cache
+      Vary:
+      - X-PJAX
+      Set-Cookie:
+      - _gh_sess=Q0NZaGd2eWZmUk9wREt0eGVTcTFJNkN3QVNwcDkrYnltRUdNdk1vZ05NTzJUb2FmNzdrMDRoQWpCcGJUNlIzN1hsdDh2aHhpRDlrQjlESnBaRGErcE5HWlBTRlNrVXljcStwb28yYWlHWTRQV0taSXppMG9McVkzUjNHZVM4KzBPOTAzZFhiTmJzSFR6dURGZU1iTXVvNENsVVNlOFZZVGpOMlZTVENmSDhLOVFPUU45OHc0MFJGRGtsQVk1R0MzSC9tSTJLMmNQZ0U0bEFnQi9CNEp0TlV0TXFHYVF5NWVJR3owcWpxVTlKbTdMY2dGUEQzSjJaVFFWZ2RYL3lFMkE3NytzZ2d5N2EyY1ViM2JvVVpoM2NXR2pRT0ZPZ0lOUVk4MitwR2x0STJGS01NSGhSalV5dTZGcFh6aHhCTUtOTkFqeTBPZVFWbzRQU0Uxb09FTEF0aVQrYXBiS1R4eWRmOW5RUGtHWlgwTkcxQkFERWxUdm5HZzJ3elVMaG93czlrc2JjTExzU1U4VzZIMTRIdzhNQT09LS1GRGVwMjRvRWNNM2lFUDBFbkk5NWpBPT0%3D--5f2d245150bc5517f277d27c080a3e9a617e676f;
+        path=/; secure; HttpOnly
+      - logged_in=no; domain=.github.com; path=/; expires=Mon, 22 Mar 2038 23:15:12
+        -0000; secure; HttpOnly
+      X-Request-Id:
+      - 9ad4c066-8e72-4fa6-93c6-538f53a2a110
+      X-Runtime:
+      - '0.311658'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Expect-Ct:
+      - max-age=2592000, report-uri="https://api.github.com/_private/browser/errors"
+      Content-Security-Policy:
+      - 'default-src ''none''; base-uri ''self''; block-all-mixed-content; child-src
+        render.githubusercontent.com; connect-src ''self'' uploads.github.com status.github.com
+        collector.githubapp.com api.github.com www.google-analytics.com github-cloud.s3.amazonaws.com
+        github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com
+        github-production-user-asset-6210df.s3.amazonaws.com wss://live.github.com;
+        font-src assets-cdn.github.com; form-action ''self'' github.com gist.github.com;
+        frame-ancestors ''none''; img-src ''self'' data: assets-cdn.github.com identicons.github.com
+        collector.githubapp.com github-cloud.s3.amazonaws.com *.githubusercontent.com;
+        manifest-src ''self''; media-src ''none''; script-src assets-cdn.github.com;
+        style-src ''unsafe-inline'' assets-cdn.github.com; worker-src ''self'''
+      X-Runtime-Rack:
+      - '0.319961'
+      X-Github-Request-Id:
+      - ED76:351F:1A38A22:2E6239E:5AB43900
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 22 Mar 2018 23:15:12 GMT
+- request:
+    method: post
+    uri: https://api.github.com/graphql
+    body:
+      encoding: UTF-8
+      string: '{"query":"{\n  repository(owner: \"rails\", name: \"rails\") {\n    nameWithOwner\n    forks
+        {\n      totalCount\n    }\n    stargazers {\n      totalCount\n    }\n    watchers
+        {\n      totalCount\n    }\n    createdAt\n    defaultBranchRef {\n      name\n      target
+        {\n        ... on Commit {\n          history(first: 50) {\n            edges
+        {\n              node {\n                authoredDate\n              }\n            }\n          }\n        }\n      }\n    }\n    description\n    hasIssuesEnabled\n    hasWikiEnabled\n    homepageUrl\n    isArchived\n    isFork\n    isMirror\n    licenseInfo
+        {\n      key\n    }\n    primaryLanguage {\n      name\n    }\n    pushedAt\n    closedIssues:
+        issues(states: CLOSED) {\n      totalCount\n    }\n    openIssues: issues(states:
+        OPEN) {\n      totalCount\n    }\n    closedPullRequests: pullRequests(states:
+        CLOSED) {\n      totalCount\n    }\n    openPullRequests: pullRequests(states:
+        OPEN) {\n      totalCount\n    }\n    mergedPullRequests: pullRequests(states:
+        MERGED) {\n      totalCount\n    }\n  }\n\n  rateLimit {\n    limit\n    cost\n    remaining\n    resetAt\n  }\n}\n"}'
+    headers:
+      Authorization:
+      - bearer <GITHUB_TOKEN>
       User-Agent:
       - ruby-toolbox.com API client
-      Accept:
-      - application/vnd.github.v3+json
       Connection:
       - close
       Host:
@@ -25,55 +104,54 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Tue, 16 Jan 2018 20:14:47 GMT
+      - Thu, 22 Mar 2018 23:15:14 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '5360'
+      - '3242'
       Connection:
       - close
       Status:
       - 200 OK
       X-Ratelimit-Limit:
-      - '60'
+      - '5000'
       X-Ratelimit-Remaining:
-      - '48'
+      - '4996'
       X-Ratelimit-Reset:
-      - '1516136899'
+      - '1521763907'
       Cache-Control:
-      - public, max-age=60, s-maxage=60
-      Vary:
-      - Accept
-      Etag:
-      - '"31d73f4c20f6d1ed277a7ab4b2aeef4a"'
-      Last-Modified:
-      - Tue, 16 Jan 2018 18:55:40 GMT
+      - no-cache
+      X-Oauth-Scopes:
+      - public_repo
+      X-Accepted-Oauth-Scopes:
+      - repo
       X-Github-Media-Type:
-      - github.v3; format=json
+      - github.v4; format=json
       Access-Control-Expose-Headers:
       - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
         X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
       Access-Control-Allow-Origin:
       - "*"
-      Content-Security-Policy:
-      - default-src 'none'
       Strict-Transport-Security:
       - max-age=31536000; includeSubdomains; preload
-      X-Content-Type-Options:
-      - nosniff
       X-Frame-Options:
       - deny
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
       X-Runtime-Rack:
-      - '0.047507'
+      - '0.868770'
       X-Github-Request-Id:
-      - 6A2B:1B93:8A1F6:1311F1:5A5E5D36
+      - ED32:4B95:1652AFB:3012203:5AB43900
     body:
       encoding: UTF-8
-      string: '{"id":8514,"name":"rails","full_name":"rails/rails","owner":{"login":"rails","id":4223,"avatar_url":"https://avatars1.githubusercontent.com/u/4223?v=4","gravatar_id":"","url":"https://api.github.com/users/rails","html_url":"https://github.com/rails","followers_url":"https://api.github.com/users/rails/followers","following_url":"https://api.github.com/users/rails/following{/other_user}","gists_url":"https://api.github.com/users/rails/gists{/gist_id}","starred_url":"https://api.github.com/users/rails/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/rails/subscriptions","organizations_url":"https://api.github.com/users/rails/orgs","repos_url":"https://api.github.com/users/rails/repos","events_url":"https://api.github.com/users/rails/events{/privacy}","received_events_url":"https://api.github.com/users/rails/received_events","type":"Organization","site_admin":false},"private":false,"html_url":"https://github.com/rails/rails","description":"Ruby
-        on Rails","fork":false,"url":"https://api.github.com/repos/rails/rails","forks_url":"https://api.github.com/repos/rails/rails/forks","keys_url":"https://api.github.com/repos/rails/rails/keys{/key_id}","collaborators_url":"https://api.github.com/repos/rails/rails/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/rails/rails/teams","hooks_url":"https://api.github.com/repos/rails/rails/hooks","issue_events_url":"https://api.github.com/repos/rails/rails/issues/events{/number}","events_url":"https://api.github.com/repos/rails/rails/events","assignees_url":"https://api.github.com/repos/rails/rails/assignees{/user}","branches_url":"https://api.github.com/repos/rails/rails/branches{/branch}","tags_url":"https://api.github.com/repos/rails/rails/tags","blobs_url":"https://api.github.com/repos/rails/rails/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/rails/rails/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/rails/rails/git/refs{/sha}","trees_url":"https://api.github.com/repos/rails/rails/git/trees{/sha}","statuses_url":"https://api.github.com/repos/rails/rails/statuses/{sha}","languages_url":"https://api.github.com/repos/rails/rails/languages","stargazers_url":"https://api.github.com/repos/rails/rails/stargazers","contributors_url":"https://api.github.com/repos/rails/rails/contributors","subscribers_url":"https://api.github.com/repos/rails/rails/subscribers","subscription_url":"https://api.github.com/repos/rails/rails/subscription","commits_url":"https://api.github.com/repos/rails/rails/commits{/sha}","git_commits_url":"https://api.github.com/repos/rails/rails/git/commits{/sha}","comments_url":"https://api.github.com/repos/rails/rails/comments{/number}","issue_comment_url":"https://api.github.com/repos/rails/rails/issues/comments{/number}","contents_url":"https://api.github.com/repos/rails/rails/contents/{+path}","compare_url":"https://api.github.com/repos/rails/rails/compare/{base}...{head}","merges_url":"https://api.github.com/repos/rails/rails/merges","archive_url":"https://api.github.com/repos/rails/rails/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/rails/rails/downloads","issues_url":"https://api.github.com/repos/rails/rails/issues{/number}","pulls_url":"https://api.github.com/repos/rails/rails/pulls{/number}","milestones_url":"https://api.github.com/repos/rails/rails/milestones{/number}","notifications_url":"https://api.github.com/repos/rails/rails/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/rails/rails/labels{/name}","releases_url":"https://api.github.com/repos/rails/rails/releases{/id}","deployments_url":"https://api.github.com/repos/rails/rails/deployments","created_at":"2008-04-11T02:19:47Z","updated_at":"2018-01-16T18:55:40Z","pushed_at":"2018-01-16T20:07:14Z","git_url":"git://github.com/rails/rails.git","ssh_url":"git@github.com:rails/rails.git","clone_url":"https://github.com/rails/rails.git","svn_url":"https://github.com/rails/rails","homepage":"http://rubyonrails.org","size":157741,"stargazers_count":38257,"watchers_count":38257,"language":"Ruby","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":false,"has_pages":false,"forks_count":15542,"mirror_url":null,"archived":false,"open_issues_count":1094,"license":{"key":"mit","name":"MIT
-        License","spdx_id":"MIT","url":"https://api.github.com/licenses/mit"},"forks":15542,"open_issues":1094,"watchers":38257,"default_branch":"master","organization":{"login":"rails","id":4223,"avatar_url":"https://avatars1.githubusercontent.com/u/4223?v=4","gravatar_id":"","url":"https://api.github.com/users/rails","html_url":"https://github.com/rails","followers_url":"https://api.github.com/users/rails/followers","following_url":"https://api.github.com/users/rails/following{/other_user}","gists_url":"https://api.github.com/users/rails/gists{/gist_id}","starred_url":"https://api.github.com/users/rails/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/rails/subscriptions","organizations_url":"https://api.github.com/users/rails/orgs","repos_url":"https://api.github.com/users/rails/repos","events_url":"https://api.github.com/users/rails/events{/privacy}","received_events_url":"https://api.github.com/users/rails/received_events","type":"Organization","site_admin":false},"network_count":15542,"subscribers_count":2526}'
+      string: '{"data":{"repository":{"nameWithOwner":"rails/rails","forks":{"totalCount":15303},"stargazers":{"totalCount":39072},"watchers":{"totalCount":2624},"createdAt":"2008-04-11T02:19:47Z","defaultBranchRef":{"name":"master","target":{"history":{"edges":[{"node":{"authoredDate":"2018-03-22T23:09:21Z"}},{"node":{"authoredDate":"2018-03-22T21:44:38Z"}},{"node":{"authoredDate":"2018-03-22T21:43:48Z"}},{"node":{"authoredDate":"2018-03-22T21:39:35Z"}},{"node":{"authoredDate":"2018-03-22T11:46:20Z"}},{"node":{"authoredDate":"2018-03-21T16:33:36Z"}},{"node":{"authoredDate":"2018-03-21T21:52:33Z"}},{"node":{"authoredDate":"2018-03-21T20:02:36Z"}},{"node":{"authoredDate":"2018-03-21T18:20:04Z"}},{"node":{"authoredDate":"2018-03-12T18:43:41Z"}},{"node":{"authoredDate":"2018-03-21T18:09:46Z"}},{"node":{"authoredDate":"2018-03-21T18:03:23Z"}},{"node":{"authoredDate":"2018-03-21T17:58:57Z"}},{"node":{"authoredDate":"2018-03-21T16:48:47Z"}},{"node":{"authoredDate":"2018-03-21T13:38:52Z"}},{"node":{"authoredDate":"2018-03-21T10:19:10Z"}},{"node":{"authoredDate":"2018-03-21T00:59:43Z"}},{"node":{"authoredDate":"2018-03-21T06:16:00Z"}},{"node":{"authoredDate":"2018-03-20T15:58:14Z"}},{"node":{"authoredDate":"2018-03-20T15:42:31Z"}},{"node":{"authoredDate":"2018-03-20T04:15:16Z"}},{"node":{"authoredDate":"2018-03-20T14:17:35Z"}},{"node":{"authoredDate":"2018-03-20T01:36:03Z"}},{"node":{"authoredDate":"2018-03-20T11:36:26Z"}},{"node":{"authoredDate":"2018-03-18T13:59:47Z"}},{"node":{"authoredDate":"2018-03-19T21:47:23Z"}},{"node":{"authoredDate":"2018-03-19T20:25:39Z"}},{"node":{"authoredDate":"2018-03-19T18:46:07Z"}},{"node":{"authoredDate":"2018-03-19T15:30:23Z"}},{"node":{"authoredDate":"2018-03-19T15:25:40Z"}},{"node":{"authoredDate":"2018-03-19T13:29:30Z"}},{"node":{"authoredDate":"2018-03-19T12:07:23Z"}},{"node":{"authoredDate":"2018-03-19T12:06:42Z"}},{"node":{"authoredDate":"2018-03-19T10:16:31Z"}},{"node":{"authoredDate":"2018-03-18T23:03:39Z"}},{"node":{"authoredDate":"2018-03-18T23:43:01Z"}},{"node":{"authoredDate":"2018-03-18T21:07:12Z"}},{"node":{"authoredDate":"2018-03-18T16:48:46Z"}},{"node":{"authoredDate":"2018-03-14T14:33:33Z"}},{"node":{"authoredDate":"2018-03-17T20:26:03Z"}},{"node":{"authoredDate":"2018-03-17T17:45:30Z"}},{"node":{"authoredDate":"2018-03-16T23:41:34Z"}},{"node":{"authoredDate":"2018-03-16T22:02:48Z"}},{"node":{"authoredDate":"2018-03-16T19:18:26Z"}},{"node":{"authoredDate":"2018-03-16T16:40:34Z"}},{"node":{"authoredDate":"2018-03-09T22:14:39Z"}},{"node":{"authoredDate":"2018-03-16T05:22:49Z"}},{"node":{"authoredDate":"2018-03-16T05:19:40Z"}},{"node":{"authoredDate":"2018-03-15T21:32:20Z"}},{"node":{"authoredDate":"2018-03-15T21:29:21Z"}}]}}},"description":"Ruby
+        on Rails","hasIssuesEnabled":true,"hasWikiEnabled":false,"homepageUrl":"http://rubyonrails.org","isArchived":false,"isFork":false,"isMirror":false,"licenseInfo":{"key":"mit"},"primaryLanguage":{"name":"Ruby"},"pushedAt":"2018-03-22T23:11:08Z","closedIssues":{"totalCount":10866},"openIssues":{"totalCount":350},"closedPullRequests":{"totalCount":6623},"openPullRequests":{"totalCount":714},"mergedPullRequests":{"totalCount":13729}},"rateLimit":{"limit":5000,"cost":1,"remaining":4996,"resetAt":"2018-03-23T00:11:47Z"}}}'
     http_version: 
-  recorded_at: Tue, 16 Jan 2018 20:14:46 GMT
+  recorded_at: Thu, 22 Mar 2018 23:15:14 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/rails/unknown_repo.yml
+++ b/spec/cassettes/rails/unknown_repo.yml
@@ -1,22 +1,18 @@
 ---
 http_interactions:
 - request:
-    method: get
-    uri: https://api.github.com/repos/rails/unknown?client_id=&client_secret=
+    method: head
+    uri: https://github.com/rails/unknown
     body:
       encoding: UTF-8
       string: ''
     headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - ruby-toolbox.com API client
-      Accept:
-      - application/vnd.github.v3+json
       Connection:
       - close
       Host:
-      - api.github.com
+      - github.com
+      User-Agent:
+      - http.rb/3.0.0
   response:
     status:
       code: 404
@@ -25,45 +21,46 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Tue, 16 Jan 2018 20:14:47 GMT
+      - Thu, 22 Mar 2018 23:15:14 GMT
       Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '77'
+      - text/html; charset=utf-8
       Connection:
       - close
       Status:
       - 404 Not Found
-      X-Ratelimit-Limit:
-      - '60'
-      X-Ratelimit-Remaining:
-      - '47'
-      X-Ratelimit-Reset:
-      - '1516136899'
-      X-Github-Media-Type:
-      - github.v3; format=json
-      Access-Control-Expose-Headers:
-      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
-        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
-      Access-Control-Allow-Origin:
-      - "*"
-      Content-Security-Policy:
-      - default-src 'none'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubdomains; preload
-      X-Content-Type-Options:
-      - nosniff
       X-Frame-Options:
       - deny
       X-Xss-Protection:
       - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Cache-Control:
+      - no-cache
+      Vary:
+      - X-PJAX
+      Set-Cookie:
+      - _gh_sess=ZjJiUFFQQ2cwYno3N3Y5a05WUWpWT0lTQnBGRGExTHhzSlZpSDlwRm16RDZPekdpcTIzM1ZtRnAwNEhNaklpWlBmbTQzYyt1dFl4TGNrd05ZTWl5bmdLMUhIYXFjU2lYd2txNDFNU2Z6OWM9LS1ET3REbCtwWVZxT1VUcmxRMGllUmpnPT0%3D--c173388516232b4de8021f49d04c1f6798ca9af4;
+        path=/; secure; HttpOnly
+      X-Request-Id:
+      - f29018d0-474d-4dbd-8740-1eb76ac40510
+      X-Runtime:
+      - '0.017466'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Expect-Ct:
+      - max-age=2592000, report-uri="https://api.github.com/_private/browser/errors"
+      Content-Security-Policy:
+      - default-src 'none'; base-uri 'self'; connect-src 'self'; form-action 'self';
+        img-src data:; script-src 'self'; style-src 'unsafe-inline'
       X-Runtime-Rack:
-      - '0.017414'
+      - '0.023406'
       X-Github-Request-Id:
-      - 7F55:1B94:C4A99:196914:5A5E5D37
+      - EDC7:3521:1BB8FE9:344027B:5AB43902
     body:
       encoding: UTF-8
-      string: '{"message":"Not Found","documentation_url":"https://developer.github.com/v3"}'
+      string: ''
     http_version: 
-  recorded_at: Tue, 16 Jan 2018 20:14:47 GMT
+  recorded_at: Thu, 22 Mar 2018 23:15:14 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/thread_safe_gem.yml
+++ b/spec/cassettes/thread_safe_gem.yml
@@ -44,9 +44,9 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - bf7fa666-bd19-46eb-a401-745bc21be540
+      - 13f8ea9c-ac62-424a-8d0a-83fce4082596
       X-Runtime:
-      - '0.017854'
+      - '0.013100'
       Strict-Transport-Security:
       - max-age=0
       X-Ua-Compatible:
@@ -58,7 +58,7 @@ http_interactions:
       Accept-Ranges:
       - bytes
       Date:
-      - Tue, 16 Jan 2018 20:14:40 GMT
+      - Thu, 22 Mar 2018 23:15:21 GMT
       Via:
       - 1.1 varnish
       Age:
@@ -66,28 +66,28 @@ http_interactions:
       Connection:
       - close
       X-Served-By:
-      - cache-ams4122-AMS
+      - cache-ams4447-AMS
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1516133680.886561,VS0,VE186
+      - S1521760522.564882,VS0,VE195
       Vary:
       - Accept-Encoding,Fastly-SSL
       Etag:
-      - '"5bf5b1998cfb0796b91cd8d4932f56dd"'
+      - '"018ba1b55a8c5bed5e439aa1efa5823d"'
       Server:
       - RubyGems.org
     body:
       encoding: UTF-8
-      string: '{"name":"thread_safe","downloads":116338126,"version":"0.3.6","version_downloads":24843666,"platform":"ruby","authors":"Charles
+      string: '{"name":"thread_safe","downloads":125922046,"version":"0.3.6","version_downloads":32885325,"platform":"ruby","authors":"Charles
         Oliver Nutter, thedarkone","info":"A collection of data structures and utilities
         to make thread-safe programming in Ruby easier","licenses":["Apache-2.0"],"metadata":{},"sha":"9ed7072821b51c57e8d6b7011a8e282e25aeea3a4065eab326e43f66f063b05a","project_uri":"https://rubygems.org/gems/thread_safe","gem_uri":"https://rubygems.org/gems/thread_safe-0.3.6.gem","homepage_uri":"https://github.com/ruby-concurrency/thread_safe","wiki_uri":"","documentation_uri":"http://ruby-concurrency.github.io/thread_safe/frames.html","mailing_list_uri":"https://groups.google.com/forum/#!forum/concurrent-ruby","source_code_uri":"https://github.com/ruby-concurrency/thread_safe","bug_tracker_uri":"https://github.com/ruby-concurrency/thread_safe/issues","changelog_uri":null,"dependencies":{"development":[{"name":"atomic","requirements":"=
         1.1.16"},{"name":"rake","requirements":"\u003c 12.0"},{"name":"rspec","requirements":"~\u003e
         3.2"}],"runtime":[]}}'
     http_version: 
-  recorded_at: Tue, 16 Jan 2018 20:14:39 GMT
+  recorded_at: Thu, 22 Mar 2018 23:15:21 GMT
 - request:
     method: get
     uri: https://rubygems.org/api/v1/versions/thread_safe.json
@@ -128,9 +128,9 @@ http_interactions:
       Cache-Control:
       - max-age=0, public
       X-Request-Id:
-      - 6957a204-37d4-411a-8306-162eacaa2758
+      - 7b5d3ff0-1a5e-4837-9da6-5d81d3221797
       X-Runtime:
-      - '0.044680'
+      - '0.050672'
       Strict-Transport-Security:
       - max-age=0
       X-Ua-Compatible:
@@ -142,21 +142,21 @@ http_interactions:
       Accept-Ranges:
       - bytes
       Date:
-      - Tue, 16 Jan 2018 20:14:40 GMT
+      - Thu, 22 Mar 2018 23:15:22 GMT
       Via:
       - 1.1 varnish
       Age:
-      - '14'
+      - '0'
       Connection:
       - close
       X-Served-By:
-      - cache-ams4423-AMS
+      - cache-ams4151-AMS
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
-      - '1'
+      - '0'
       X-Timer:
-      - S1516133680.166368,VS0,VE1
+      - S1521760522.857219,VS0,VE218
       Vary:
       - Accept-Encoding,Fastly-SSL
       Etag:
@@ -167,114 +167,114 @@ http_interactions:
       encoding: UTF-8
       string: '[{"authors":"Charles Oliver Nutter, thedarkone","built_at":"2017-02-22T00:00:00.000Z","created_at":"2017-02-22T19:51:15.835Z","description":"A
         collection of data structures and utilities to make thread-safe programming
-        in Ruby easier","downloads_count":1023129,"metadata":{},"number":"0.3.6","summary":"Thread-safe
+        in Ruby easier","downloads_count":1254028,"metadata":{},"number":"0.3.6","summary":"Thread-safe
         collections and utilities for Ruby","platform":"java","rubygems_version":"\u003e=
         0","ruby_version":"\u003e= 0","prerelease":false,"licenses":["Apache-2.0"],"requirements":[],"sha":"bb28394cd0924c068981adee71f36a81c85c92e7d74d3f62372bd51489a0e0c2"},{"authors":"Charles
         Oliver Nutter, thedarkone","built_at":"2017-02-22T00:00:00.000Z","created_at":"2017-02-22T19:50:54.397Z","description":"A
         collection of data structures and utilities to make thread-safe programming
-        in Ruby easier","downloads_count":24843666,"metadata":{},"number":"0.3.6","summary":"Thread-safe
+        in Ruby easier","downloads_count":32885325,"metadata":{},"number":"0.3.6","summary":"Thread-safe
         collections and utilities for Ruby","platform":"ruby","rubygems_version":"\u003e=
         0","ruby_version":"\u003e= 0","prerelease":false,"licenses":["Apache-2.0"],"requirements":[],"sha":"9ed7072821b51c57e8d6b7011a8e282e25aeea3a4065eab326e43f66f063b05a"},{"authors":"Charles
         Oliver Nutter, thedarkone","built_at":"2015-03-11T00:00:00.000Z","created_at":"2015-03-11T15:00:52.728Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":6932543,"metadata":{},"number":"0.3.5","summary":"A
+        collections and utilities for Ruby","downloads_count":6977588,"metadata":{},"number":"0.3.5","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"java","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
         0","prerelease":false,"licenses":["Apache-2.0"],"requirements":[],"sha":"52976573c9934c696a0c577ea57f51e38714191cc6bd0fac499f9ad5843e060c"},{"authors":"Charles
         Oliver Nutter, thedarkone","built_at":"2015-03-11T00:00:00.000Z","created_at":"2015-03-11T15:00:41.140Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":42224424,"metadata":{},"number":"0.3.5","summary":"A
+        collections and utilities for Ruby","downloads_count":43198343,"metadata":{},"number":"0.3.5","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
         0","prerelease":false,"licenses":["Apache-2.0"],"requirements":[],"sha":"993da065f98b8575c537ebf984ffb79eecdb6064559a3b9d2a9d7aaf313704c3"},{"authors":"Charles
         Oliver Nutter, thedarkone","built_at":"2014-05-27T00:00:00.000Z","created_at":"2014-05-27T20:10:29.698Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":31846703,"metadata":{},"number":"0.3.4","summary":"A
+        collections and utilities for Ruby","downloads_count":32104263,"metadata":{},"number":"0.3.4","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
         0","prerelease":false,"licenses":["Apache-2.0"],"requirements":[],"sha":"16315baa971c48d00104bcd35e8934e3f9ccfd3b8f429e3fca7ee2dfd81734b2"},{"authors":"Charles
         Oliver Nutter, thedarkone","built_at":"2014-05-27T00:00:00.000Z","created_at":"2014-05-27T20:10:16.778Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":402480,"metadata":{},"number":"0.3.4","summary":"A
+        collections and utilities for Ruby","downloads_count":404491,"metadata":{},"number":"0.3.4","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"java","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
         0","prerelease":false,"licenses":["Apache-2.0"],"requirements":[],"sha":"903716024d787ea90b6647c81f3ff3710721279f1ed435fc0e219582ca851ba0"},{"authors":"Charles
         Oliver Nutter, thedarkone","built_at":"2014-04-07T00:00:00.000Z","created_at":"2014-04-07T10:05:01.221Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":61512,"metadata":{},"number":"0.3.3","summary":"A
+        collections and utilities for Ruby","downloads_count":62245,"metadata":{},"number":"0.3.3","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"java","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
         0","prerelease":false,"licenses":["Apache-2.0"],"requirements":[],"sha":"e8122caeee98b9294f36760ca1fcf5589b4e27ead202296ffef6854b01693731"},{"authors":"Charles
         Oliver Nutter, thedarkone","built_at":"2014-04-07T00:00:00.000Z","created_at":"2014-04-07T10:04:43.000Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":1652137,"metadata":{},"number":"0.3.3","summary":"A
+        collections and utilities for Ruby","downloads_count":1655478,"metadata":{},"number":"0.3.3","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
         0","prerelease":false,"licenses":["Apache-2.0"],"requirements":[],"sha":"f0f4307ea85d6eff7f9c304587073e3465da58beb198ea686bf69ec87f2ddb7e"},{"authors":"Charles
         Oliver Nutter, thedarkone","built_at":"2014-04-05T00:00:00.000Z","created_at":"2014-04-05T12:15:16.825Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":3269,"metadata":{},"number":"0.3.2","summary":"A
+        collections and utilities for Ruby","downloads_count":3376,"metadata":{},"number":"0.3.2","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"java","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
         0","prerelease":false,"licenses":["Apache-2.0"],"requirements":[],"sha":"a475303101015f279b2791ddcb821e275d0f76cbce46251359a15d39dfb69117"},{"authors":"Charles
         Oliver Nutter, thedarkone","built_at":"2014-04-05T00:00:00.000Z","created_at":"2014-04-05T12:14:51.531Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":46769,"metadata":{},"number":"0.3.2","summary":"A
+        collections and utilities for Ruby","downloads_count":46816,"metadata":{},"number":"0.3.2","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
         0","prerelease":false,"licenses":["Apache-2.0"],"requirements":[],"sha":"e66e8c03414aa0e1982a5f505d659ed5fd1a411fee71b8e852ab57e0eb9e4853"},{"authors":"Charles
         Oliver Nutter, thedarkone","built_at":"2014-03-21T00:00:00.000Z","created_at":"2014-03-21T07:24:51.143Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":474763,"metadata":{},"number":"0.3.1","summary":"A
+        collections and utilities for Ruby","downloads_count":475319,"metadata":{},"number":"0.3.1","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
         0","prerelease":false,"licenses":["Apache-2.0"],"requirements":[],"sha":"aff0cf52e87876f46767c5327b8c4332381c6f6f832dff36679e928c30b82f3d"},{"authors":"Charles
         Oliver Nutter, thedarkone","built_at":"2014-03-21T00:00:00.000Z","created_at":"2014-03-21T07:24:24.214Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":29116,"metadata":{},"number":"0.3.1","summary":"A
+        collections and utilities for Ruby","downloads_count":29875,"metadata":{},"number":"0.3.1","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"java","rubygems_version":"\u003e= 0","ruby_version":"\u003e=
         0","prerelease":false,"licenses":["Apache-2.0"],"requirements":[],"sha":"d71d0686a011d478562460c7734694c750afb03f769445bd46c6da740e869020"},{"authors":"Charles
         Oliver Nutter, thedarkone","built_at":"2014-02-26T00:00:00.000Z","created_at":"2014-02-26T17:43:22.372Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":29136,"metadata":{},"number":"0.2.0","summary":"A
+        collections and utilities for Ruby","downloads_count":29196,"metadata":{},"number":"0.2.0","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"java","rubygems_version":"\u003e= 0","ruby_version":null,"prerelease":false,"licenses":["Apache-2.0"],"requirements":[],"sha":"a184903697075973c6959e48ab28b8f6c3ad628728bb2817c2b0d0bc6aa67433"},{"authors":"Charles
         Oliver Nutter, thedarkone","built_at":"2014-02-26T00:00:00.000Z","created_at":"2014-02-26T17:40:40.192Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":662261,"metadata":{},"number":"0.2.0","summary":"A
+        collections and utilities for Ruby","downloads_count":663522,"metadata":{},"number":"0.2.0","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":null,"prerelease":false,"licenses":["Apache-2.0"],"requirements":[],"sha":"a85f7f14c3269fd6c77514aa4fdeef20bef19eee91839762b3b4a4f8cf323145"},{"authors":"Charles
         Oliver Nutter, thedarkone","built_at":"2013-09-10T00:00:00.000Z","created_at":"2013-09-10T14:35:21.960Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":4146136,"metadata":{},"number":"0.1.3","summary":"A
+        collections and utilities for Ruby","downloads_count":4160454,"metadata":{},"number":"0.1.3","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":null,"prerelease":false,"licenses":["Apache-2.0"],"requirements":[],"sha":"f8b9f8db0889aa97676b4a1efe919b1e76601ed9c9662a986825755bba305c38"},{"authors":"Charles
         Oliver Nutter, thedarkone","built_at":"2013-09-10T00:00:00.000Z","created_at":"2013-09-10T14:34:01.740Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":148657,"metadata":{},"number":"0.1.3","summary":"A
+        collections and utilities for Ruby","downloads_count":149141,"metadata":{},"number":"0.1.3","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"java","rubygems_version":"\u003e= 0","ruby_version":null,"prerelease":false,"licenses":["Apache-2.0"],"requirements":[],"sha":"24905e6433a692412ddfeb2105c4768266ef693b7e51d9b9dcdb789141b5a7e1"},{"authors":"Charles
         Oliver Nutter","built_at":"2013-07-24T00:00:00.000Z","created_at":"2013-07-24T00:12:01.379Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":929854,"metadata":{},"number":"0.1.2","summary":"A
+        collections and utilities for Ruby","downloads_count":939589,"metadata":{},"number":"0.1.2","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":null,"prerelease":false,"licenses":["Apache-2.0"],"requirements":[],"sha":"7e2b957c28f2676b0a5ba5c0ad3a92988887922edfcb7be66acac6106881beaf"},{"authors":"Charles
         Oliver Nutter","built_at":"2013-07-24T00:00:00.000Z","created_at":"2013-07-24T00:11:38.470Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":97167,"metadata":{},"number":"0.1.2","summary":"A
+        collections and utilities for Ruby","downloads_count":97278,"metadata":{},"number":"0.1.2","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"java","rubygems_version":"\u003e= 0","ruby_version":null,"prerelease":false,"licenses":["Apache-2.0"],"requirements":[],"sha":"d31bb9b0cafd67510f9d5d026064e00c99dcd2935fe310a9deba987788146da7"},{"authors":"Charles
         Oliver Nutter","built_at":"2013-07-23T00:00:00.000Z","created_at":"2013-07-23T19:40:30.776Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":5064,"metadata":{},"number":"0.1.1","summary":"A
+        collections and utilities for Ruby","downloads_count":5095,"metadata":{},"number":"0.1.1","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":null,"prerelease":false,"licenses":["Apache-2.0"],"requirements":[],"sha":"3102637a5f58ebb8adfbffad76acd9d40b2f0889c3fb4959a9b5e45b6f82942b"},{"authors":"Charles
         Oliver Nutter","built_at":"2013-07-23T00:00:00.000Z","created_at":"2013-07-23T19:39:55.576Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":1347,"metadata":{},"number":"0.1.1","summary":"A
+        collections and utilities for Ruby","downloads_count":1377,"metadata":{},"number":"0.1.1","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"java","rubygems_version":"\u003e= 0","ruby_version":null,"prerelease":false,"licenses":["Apache-2.0"],"requirements":[],"sha":"787f8084a847cbe26a9aad685a6e7b46ae113cd87aa144d78a9c3e4f631161db"},{"authors":"Charles
         Oliver Nutter, thedarkone","built_at":"2012-12-12T23:00:00.000Z","created_at":"2012-12-13T12:37:46.787Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":741215,"metadata":{},"number":"0.1.0","summary":"A
+        collections and utilities for Ruby","downloads_count":742385,"metadata":{},"number":"0.1.0","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":null,"prerelease":false,"licenses":[],"requirements":null,"sha":"4ee7605080ea11b1bfd8a5d7ddeef97a73609d1ad8355e648c91d00842201d3a"},{"authors":"Charles
         Oliver Nutter","built_at":"2012-04-27T00:00:00.000Z","created_at":"2012-04-27T16:52:19.721Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":3582,"metadata":{},"number":"0.0.3","summary":"A
+        collections and utilities for Ruby","downloads_count":3609,"metadata":{},"number":"0.0.3","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"d4fac31142dd3262bcf4e66f730e8ef5d0f058e4f5bc43d510fc4db92a4085e9"},{"authors":"Charles
         Oliver Nutter","built_at":"2012-04-26T00:00:00.000Z","created_at":"2012-04-26T00:12:31.448Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":1806,"metadata":{},"number":"0.0.2","summary":"A
+        collections and utilities for Ruby","downloads_count":1834,"metadata":{},"number":"0.0.2","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"bd74ee7ad95567721f7cd5757d6fb5a6cbf21e6613cf6f187ad3d72c245c2b39"},{"authors":"Charles
         Oliver Nutter","built_at":"2012-04-26T00:00:00.000Z","created_at":"2012-04-26T00:02:37.807Z","description":"Thread-safe
-        collections and utilities for Ruby","downloads_count":1788,"metadata":{},"number":"0.0.1","summary":"A
+        collections and utilities for Ruby","downloads_count":1816,"metadata":{},"number":"0.0.1","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"b1f7dfeb8bc765e421a90836c6a7e7dbe587abe238b2f660a89c6ad6e8e4975d"}]'
     http_version: 
-  recorded_at: Tue, 16 Jan 2018 20:14:39 GMT
+  recorded_at: Thu, 22 Mar 2018 23:15:22 GMT
 - request:
     method: get
     uri: https://rubygems.org/api/v1/gems/thread_safe/reverse_dependencies.json
@@ -313,9 +313,9 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - acfe7c65-a1ef-4932-8df0-67a3f638a404
+      - 9fe5cf8d-114b-461c-b438-c68bc8f046a7
       X-Runtime:
-      - '0.032287'
+      - '0.029025'
       Strict-Transport-Security:
       - max-age=0
       X-Ua-Compatible:
@@ -327,7 +327,7 @@ http_interactions:
       Accept-Ranges:
       - bytes
       Date:
-      - Tue, 16 Jan 2018 20:14:40 GMT
+      - Thu, 22 Mar 2018 23:15:22 GMT
       Via:
       - 1.1 varnish
       Age:
@@ -335,22 +335,22 @@ http_interactions:
       Connection:
       - close
       X-Served-By:
-      - cache-ams4425-AMS
+      - cache-ams4448-AMS
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1516133680.272669,VS0,VE200
+      - S1521760522.169719,VS0,VE199
       Vary:
       - Accept-Encoding,Fastly-SSL
       Etag:
-      - '"cccee33f2e7f9909d8b82cfe39b92db6"'
+      - '"d38483f52e86f34ead7b98a2f81f20ef"'
       Server:
       - RubyGems.org
     body:
       encoding: UTF-8
-      string: '["r4s","cache_digests","tickr_client","racing-sprockets","clasp","gemerald_beanstalk","ruby_skynet","autodeps","dskiplist","barker","memoizable","descendants_tracker","axiom-types","devise-bootstrap","devbootsrap","axiom-memory-adapter","mongoid_connection_pool","cap_proxy","jirabas","gene_pool","metrics_logger","ruby_nsq","multi_connection","brainsome_devise","postamt","devision","venet-backup","mock_dns_server","whisperer","thread_hazardous","deviseOne","aws_student_accounts","colossus","vigilem-core","pd-blender","hexx-storage","stapfen","prepor-protobuf","persie","rom-generated_id","pagseguro-transparente","smelter","faraday_persistent_excon","persistent_excon","ruby_storm","email_crawler","backup_zh","collectr","ruby-dovado","dry-data","hermann","hermann","turbot-ruby-gems","pg_helper","asciidoctor-bespoke","fluent-plugin-multiline-parser","iplan-appsignal","wet-command_bus","arkency-command_bus","fleck","sliday_backup","neo4j_legacy","rester","slack-cli","sportweb","rohbau","killbill-payu-latam","killbill-firstdata_e4","killbill-securenet","killbill-chartmogul","s3reamer","datashift","elastics","peastash","shuttle_cli","asciidoctor-htmlbook","mixture","asciidoctor-accelerated-mobile-pages","asciidoctor-instant-articles","backup-ssh","asciidoctor-epub3","docli","protobuffy","killbill-litle","killbill-stripe","wechat_client","killbill-braintree_blue","nexpose_pxgrid","killbill-payment-test","gooddata-edge","asciidoctor","asciidoctor-pdf","asciidoctor-doctest","asciidoctor-html5s","killbill-cybersource","protobuf","tzinfo","killbill-orbital","logstash-filter-metrics","logstash-filter-throttle","asciidoctor-rfc","zapnito-cli","lines-engine","killbill-paypal-express","sequent","logstash-input-syslog","asciidoctor-iso","splitclient-rb","asciidoctor-revealjs","gooddata","gooddata","logstash-input-beats","killbill","ldclient-rb","easy_translate","hu","logstash-core"]'
+      string: '["killbill-cybersource","logstash-core","asciidoctor","datashift","asciidoctor-iso","isodoc","html2doc","killbill","hu","logstash-input-beats","gooddata","gooddata","asciidoctor-gb","ldclient-rb","asciidoctor-html5s","splitclient-rb","protobuf","asciidoctor-epub3","logstash-input-syslog","tzinfo","asciidoctor-revealjs","asciidoctor-csd","easy_translate","killbill-chartmogul","killbill-securenet","killbill-firstdata_e4","killbill-payu-latam","rohbau","sportweb","slack-cli","rester","neo4j_legacy","sliday_backup","iplan-appsignal","fluent-plugin-multiline-parser","asciidoctor-bespoke","asciidoctor-pdf","gooddata-edge","killbill-payment-test","nexpose_pxgrid","wechat_client","killbill-braintree_blue","killbill-litle","killbill-stripe","protobuffy","docli","backup-ssh","asciidoctor-instant-articles","asciidoctor-accelerated-mobile-pages","mixture","asciidoctor-htmlbook","shuttle_cli","peastash","elastics","s3reamer","pg_helper","turbot-ruby-gems","dry-data","ruby-dovado","collectr","sequent","killbill-paypal-express","lines-engine","asciidoctor-rfc","zapnito-cli","logstash-filter-throttle","logstash-filter-metrics","killbill-orbital","asciidoctor-doctest","fleck","arkency-command_bus","wet-command_bus","rom-generated_id","persie","prepor-protobuf","stapfen","hexx-storage","pd-blender","vigilem-core","hermann","hermann","colossus","aws_student_accounts","deviseOne","thread_hazardous","whisperer","mock_dns_server","venet-backup","devision","postamt","brainsome_devise","multi_connection","backup_zh","email_crawler","ruby_storm","persistent_excon","faraday_persistent_excon","smelter","pagseguro-transparente","ruby_nsq","r4s","cache_digests","tickr_client","racing-sprockets","clasp","gemerald_beanstalk","ruby_skynet","autodeps","dskiplist","barker","memoizable","descendants_tracker","axiom-types","devise-bootstrap","devbootsrap","axiom-memory-adapter","mongoid_connection_pool","cap_proxy","jirabas","gene_pool","metrics_logger"]'
     http_version: 
-  recorded_at: Tue, 16 Jan 2018 20:14:40 GMT
+  recorded_at: Thu, 22 Mar 2018 23:15:22 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/unknown_gem.yml
+++ b/spec/cassettes/unknown_gem.yml
@@ -25,9 +25,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       X-Request-Id:
-      - 3e9d7fca-afcd-4871-b2b0-5e8c53edf0e1
+      - 42158ddf-58c7-492d-ba0c-150a87946dbc
       X-Runtime:
-      - '0.001740'
+      - '0.001373'
       Strict-Transport-Security:
       - max-age=0
       Content-Length:
@@ -35,26 +35,26 @@ http_interactions:
       Accept-Ranges:
       - bytes
       Date:
-      - Tue, 16 Jan 2018 20:14:40 GMT
+      - Thu, 22 Mar 2018 23:15:21 GMT
       Via:
       - 1.1 varnish
       Age:
-      - '12'
+      - '0'
       Connection:
       - close
       X-Served-By:
-      - cache-ams4448-AMS
+      - cache-ams4120-AMS
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
-      - '1'
+      - '0'
       X-Timer:
-      - S1516133681.673714,VS0,VE0
+      - S1521760521.259126,VS0,VE183
       Server:
       - RubyGems.org
     body:
       encoding: UTF-8
       string: '{"status":404,"error":"Not Found"}'
     http_version: 
-  recorded_at: Tue, 16 Jan 2018 20:14:40 GMT
+  recorded_at: Thu, 22 Mar 2018 23:15:21 GMT
 recorded_with: VCR 4.0.0

--- a/spec/fixtures/graphql_responses/github/rails.json
+++ b/spec/fixtures/graphql_responses/github/rails.json
@@ -1,0 +1,311 @@
+{
+  "data": {
+    "repository": {
+      "nameWithOwner": "rails/rails",
+      "forks": {
+        "totalCount": 15303
+      },
+      "stargazers": {
+        "totalCount": 39070
+      },
+      "watchers": {
+        "totalCount": 2623
+      },
+      "createdAt": "2008-04-11T02:19:47Z",
+      "defaultBranchRef": {
+        "name": "master",
+        "target": {
+          "history": {
+            "edges": [
+              {
+                "node": {
+                  "authoredDate": "2018-03-22T21:44:38Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-22T21:43:48Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-22T21:39:35Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-22T11:46:20Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-21T16:33:36Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-21T21:52:33Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-21T20:02:36Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-21T18:20:04Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-12T18:43:41Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-21T18:09:46Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-21T18:03:23Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-21T17:58:57Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-21T16:48:47Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-21T13:38:52Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-21T10:19:10Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-21T00:59:43Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-20T15:58:14Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-20T15:42:31Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-20T04:15:16Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-20T14:17:35Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-20T01:36:03Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-20T11:36:26Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-18T13:59:47Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-19T21:47:23Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-19T20:25:39Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-19T18:46:07Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-19T15:30:23Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-19T15:25:40Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-19T13:29:30Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-19T12:07:23Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-19T12:06:42Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-19T10:16:31Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-18T23:03:39Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-18T23:43:01Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-18T21:07:12Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-18T16:48:46Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-14T14:33:33Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-17T20:26:03Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-17T17:45:30Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-16T23:41:34Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-16T22:02:48Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-16T19:18:26Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-16T16:40:34Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-09T22:14:39Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-16T05:22:49Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-16T05:19:40Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-15T21:32:20Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-15T21:29:21Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-15T19:49:21Z"
+                }
+              },
+              {
+                "node": {
+                  "authoredDate": "2018-03-15T19:36:51Z"
+                }
+              }
+            ]
+          }
+        }
+      },
+      "description": "Ruby on Rails",
+      "hasIssuesEnabled": true,
+      "hasWikiEnabled": false,
+      "homepageUrl": "http://rubyonrails.org",
+      "isArchived": false,
+      "isFork": false,
+      "isMirror": false,
+      "licenseInfo": {
+        "key": "mit"
+      },
+      "primaryLanguage": {
+        "name": "Ruby"
+      },
+      "pushedAt": "2018-03-22T21:45:47Z",
+      "closedIssues": {
+        "totalCount": 10866
+      },
+      "openIssues": {
+        "totalCount": 350
+      },
+      "closedPullRequests": {
+        "totalCount": 6623
+      },
+      "openPullRequests": {
+        "totalCount": 715
+      },
+      "mergedPullRequests": {
+        "totalCount": 13728
+      }
+    },
+    "rateLimit": {
+      "limit": 5000,
+      "cost": 1,
+      "remaining": 4995,
+      "resetAt": "2018-03-22T23:00:33Z"
+    }
+  }
+}

--- a/spec/integration/github_client_spec.rb
+++ b/spec/integration/github_client_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe GithubClient, :real_http do
+  let(:client) { described_class.new }
+
+  describe "for existing repo", vcr: { cassette_name: "graphql/rails" } do
+    let(:expected_attributes) do
+      {
+        archived?: false,
+        average_recent_committed_at: a_value > Time.utc(2018, 3, 1),
+        closed_issues_count: a_value > 10_000,
+        closed_pull_requests_count: a_value > 6000,
+        created_at: Time.zone.parse("2008-04-11T02:19:47Z"),
+        default_branch: "master",
+        description: "Ruby on Rails",
+        fork?: false,
+        forks_count: a_value > 10_000,
+        homepage_url: "http://rubyonrails.org",
+        issues?: true,
+        license: "mit",
+        merged_pull_requests_count: a_value > 13_000,
+        mirror?: false,
+        open_issues_count: a_value > 10,
+        open_pull_requests_count: a_value > 50,
+        path: "rails/rails",
+        primary_language: "Ruby",
+        pushed_at: a_value >= Time.zone.parse("2018-03-12T19:56:09Z"),
+        stargazers_count: a_value > 35_000,
+        watchers_count: a_value > 2500,
+        wiki?: false,
+      }
+    end
+
+    it "can fetch a whole bunch of data about the repository in question" do
+      expect(client.fetch_repository("rails/rails")).to have_attributes(expected_attributes)
+    end
+  end
+
+  describe "for unknown repo", vcr: { cassette_name: "graphql/fails" } do
+    it "raises an GithubClient::InvalidResponse" do
+      expect { client.fetch_repository("thisverylikely/fails") }.to raise_error(
+        GithubClient::InvalidResponse, /Could not resolve to a User with the username/
+      )
+    end
+  end
+
+  # This is currently not possible with Github's GraphQL API :(
+  # https://platform.github.community/t/repository-redirects-in-api-v4-graphql/4417
+  #
+  # describe "for a moved repo", vcr: { cassette_name: "graphql/carrierwave" } do
+  #   it "resolves to the real repository path" do
+  #     response = client.fetch_repository "jnicklas/carrierwave"
+  #     expect(response.path).to be == "carrierwaveuploader/carrierwave"
+  #   end
+  # end
+end

--- a/spec/integration/github_client_spec.rb
+++ b/spec/integration/github_client_spec.rb
@@ -39,9 +39,9 @@ RSpec.describe GithubClient, :real_http do
   end
 
   describe "for unknown repo", vcr: { cassette_name: "graphql/fails" } do
-    it "raises an GithubClient::InvalidResponse" do
+    it "raises a GithubClient::UnknownRepoError" do
       expect { client.fetch_repository("thisverylikely/fails") }.to raise_error(
-        GithubClient::InvalidResponse, /Could not resolve to a User with the username/
+        GithubClient::UnknownRepoError, /Cannot find repo/
       )
     end
   end
@@ -49,10 +49,10 @@ RSpec.describe GithubClient, :real_http do
   # This is currently not possible with Github's GraphQL API :(
   # https://platform.github.community/t/repository-redirects-in-api-v4-graphql/4417
   #
-  # describe "for a moved repo", vcr: { cassette_name: "graphql/carrierwave" } do
-  #   it "resolves to the real repository path" do
-  #     response = client.fetch_repository "jnicklas/carrierwave"
-  #     expect(response.path).to be == "carrierwaveuploader/carrierwave"
-  #   end
-  # end
+  describe "for a moved repo", vcr: { cassette_name: "graphql/carrierwave" } do
+    it "resolves to the real repository path" do
+      response = client.fetch_repository "jnicklas/carrierwave"
+      expect(response.path).to be == "carrierwaveuploader/carrierwave"
+    end
+  end
 end

--- a/spec/jobs/github_repo_update_job_spec.rb
+++ b/spec/jobs/github_repo_update_job_spec.rb
@@ -3,26 +3,30 @@
 require "rails_helper"
 
 RSpec.describe GithubRepoUpdateJob, type: :job do
-  let(:job) { described_class.new }
+  let(:repo_data) do
+    json = Rails.root.join("spec", "fixtures", "graphql_responses", "github", "rails.json").read
+    GithubClient::RepositoryData.new Oj.load(json)
+  end
+  let(:faked_github_client) do
+    instance_double(GithubClient, fetch_repository: repo_data)
+  end
+
+  let(:job) { described_class.new client: faked_github_client }
   let(:do_perform) { job.perform repo_path }
   let(:repo_path) { "rails/rails" }
 
   describe "#perform" do
     let(:expected_attributes) do
       {
-        stargazers_count: 38_140,
-        watchers_count: 2520,
-        forks_count: 15_500,
+        stargazers_count: a_value > 38_140,
+        watchers_count: a_value > 2520,
+        forks_count: a_value > 14_000,
         description: "Ruby on Rails",
         repo_created_at: Time.zone.parse("2008-04-11T02:19:47Z"),
-        repo_updated_at: Time.zone.parse("2018-01-03T21:10:44Z"),
-        repo_pushed_at: Time.zone.parse("2018-01-03T22:39:06Z"),
+        repo_pushed_at: a_value > Time.zone.parse("2018-01-03T22:39:06Z"),
         homepage_url: "http://rubyonrails.org",
         has_issues: true,
-        has_projects: true,
-        has_downloads: true,
         has_wiki: false,
-        has_pages: false,
         archived: false,
       }
     end
@@ -34,7 +38,7 @@ RSpec.describe GithubRepoUpdateJob, type: :job do
     end
 
     it "changes the updated_at timestamp regardless of changes" do
-      described_class.new.perform repo_path
+      described_class.new(client: faked_github_client).perform repo_path
       GithubRepo.find(repo_path).update! updated_at: 2.days.ago
       expect { do_perform }.to(change { GithubRepo.find(repo_path).updated_at })
     end
@@ -44,14 +48,6 @@ RSpec.describe GithubRepoUpdateJob, type: :job do
       Project.create! permalink: "rails", github_repo_path: repo_path, rubygem: rubygem
       expect(ProjectUpdateJob).to receive(:perform_async).with("rails")
       do_perform
-    end
-
-    describe "when github is down" do
-      let(:repo_path) { "ohnogithub/isdown" }
-
-      it "raises an exception" do
-        expect { do_perform }.to raise_error "Unknown response status 500"
-      end
     end
   end
 end

--- a/spec/jobs/github_repo_update_job_spec.rb
+++ b/spec/jobs/github_repo_update_job_spec.rb
@@ -18,16 +18,27 @@ RSpec.describe GithubRepoUpdateJob, type: :job do
   describe "#perform" do
     let(:expected_attributes) do
       {
-        stargazers_count: a_value > 38_140,
-        watchers_count: a_value > 2520,
-        forks_count: a_value > 14_000,
+        archived: false,
+        average_recent_committed_at: a_value > Time.zone.parse("2018-03-03T22:39:06Z"),
+        closed_issues_count: a_value > 10_000,
+        closed_pull_requests_count: a_value > 6000,
+        default_branch: "master",
         description: "Ruby on Rails",
-        repo_created_at: Time.zone.parse("2008-04-11T02:19:47Z"),
-        repo_pushed_at: a_value > Time.zone.parse("2018-01-03T22:39:06Z"),
-        homepage_url: "http://rubyonrails.org",
+        forks_count: a_value > 14_000,
         has_issues: true,
         has_wiki: false,
-        archived: false,
+        homepage_url: "http://rubyonrails.org",
+        is_fork: false,
+        is_mirror: false,
+        license: "mit",
+        merged_pull_requests_count: a_value > 13_700,
+        open_issues_count: a_value > 50,
+        open_pull_requests_count: a_value > 100,
+        primary_language: "Ruby",
+        repo_created_at: Time.zone.parse("2008-04-11T02:19:47Z"),
+        repo_pushed_at: a_value > Time.zone.parse("2018-01-03T22:39:06Z"),
+        stargazers_count: a_value > 38_140,
+        watchers_count: a_value > 2520,
       }
     end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -42,6 +42,7 @@ VCR.configure do |c|
   c.default_cassette_options = { record: :new_episodes }
   c.hook_into :webmock
   c.configure_rspec_metadata!
+  c.filter_sensitive_data("<GITHUB_TOKEN>") { ENV["GITHUB_TOKEN"] }
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
This replaces #83

The query shown here is rated as 1 against the hourly 5k limit as it stands, and it conveys a whole lot more information, i.e. open/closed ratios, total amounts and commit frequency (see #77)

Downsides: 

* You need a valid OAuth API bearer token to use this at all (in contrast to the limited, but functional 60 requests per hour on github REST)
* No HTTP caching via e-tag or similar. Since most of the requests made against the API via the daily sync actually are in vein (nothing has changed at all), caching could really help to save some rate limit points
* No README endpoint
* No stats endpoint (see #93)

This should end up replacing the current way of syncing github stats.

The API call is simple enough:

```ruby
query = Rails.root.join("app/graphql-queries/github/repo.graphql").read
HTTP.headers(authorization: "bearer 12345")
  .post("https://api.github.com/graphql", body: { query: query }.to_json)
```