### PR TITLE
Normalize path before find_or_initialize on github repo project creation

### DIFF
--- a/app/services/catalog_import.rb
+++ b/app/services/catalog_import.rb
@@ -83,8 +83,9 @@ class CatalogImport
   #
   def upsert_github_projects(projects)
     projects.each do |project|
-      next unless project.include? "/"
-      Project.find_or_initialize_by(permalink: project).save!
+      normalized_path = Github.normalize_path(project)
+      next if !project.include?("/") || Project.find_by(permalink: normalized_path)
+      Project.create! permalink: normalized_path
     end
   end
 

--- a/spec/integration/catalog_import_spec.rb
+++ b/spec/integration/catalog_import_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe CatalogImport do
 
   before do
     Project.create! permalink: "clockwork"
+    Project.create! permalink: "swirrl/taskit"
     Project.create! permalink: "sidekiq"
   end
 
@@ -69,8 +70,8 @@ RSpec.describe CatalogImport do
       expect { import.perform }.to change { Category.find_by(permalink: obsolete_category.permalink) }.to(nil)
     end
 
-    it "creates all missing github-based projects" do
-      expect { import.perform }.to change(Project, :count).by(2)
+    it "creates missing github-based project" do
+      expect { import.perform }.to change(Project, :count).by(1)
     end
 
     it "results in expected set of projects" do


### PR DESCRIPTION
Minor oversight in #103 - the find or initialize obviously needs to also use the normalized github repo path.

In further cleanups, I also cleaned up all github-backed projects in the catalog that 404 when trying to fetch them in https://github.com/rubytoolbox/catalog/pull/26