### PR TITLE
Convert primary keys to case-insensitive text where applicable

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -3,5 +3,6 @@
 class CategoriesController < ApplicationController
   def show
     @category = Category.find_for_show! params[:id]
+    redirect_to @category if @category.permalink != params[:id]
   end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -3,6 +3,6 @@
 class ProjectsController < ApplicationController
   def show
     @project = Project.find_for_show! params[:id]
-    redirect_to @project if @project.permalink != params[:id]
+    redirect_to "/projects/#{@project.permalink}" if @project.permalink != params[:id]
   end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -3,5 +3,6 @@
 class ProjectsController < ApplicationController
   def show
     @project = Project.find_for_show! params[:id]
+    redirect_to @project if @project.permalink != params[:id]
   end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -34,7 +34,7 @@ class Category < ApplicationRecord
   end
 
   def self.find_for_show!(permalink)
-    includes(:category_group, projects: %i[rubygem github_repo]).find(permalink)
+    includes(:category_group, projects: %i[rubygem github_repo]).find(permalink.try(:strip))
   end
 
   CATALOG_GITHUB_BASE_URL = "https://github.com/rubytoolbox/catalog/"

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -75,7 +75,7 @@ class Project < ApplicationRecord
            prefix: :github_repo
 
   def self.find_for_show!(permalink)
-    includes_associations.find(permalink)
+    includes_associations.find(Github.normalize_path(permalink))
   end
 
   def permalink=(permalink)

--- a/db/migrate/20180221214013_change_categories_and_github_repo_primary_keys_to_citext.rb
+++ b/db/migrate/20180221214013_change_categories_and_github_repo_primary_keys_to_citext.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class ChangeCategoriesAndGithubRepoPrimaryKeysToCitext < ActiveRecord::Migration[5.1]
+  def up
+    enable_extension "citext"
+
+    remove_foreign_key :categories, column: :category_group_permalink, primary_key: :permalink
+    remove_foreign_key :categorizations,
+                       column: :category_permalink,
+                       primary_key: :permalink
+
+    change_column :category_groups, :permalink, :citext, null: false
+
+    change_column :categories, :permalink, :citext, null: false
+    change_column :categories, :category_group_permalink, :citext, null: false
+
+    change_column :categorizations, :category_permalink, :citext, null: false
+
+    add_foreign_key :categories, :category_groups, column: :category_group_permalink, primary_key: :permalink
+    add_foreign_key :categorizations, :categories,
+                    column: :category_permalink,
+                    primary_key: :permalink
+
+    change_column :github_repos, :path, :citext, null: false
+    change_column :projects, :github_repo_path, :citext
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -20,6 +20,20 @@ COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
 
 
 --
+-- Name: citext; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS citext WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION citext; Type: COMMENT; Schema: -; Owner: -
+--
+
+COMMENT ON EXTENSION citext IS 'data type for case-insensitive character strings';
+
+
+--
 -- Name: pg_stat_statements; Type: EXTENSION; Schema: -; Owner: -
 --
 
@@ -98,12 +112,12 @@ CREATE TABLE ar_internal_metadata (
 --
 
 CREATE TABLE categories (
-    permalink character varying NOT NULL,
+    permalink citext NOT NULL,
     name character varying NOT NULL,
     description text,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    category_group_permalink character varying NOT NULL,
+    category_group_permalink citext NOT NULL,
     name_tsvector tsvector
 );
 
@@ -114,7 +128,7 @@ CREATE TABLE categories (
 
 CREATE TABLE categorizations (
     id bigint NOT NULL,
-    category_permalink character varying NOT NULL,
+    category_permalink citext NOT NULL,
     project_permalink character varying NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL
@@ -145,7 +159,7 @@ ALTER SEQUENCE categorizations_id_seq OWNED BY categorizations.id;
 --
 
 CREATE TABLE category_groups (
-    permalink character varying NOT NULL,
+    permalink citext NOT NULL,
     name character varying NOT NULL,
     description text,
     created_at timestamp without time zone NOT NULL,
@@ -158,7 +172,7 @@ CREATE TABLE category_groups (
 --
 
 CREATE TABLE github_repos (
-    path character varying NOT NULL,
+    path citext NOT NULL,
     stargazers_count integer NOT NULL,
     forks_count integer NOT NULL,
     watchers_count integer NOT NULL,
@@ -187,7 +201,7 @@ CREATE TABLE projects (
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     rubygem_name character varying,
-    github_repo_path character varying,
+    github_repo_path citext,
     score numeric(5,2),
     description text,
     permalink_tsvector tsvector,
@@ -430,6 +444,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180126213034'),
 ('20180126214714'),
 ('20180127203832'),
-('20180127211755');
+('20180127211755'),
+('20180221214013');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,6 +2,7 @@ SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
 SET client_min_messages = warning;
 
@@ -47,13 +48,11 @@ CREATE EXTENSION IF NOT EXISTS pg_stat_statements WITH SCHEMA public;
 COMMENT ON EXTENSION pg_stat_statements IS 'track execution statistics of all SQL statements executed';
 
 
-SET search_path = public, pg_catalog;
-
 --
 -- Name: categories_update_name_tsvector_trigger(); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION categories_update_name_tsvector_trigger() RETURNS trigger
+CREATE FUNCTION public.categories_update_name_tsvector_trigger() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 BEGIN
@@ -67,7 +66,7 @@ $$;
 -- Name: projects_update_description_tsvector_trigger(); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION projects_update_description_tsvector_trigger() RETURNS trigger
+CREATE FUNCTION public.projects_update_description_tsvector_trigger() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 BEGIN
@@ -81,7 +80,7 @@ $$;
 -- Name: projects_update_permalink_tsvector_trigger(); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION projects_update_permalink_tsvector_trigger() RETURNS trigger
+CREATE FUNCTION public.projects_update_permalink_tsvector_trigger() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 BEGIN
@@ -99,7 +98,7 @@ SET default_with_oids = false;
 -- Name: ar_internal_metadata; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
-CREATE TABLE ar_internal_metadata (
+CREATE TABLE public.ar_internal_metadata (
     key character varying NOT NULL,
     value character varying,
     created_at timestamp without time zone NOT NULL,
@@ -111,13 +110,13 @@ CREATE TABLE ar_internal_metadata (
 -- Name: categories; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
-CREATE TABLE categories (
-    permalink citext NOT NULL,
+CREATE TABLE public.categories (
+    permalink public.citext NOT NULL,
     name character varying NOT NULL,
     description text,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    category_group_permalink citext NOT NULL,
+    category_group_permalink public.citext NOT NULL,
     name_tsvector tsvector
 );
 
@@ -126,9 +125,9 @@ CREATE TABLE categories (
 -- Name: categorizations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
-CREATE TABLE categorizations (
+CREATE TABLE public.categorizations (
     id bigint NOT NULL,
-    category_permalink citext NOT NULL,
+    category_permalink public.citext NOT NULL,
     project_permalink character varying NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL
@@ -139,7 +138,7 @@ CREATE TABLE categorizations (
 -- Name: categorizations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE categorizations_id_seq
+CREATE SEQUENCE public.categorizations_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -151,15 +150,15 @@ CREATE SEQUENCE categorizations_id_seq
 -- Name: categorizations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE categorizations_id_seq OWNED BY categorizations.id;
+ALTER SEQUENCE public.categorizations_id_seq OWNED BY public.categorizations.id;
 
 
 --
 -- Name: category_groups; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
-CREATE TABLE category_groups (
-    permalink citext NOT NULL,
+CREATE TABLE public.category_groups (
+    permalink public.citext NOT NULL,
     name character varying NOT NULL,
     description text,
     created_at timestamp without time zone NOT NULL,
@@ -171,8 +170,8 @@ CREATE TABLE category_groups (
 -- Name: github_repos; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
-CREATE TABLE github_repos (
-    path citext NOT NULL,
+CREATE TABLE public.github_repos (
+    path public.citext NOT NULL,
     stargazers_count integer NOT NULL,
     forks_count integer NOT NULL,
     watchers_count integer NOT NULL,
@@ -196,12 +195,12 @@ CREATE TABLE github_repos (
 -- Name: projects; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
-CREATE TABLE projects (
+CREATE TABLE public.projects (
     permalink character varying NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     rubygem_name character varying,
-    github_repo_path citext,
+    github_repo_path public.citext,
     score numeric(5,2),
     description text,
     permalink_tsvector tsvector,
@@ -214,7 +213,7 @@ CREATE TABLE projects (
 -- Name: rubygems; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
-CREATE TABLE rubygems (
+CREATE TABLE public.rubygems (
     name character varying NOT NULL,
     downloads integer NOT NULL,
     current_version character varying NOT NULL,
@@ -241,7 +240,7 @@ CREATE TABLE rubygems (
 -- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
-CREATE TABLE schema_migrations (
+CREATE TABLE public.schema_migrations (
     version character varying NOT NULL
 );
 
@@ -250,14 +249,14 @@ CREATE TABLE schema_migrations (
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY categorizations ALTER COLUMN id SET DEFAULT nextval('categorizations_id_seq'::regclass);
+ALTER TABLE ONLY public.categorizations ALTER COLUMN id SET DEFAULT nextval('public.categorizations_id_seq'::regclass);
 
 
 --
 -- Name: ar_internal_metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
-ALTER TABLE ONLY ar_internal_metadata
+ALTER TABLE ONLY public.ar_internal_metadata
     ADD CONSTRAINT ar_internal_metadata_pkey PRIMARY KEY (key);
 
 
@@ -265,7 +264,7 @@ ALTER TABLE ONLY ar_internal_metadata
 -- Name: categorizations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
-ALTER TABLE ONLY categorizations
+ALTER TABLE ONLY public.categorizations
     ADD CONSTRAINT categorizations_pkey PRIMARY KEY (id);
 
 
@@ -273,7 +272,7 @@ ALTER TABLE ONLY categorizations
 -- Name: schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
-ALTER TABLE ONLY schema_migrations
+ALTER TABLE ONLY public.schema_migrations
     ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
 
 
@@ -281,144 +280,144 @@ ALTER TABLE ONLY schema_migrations
 -- Name: categorizations_unique_index; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
-CREATE UNIQUE INDEX categorizations_unique_index ON categorizations USING btree (category_permalink, project_permalink);
+CREATE UNIQUE INDEX categorizations_unique_index ON public.categorizations USING btree (category_permalink, project_permalink);
 
 
 --
 -- Name: index_categories_on_category_group_permalink; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
-CREATE INDEX index_categories_on_category_group_permalink ON categories USING btree (category_group_permalink);
+CREATE INDEX index_categories_on_category_group_permalink ON public.categories USING btree (category_group_permalink);
 
 
 --
 -- Name: index_categories_on_name_tsvector; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
-CREATE INDEX index_categories_on_name_tsvector ON categories USING gin (name_tsvector);
+CREATE INDEX index_categories_on_name_tsvector ON public.categories USING gin (name_tsvector);
 
 
 --
 -- Name: index_categories_on_permalink; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
-CREATE UNIQUE INDEX index_categories_on_permalink ON categories USING btree (permalink);
+CREATE UNIQUE INDEX index_categories_on_permalink ON public.categories USING btree (permalink);
 
 
 --
 -- Name: index_categorizations_on_category_permalink; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
-CREATE INDEX index_categorizations_on_category_permalink ON categorizations USING btree (category_permalink);
+CREATE INDEX index_categorizations_on_category_permalink ON public.categorizations USING btree (category_permalink);
 
 
 --
 -- Name: index_categorizations_on_project_permalink; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
-CREATE INDEX index_categorizations_on_project_permalink ON categorizations USING btree (project_permalink);
+CREATE INDEX index_categorizations_on_project_permalink ON public.categorizations USING btree (project_permalink);
 
 
 --
 -- Name: index_category_groups_on_permalink; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
-CREATE UNIQUE INDEX index_category_groups_on_permalink ON category_groups USING btree (permalink);
+CREATE UNIQUE INDEX index_category_groups_on_permalink ON public.category_groups USING btree (permalink);
 
 
 --
 -- Name: index_github_repos_on_path; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
-CREATE UNIQUE INDEX index_github_repos_on_path ON github_repos USING btree (path);
+CREATE UNIQUE INDEX index_github_repos_on_path ON public.github_repos USING btree (path);
 
 
 --
 -- Name: index_projects_on_description_tsvector; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
-CREATE INDEX index_projects_on_description_tsvector ON projects USING gin (description_tsvector);
+CREATE INDEX index_projects_on_description_tsvector ON public.projects USING gin (description_tsvector);
 
 
 --
 -- Name: index_projects_on_permalink; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
-CREATE UNIQUE INDEX index_projects_on_permalink ON projects USING btree (permalink);
+CREATE UNIQUE INDEX index_projects_on_permalink ON public.projects USING btree (permalink);
 
 
 --
 -- Name: index_projects_on_permalink_tsvector; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
-CREATE INDEX index_projects_on_permalink_tsvector ON projects USING gin (permalink_tsvector);
+CREATE INDEX index_projects_on_permalink_tsvector ON public.projects USING gin (permalink_tsvector);
 
 
 --
 -- Name: index_projects_on_rubygem_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
-CREATE UNIQUE INDEX index_projects_on_rubygem_name ON projects USING btree (rubygem_name);
+CREATE UNIQUE INDEX index_projects_on_rubygem_name ON public.projects USING btree (rubygem_name);
 
 
 --
 -- Name: index_rubygems_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
-CREATE UNIQUE INDEX index_rubygems_on_name ON rubygems USING btree (name);
+CREATE UNIQUE INDEX index_rubygems_on_name ON public.rubygems USING btree (name);
 
 
 --
 -- Name: categories_update_name_tsvector_trigger; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER categories_update_name_tsvector_trigger BEFORE INSERT OR UPDATE ON categories FOR EACH ROW EXECUTE PROCEDURE categories_update_name_tsvector_trigger();
+CREATE TRIGGER categories_update_name_tsvector_trigger BEFORE INSERT OR UPDATE ON public.categories FOR EACH ROW EXECUTE PROCEDURE public.categories_update_name_tsvector_trigger();
 
 
 --
 -- Name: projects_update_description_tsvector_trigger; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER projects_update_description_tsvector_trigger BEFORE INSERT OR UPDATE ON projects FOR EACH ROW EXECUTE PROCEDURE projects_update_description_tsvector_trigger();
+CREATE TRIGGER projects_update_description_tsvector_trigger BEFORE INSERT OR UPDATE ON public.projects FOR EACH ROW EXECUTE PROCEDURE public.projects_update_description_tsvector_trigger();
 
 
 --
 -- Name: projects_update_permalink_tsvector_trigger; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER projects_update_permalink_tsvector_trigger BEFORE INSERT OR UPDATE ON projects FOR EACH ROW EXECUTE PROCEDURE projects_update_permalink_tsvector_trigger();
+CREATE TRIGGER projects_update_permalink_tsvector_trigger BEFORE INSERT OR UPDATE ON public.projects FOR EACH ROW EXECUTE PROCEDURE public.projects_update_permalink_tsvector_trigger();
 
 
 --
 -- Name: fk_rails_1c87ed593b; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY categorizations
-    ADD CONSTRAINT fk_rails_1c87ed593b FOREIGN KEY (category_permalink) REFERENCES categories(permalink);
+ALTER TABLE ONLY public.categorizations
+    ADD CONSTRAINT fk_rails_1c87ed593b FOREIGN KEY (category_permalink) REFERENCES public.categories(permalink);
 
 
 --
 -- Name: fk_rails_2f82cbb022; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY categorizations
-    ADD CONSTRAINT fk_rails_2f82cbb022 FOREIGN KEY (project_permalink) REFERENCES projects(permalink);
+ALTER TABLE ONLY public.categorizations
+    ADD CONSTRAINT fk_rails_2f82cbb022 FOREIGN KEY (project_permalink) REFERENCES public.projects(permalink);
 
 
 --
 -- Name: fk_rails_4bd2d3273a; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY categories
-    ADD CONSTRAINT fk_rails_4bd2d3273a FOREIGN KEY (category_group_permalink) REFERENCES category_groups(permalink);
+ALTER TABLE ONLY public.categories
+    ADD CONSTRAINT fk_rails_4bd2d3273a FOREIGN KEY (category_group_permalink) REFERENCES public.category_groups(permalink);
 
 
 --
 -- Name: fk_rails_ddb4eb0108; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY projects
-    ADD CONSTRAINT fk_rails_ddb4eb0108 FOREIGN KEY (rubygem_name) REFERENCES rubygems(name);
+ALTER TABLE ONLY public.projects
+    ADD CONSTRAINT fk_rails_ddb4eb0108 FOREIGN KEY (rubygem_name) REFERENCES public.rubygems(name);
 
 
 --

--- a/spec/controllers/categories_controller_spec.rb
+++ b/spec/controllers/categories_controller_spec.rb
@@ -34,6 +34,15 @@ RSpec.describe CategoriesController, type: :controller do
         do_request
         expect(assigns(:category)).to be == category
       end
+
+      describe "case-sensitivity" do
+        ["CATegory", " catEGory "].each do |variant|
+          it "redirects to the correct variant if accessed via #{variant.inspect}" do
+            category
+            expect(get(:show, params: { id: variant })).to redirect_to(category_url("category"))
+          end
+        end
+      end
     end
   end
 end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe ProjectsController, type: :controller do
       end
 
       it "redirects to normalized path if accessed as 'Rails/Rails'" do
-        expect(do_request("Rails/Rails")).to redirect_to(project_url("rails/rails"))
+        expect(do_request("Rails/Rails")).to redirect_to("/projects/rails/rails")
       end
     end
   end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -33,5 +33,23 @@ RSpec.describe ProjectsController, type: :controller do
         expect(assigns(:project)).to be == project
       end
     end
+
+    describe "for known github project" do
+      def do_request(permalink)
+        get :show, params: { id: permalink }
+      end
+
+      before do
+        Project.create! permalink: "rails/rails"
+      end
+
+      it "responds with success when accessed with the 'correct' permalink" do
+        expect(do_request("rails/rails")).to have_http_status :success
+      end
+
+      it "redirects to normalized path if accessed as 'Rails/Rails'" do
+        expect(do_request("Rails/Rails")).to redirect_to(project_url("rails/rails"))
+      end
+    end
   end
 end


### PR DESCRIPTION
See also #146 and #104

- [x] When accessing a category with the "wrong" permalink, the controller should issue a 301 to the correct destination
- [x] Since projects have a "mixed" index of (case-sensitive) rubygems and insensitive github repos, the primary key cannot be switched there, so #104 needs special treatment

Once this is done, maybe all category permalinks in the catalog should be unified to lowercase writing