### PR TITLE
Show Category description

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -45,4 +45,8 @@ module ApplicationHelper
   def description
     content_for(:description).presence || t(:description)
   end
+
+  def category_description(category)
+    category.description || "No description yet"
+  end
 end

--- a/app/views/categories/show.html.slim
+++ b/app/views/categories/show.html.slim
@@ -10,6 +10,8 @@
     h2
       a href=category_path(@category)
         = @category.name
+    p.subtitle
+      = category_description(@category)
 
 section.section: .container: .columns
   .column.projects

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -53,4 +53,16 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(helper.description).to be == "Some other text"
     end
   end
+
+  describe "#category_description" do
+    it "returns a default for a Category without description" do
+      category = Category.new name: "Indescribable Category"
+      expect(helper.category_description(category)).to be == "No description yet"
+    end
+
+    it "returns a given description of a Category" do
+      category = Category.new name: "Described Category", description: "Some description"
+      expect(helper.category_description(category)).to be == "Some description"
+    end
+  end
 end


### PR DESCRIPTION
Fixes #115 and references #116 

I opted for the easy helper-method solution instead of defaulting the description via AR getter override as in
```ruby
def description
  self[:description] || "No description yet"
end
```
since it rightfully violated the CatalogImport spec and would consequently block any operations on Categories with empty description in the future 