### PR TITLE
Invite catalog contribution by adding a edit button to each category

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -36,4 +36,21 @@ class Category < ApplicationRecord
   def self.find_for_show!(permalink)
     includes(:category_group, projects: %i[rubygem github_repo]).find(permalink)
   end
+
+  CATALOG_GITHUB_BASE_URL = "https://github.com/rubytoolbox/catalog/"
+
+  def catalog_show_url
+    catalog_github_url
+  end
+
+  def catalog_edit_url
+    catalog_github_url edit: true
+  end
+
+  private
+
+  def catalog_github_url(edit: false)
+    type = edit ? "edit" : "tree"
+    File.join CATALOG_GITHUB_BASE_URL, type, "master/catalog", category_group.permalink, "#{permalink}.yml"
+  end
 end

--- a/app/views/categories/show.html.slim
+++ b/app/views/categories/show.html.slim
@@ -2,6 +2,10 @@
 
 .hero
   section.section: .container
+    .pull-right
+      a.button.is-light href=@category.catalog_edit_url
+        span.icon: i.fa.fa-edit
+        span Edit this category
     p.heading Category
     h2
       a href=category_path(@category)

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -3,14 +3,34 @@
 require "rails_helper"
 
 RSpec.describe Category, type: :model do
+  let(:group) do
+    CategoryGroup.create! permalink: "unimportant", name: "unimportant"
+  end
+  let(:category) do
+    Category.create! permalink: "mocking", name: "Mocking Frameworks", category_group: group
+  end
+
   describe ".search" do
     it "can find a matching category" do
-      group = CategoryGroup.create! permalink: "unimportant", name: "unimportant"
-      expected = Category.create! permalink: "mocking", name: "Mocking Frameworks", category_group: group
+      category
       Category.create! permalink: "foo", name: "Foo", category_group: group
       Category.create! permalink: "bar", name: "Bar", category_group: group
 
-      expect(Category.search("mock")).to be == [expected]
+      expect(Category.search("mock")).to be == [category]
+    end
+  end
+
+  describe "#catalog_show_url" do
+    it "is the url where the category definition can be seen on github" do
+      expected = "https://github.com/rubytoolbox/catalog/tree/master/catalog/unimportant/mocking.yml"
+      expect(category.catalog_show_url).to be == expected
+    end
+  end
+
+  describe "#catalog_edit_url" do
+    it "is the url where the category definition can be edited on github" do
+      expected = "https://github.com/rubytoolbox/catalog/edit/master/catalog/unimportant/mocking.yml"
+      expect(category.catalog_edit_url).to be == expected
     end
   end
 end


### PR DESCRIPTION
![bildschirmfoto vom 2018-01-30 23 26 45](https://user-images.githubusercontent.com/13972/35594890-0fbb6e6c-0615-11e8-83c0-cb5f57de3992.png)

This adds an edit button that links directly to that category's definition in the catalog on github.