### PR TITLE
Fix a minor glitch in metric row label positioning

### DIFF
--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -129,6 +129,7 @@ footer.footer
     .label
       @extend .column, .is-2-tablet, .is-12-mobile
       align-self: flex-end
+      margin-bottom: 0
 
     .metric
       @extend .column, .is-3-tablet, .is-6-mobile


### PR DESCRIPTION
This must have slipped in via a recent update of the bulma package. Notice how the "Popularity" label to the left is not vertically aligned with the numbers to the right.

## Before

![localhost_5000_categories_background_jobs](https://user-images.githubusercontent.com/13972/36506705-b2bac1aa-1757-11e8-8a07-cfeb2cdf3929.png)

## After

![localhost_5000_categories_background_jobs-fixed](https://user-images.githubusercontent.com/13972/36506706-b2d8808c-1757-11e8-8cd0-d40b19edae28.png)
