### PR TITLE
Drop release announcement hero from startpage

### DIFF
--- a/app/views/welcome/home.html.slim
+++ b/app/views/welcome/home.html.slim
@@ -1,10 +1,11 @@
-.hero.is-medium
-  section.container.section.hero-body
-    .content.has-text-centered
-      h2 Welcome to the new Ruby Toolbox!
-      a.button.is-info.is-outlined href="/blog/2018-02-01/lets-push-things-forward"
-        span.icon: i.fa.fa-newspaper-o
-        span Read the announcement blog post
+- unless :time_for_announcements
+  .hero.is-medium
+    section.container.section.hero-body
+      .content.has-text-centered
+        h2 Welcome to the new Ruby Toolbox!
+        a.button.is-info.is-outlined href="/blog/2018-02-01/lets-push-things-forward"
+          span.icon: i.fa.fa-newspaper-o
+          span Read the announcement blog post
 
 .container
   section.section


### PR DESCRIPTION
Drops the welcome page blog post / release announcement added in #124, keeping the markup for possible future announcements :)