### PR TITLE
Further Github GraphQL integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Yarn is used to manage frontend dependencies for the project. It can be installe
 1. Install the project's dependencies by running `bundle install`
 1. Prepare the database with `rake db:setup` (**Note that this is currently semi-useful until [#147](https://github.com/rubytoolbox/rubytoolbox/issues/147) is fixed**)
 1. Install the frontend dependencies using `yarn install`
+1. In order to access the Github GraphQL API for pulling repo data, you need to [create a OAuth token as per Github's documentation](https://developer.github.com/v4/guides/forming-calls/#authenticating-with-graphql). No auth scopes are needed. Place the token as `GITHUB_TOKEN=yourtoken` in `.env.local` and `.env.local.test`.
 1. Run the services with `foreman start`. You can access the site at `http://localhost:5000`
 
 ### Further steps

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -56,6 +56,7 @@ module ApplicationHelper
   }.freeze
 
   def recent_distance_in_words(time)
+    return if time.blank?
     matching_distance = DISTANCES.find do |distance, _label|
       time >= distance.ago
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -45,8 +45,4 @@ module ApplicationHelper
   def description
     content_for(:description).presence || t(:description)
   end
-
-  def category_description(category)
-    category.description || "No description yet"
-  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -45,4 +45,21 @@ module ApplicationHelper
   def description
     content_for(:description).presence || t(:description)
   end
+
+  DISTANCES = {
+    1.week => "within last week",
+    2.weeks => "within last two weeks",
+    1.month => "within last month",
+    3.months => "within last 3 months",
+    1.year => "within last year",
+    2.years => "within last 2 years",
+  }.freeze
+
+  def recent_distance_in_words(time)
+    matching_distance = DISTANCES.find do |distance, _label|
+      time >= distance.ago
+    end
+
+    matching_distance&.last || "more than 2 years ago"
+  end
 end

--- a/app/models/github.rb
+++ b/app/models/github.rb
@@ -7,7 +7,7 @@ module Github
   def self.detect_repo_name(*urls)
     urls.map(&:presence).compact.each do |url|
       next unless ALLOWED_HOSTS.include? URI.parse(url).host
-      match = url.match %r{github\.com\/([^\/]+\/[^\/]+)}
+      match = url.match %r{github\.com\/([^\/]+\/[^\/\#]+)}
       return match[1] if match
     rescue URI::InvalidURIError
       next

--- a/app/models/github_repo.rb
+++ b/app/models/github_repo.rb
@@ -31,4 +31,19 @@ class GithubRepo < ApplicationRecord
   def wiki_url
     File.join(url, "wiki") if has_wiki?
   end
+
+  def issue_closure_rate
+    return if !has_issues? || [closed_issues_count, open_issues_count].any?(&:nil?)
+    (closed_issues_count * 100.0) / (open_issues_count + closed_issues_count)
+  end
+
+  def pull_request_acceptance_rate
+    return unless total_pull_requests
+    (merged_pull_requests_count * 100.0) / total_pull_requests
+  end
+
+  def total_pull_requests
+    return if [open_pull_requests_count, merged_pull_requests_count, closed_pull_requests_count].any?(&:nil?)
+    open_pull_requests_count + merged_pull_requests_count + closed_pull_requests_count
+  end
 end

--- a/app/models/github_repo.rb
+++ b/app/models/github_repo.rb
@@ -32,17 +32,22 @@ class GithubRepo < ApplicationRecord
     File.join(url, "wiki") if has_wiki?
   end
 
+  def total_issues_count
+    return if !has_issues? || [open_issues_count, closed_issues_count].any?(&:nil?)
+    closed_issues_count + open_issues_count
+  end
+
   def issue_closure_rate
-    return if !has_issues? || [closed_issues_count, open_issues_count].any?(&:nil?)
+    return if !has_issues? || total_issues_count.nil? || total_issues_count.zero?
     (closed_issues_count * 100.0) / (open_issues_count + closed_issues_count)
   end
 
   def pull_request_acceptance_rate
-    return unless total_pull_requests
-    (merged_pull_requests_count * 100.0) / total_pull_requests
+    return if total_pull_requests_count.nil? || total_pull_requests_count.zero?
+    (merged_pull_requests_count * 100.0) / total_pull_requests_count
   end
 
-  def total_pull_requests
+  def total_pull_requests_count
     return if [open_pull_requests_count, merged_pull_requests_count, closed_pull_requests_count].any?(&:nil?)
     open_pull_requests_count + merged_pull_requests_count + closed_pull_requests_count
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/ClassLength
 class Project < ApplicationRecord
   self.primary_key = :permalink
 
@@ -57,7 +58,9 @@ class Project < ApplicationRecord
            :changelog_url,
            :wiki_url,
            :bug_tracker_url,
+           :licenses,
            :url,
+           :reverse_dependencies_count,
            to: :rubygem,
            allow_nil: true,
            prefix: :rubygem
@@ -70,6 +73,20 @@ class Project < ApplicationRecord
            :wiki_url,
            :issues_url,
            :url,
+           :primary_language,
+           :has_issues,
+           :license,
+           :default_branch,
+           :is_fork,
+           :is_mirror,
+           :open_issues_count,
+           :closed_issues_count,
+           :issue_closure_rate,
+           :open_pull_requests_count,
+           :merged_pull_requests_count,
+           :closed_pull_requests_count,
+           :pull_request_acceptance_rate,
+           :average_recent_committed_at,
            to: :github_repo,
            allow_nil: true,
            prefix: :github_repo
@@ -110,3 +127,4 @@ class Project < ApplicationRecord
     rubygem_bug_tracker_url || github_repo_issues_url
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -82,6 +82,7 @@ class Project < ApplicationRecord
            :open_issues_count,
            :closed_issues_count,
            :issue_closure_rate,
+           :total_issues_count,
            :open_pull_requests_count,
            :merged_pull_requests_count,
            :closed_pull_requests_count,

--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -2,6 +2,7 @@
 
 class GithubClient
   class InvalidResponse < StandardError; end
+  class InvalidResponseStatus < StandardError; end
   class UnknownRepoError < StandardError; end
 
   REPOSITORY_QUERY_TEMPLATE = Tilt.new(Rails.root.join("app", "graphql-queries", "github", "repo.erb"))
@@ -49,6 +50,7 @@ class GithubClient
   end
 
   def handle_response(response)
+    raise InvalidResponseStatus, "status=#{response.status}" unless response.status == 200
     parsed_body = Oj.load(response.body)
     raise InvalidResponse, parsed_body["errors"].map { |e| e["message"] }.join(", ") if parsed_body["errors"]
     RepositoryData.new parsed_body

--- a/app/views/categories/show.html.slim
+++ b/app/views/categories/show.html.slim
@@ -11,7 +11,10 @@
       a href=category_path(@category)
         = @category.name
     p.subtitle
-      = category_description(@category)
+      - if @category.description.present?
+        = @category.description
+      - else
+        em This category does not have a description yet. You can <strong><a href="#{@category.catalog_edit_url}">add one on github</a></strong>!
 
 section.section: .container: .columns
   .column.projects

--- a/app/views/projects/_metric.html.slim
+++ b/app/views/projects/_metric.html.slim
@@ -5,7 +5,10 @@
         i.fa class="fa-#{icon}"
       span= label
     strong
-      - if value.kind_of? Integer
+      - if value.kind_of? Float
+        = number_with_delimiter value.floor
+        | %
+      - elsif value.kind_of? Integer
         = number_with_delimiter value
       - elsif value.kind_of? Date or value.kind_of? Time
         time datetime=value.iso8601 title=l(value)

--- a/app/views/projects/_metrics.html.slim
+++ b/app/views/projects/_metrics.html.slim
@@ -29,6 +29,7 @@
     .column: .metrics
       = metric "Open", project.github_repo_open_issues_count, icon: "bug"
       = metric "Closed", project.github_repo_closed_issues_count, icon: "check"
+      = metric "Total Issues", project.github_repo_total_issues_count, icon: "bug"
       = metric "Closure Rate", project.github_repo_issue_closure_rate, icon: "percent"
 
 - if project.github_repo_pull_request_acceptance_rate
@@ -53,4 +54,4 @@
       = metric "Primary Language", project.github_repo_primary_language, icon: "code"
       = metric "Licenses", project.rubygem_licenses.try(:to_sentence), icon: "legal"
       = metric "Recent Commit Activity", project.github_repo_average_recent_committed_at, icon: "industry"
-      = metric "Reverse Depencencies", project.rubygem_reverse_dependencies_count, icon: "industry"
+      = metric "Reverse Depencencies", project.rubygem_reverse_dependencies_count, icon: "compress"

--- a/app/views/projects/_metrics.html.slim
+++ b/app/views/projects/_metrics.html.slim
@@ -20,38 +20,43 @@
       = metric "Total releases", project.rubygem_releases_count, icon: "archive"
       = metric "First release", project.rubygem_first_release_on, icon: "file-o"
       = metric "Latest release", project.rubygem_latest_release_on, icon: "file-text-o"
-- if project.github_repo_issue_closure_rate
-  .metrics
-    .label
-      span &nbsp;
-      strong
-        | Issues
-    .column: .metrics
-      = metric "Open", project.github_repo_open_issues_count, icon: "bug"
-      = metric "Closed", project.github_repo_closed_issues_count, icon: "check"
-      = metric "Total Issues", project.github_repo_total_issues_count, icon: "bug"
-      = metric "Closure Rate", project.github_repo_issue_closure_rate, icon: "percent"
+- if local_assigns[:expanded_view]
+  - if project.github_repo_issue_closure_rate
+    .metrics
+      .label
+        span &nbsp;
+        strong
+          | Issues
+      .column: .metrics
+        = metric "Open", project.github_repo_open_issues_count, icon: "bug"
+        = metric "Closed", project.github_repo_closed_issues_count, icon: "check"
+        = metric "Total Issues", project.github_repo_total_issues_count, icon: "bug"
+        = metric "Closure Rate", project.github_repo_issue_closure_rate, icon: "percent"
 
-- if project.github_repo_pull_request_acceptance_rate
-  .metrics
-    .label
-      span &nbsp;
-      strong
-        | Pull Requests
-    .column: .metrics
-      = metric "Open", project.github_repo_open_pull_requests_count, icon: "code-fork"
-      = metric "Rejected", project.github_repo_closed_pull_requests_count, icon: "times"
-      = metric "Merged", project.github_repo_merged_pull_requests_count, icon: "check"
-      = metric "Acceptance Rate", project.github_repo_pull_request_acceptance_rate, icon: "percent"
+  - if project.github_repo_pull_request_acceptance_rate
+    .metrics
+      .label
+        span &nbsp;
+        strong
+          | Pull Requests
+      .column: .metrics
+        = metric "Open", project.github_repo_open_pull_requests_count, icon: "code-fork"
+        = metric "Rejected", project.github_repo_closed_pull_requests_count, icon: "times"
+        = metric "Merged", project.github_repo_merged_pull_requests_count, icon: "check"
+        = metric "Acceptance Rate", project.github_repo_pull_request_acceptance_rate, icon: "percent"
 
-- if project.github_repo_average_recent_committed_at
-  .metrics
-    .label
-      span &nbsp;
-      strong
-        | Development
-    .column: .metrics
-      = metric "Primary Language", project.github_repo_primary_language, icon: "code"
-      = metric "Licenses", project.rubygem_licenses.try(:to_sentence), icon: "legal"
-      = metric "Recent Commit Activity", project.github_repo_average_recent_committed_at, icon: "industry"
-      = metric "Reverse Depencencies", project.rubygem_reverse_dependencies_count, icon: "compress"
+  - if project.github_repo_average_recent_committed_at
+    .metrics
+      .label
+        span &nbsp;
+        strong
+          | Development
+      .column: .metrics
+        = metric "Primary Language", project.github_repo_primary_language, icon: "code"
+        = metric "Licenses", project.rubygem_licenses.try(:to_sentence), icon: "legal"
+        = metric "Recent Commit Activity", project.github_repo_average_recent_committed_at, icon: "industry"
+        = metric "Reverse Depencencies", project.rubygem_reverse_dependencies_count, icon: "compress"
+- else
+  .columns: .column.has-text-right: a.button.is-outlined href="/projects/#{project.permalink}"
+    span.icon: i.fa.fa-search
+    | &nbsp;Show more project details

--- a/app/views/projects/_metrics.html.slim
+++ b/app/views/projects/_metrics.html.slim
@@ -45,18 +45,28 @@
         = metric "Merged", project.github_repo_merged_pull_requests_count, icon: "check"
         = metric "Acceptance Rate", project.github_repo_pull_request_acceptance_rate, icon: "percent"
 
-  - if project.github_repo_average_recent_committed_at
-    .metrics
-      .label
-        span &nbsp;
-        strong
-          | Development
-      .column: .metrics
-        = metric "Primary Language", project.github_repo_primary_language, icon: "code"
-        = metric "Licenses", project.rubygem_licenses.try(:to_sentence), icon: "legal"
-        = metric "Averege date of last 50 commits", recent_distance_in_words(project.github_repo_average_recent_committed_at), icon: "link"
-        = metric "Reverse Depencencies", project.rubygem_reverse_dependencies_count, icon: "compress"
+  .metrics
+    .label
+      span &nbsp;
+      strong
+        | Development
+    .column: .metrics
+      = metric "Primary Language", project.github_repo_primary_language, icon: "code"
+      = metric "Licenses", project.rubygem_licenses.try(:to_sentence), icon: "legal"
+      = metric "Average date of last 50 commits", recent_distance_in_words(project.github_repo_average_recent_committed_at), icon: "link"
+      = metric "Reverse Depencencies", project.rubygem_reverse_dependencies_count, icon: "compress"
 - else
-  .columns: .column.has-text-right: a.button.is-outlined href="/projects/#{project.permalink}"
-    span.icon: i.fa.fa-search
-    | &nbsp;Show more project details
+  .metrics
+    .label
+      span &nbsp;
+      strong
+        | Activity
+    .column: .metrics
+      = metric "Issue Closure Rate", project.github_repo_issue_closure_rate, icon: "percent"
+      = metric "Pull Request Acceptance Rate", project.github_repo_pull_request_acceptance_rate, icon: "percent"
+      = metric "Average date of last 50 commits", recent_distance_in_words(project.github_repo_average_recent_committed_at), icon: "link"
+      = metric "Reverse Depencencies", project.rubygem_reverse_dependencies_count, icon: "compress"
+  .columns: .column.has-text-right
+    a.button.is-outlined href="/projects/#{project.permalink}"
+      span.icon: i.fa.fa-plus
+      | &nbsp;Show more project details

--- a/app/views/projects/_metrics.html.slim
+++ b/app/views/projects/_metrics.html.slim
@@ -20,3 +20,37 @@
       = metric "Total releases", project.rubygem_releases_count, icon: "archive"
       = metric "First release", project.rubygem_first_release_on, icon: "file-o"
       = metric "Latest release", project.rubygem_latest_release_on, icon: "file-text-o"
+- if project.github_repo_issue_closure_rate
+  .metrics
+    .label
+      span &nbsp;
+      strong
+        | Issues
+    .column: .metrics
+      = metric "Open", project.github_repo_open_issues_count, icon: "bug"
+      = metric "Closed", project.github_repo_closed_issues_count, icon: "check"
+      = metric "Closure Rate", project.github_repo_issue_closure_rate, icon: "percent"
+
+- if project.github_repo_pull_request_acceptance_rate
+  .metrics
+    .label
+      span &nbsp;
+      strong
+        | Pull Requests
+    .column: .metrics
+      = metric "Open", project.github_repo_open_pull_requests_count, icon: "code-fork"
+      = metric "Rejected", project.github_repo_closed_pull_requests_count, icon: "times"
+      = metric "Merged", project.github_repo_merged_pull_requests_count, icon: "check"
+      = metric "Acceptance Rate", project.github_repo_pull_request_acceptance_rate, icon: "percent"
+
+- if project.github_repo_average_recent_committed_at
+  .metrics
+    .label
+      span &nbsp;
+      strong
+        | Development
+    .column: .metrics
+      = metric "Primary Language", project.github_repo_primary_language, icon: "code"
+      = metric "Licenses", project.rubygem_licenses.try(:to_sentence), icon: "legal"
+      = metric "Recent Commit Activity", project.github_repo_average_recent_committed_at, icon: "industry"
+      = metric "Reverse Depencencies", project.rubygem_reverse_dependencies_count, icon: "industry"

--- a/app/views/projects/_metrics.html.slim
+++ b/app/views/projects/_metrics.html.slim
@@ -54,7 +54,7 @@
       .column: .metrics
         = metric "Primary Language", project.github_repo_primary_language, icon: "code"
         = metric "Licenses", project.rubygem_licenses.try(:to_sentence), icon: "legal"
-        = metric "Recent Commit Activity", project.github_repo_average_recent_committed_at, icon: "industry"
+        = metric "Averege date of last 50 commits", recent_distance_in_words(project.github_repo_average_recent_committed_at), icon: "link"
         = metric "Reverse Depencencies", project.rubygem_reverse_dependencies_count, icon: "compress"
 - else
   .columns: .column.has-text-right: a.button.is-outlined href="/projects/#{project.permalink}"

--- a/app/views/projects/show.html.slim
+++ b/app/views/projects/show.html.slim
@@ -29,4 +29,4 @@
   .columns: .description.column= @project.description
 
 section.section: .container: .project
-  = render partial: "projects/metrics", locals: { project: @project }
+  = render partial: "projects/metrics", locals: { project: @project, expanded_view: true }

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -53,4 +53,28 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(helper.description).to be == "Some other text"
     end
   end
+
+  describe "#recent_distance_in_words" do
+    {
+      3.days => "within last week",
+      6.days => "within last week",
+      7.days - 2.seconds => "within last week",
+      7.days => "within last two weeks",
+      14.days - 2.seconds => "within last two weeks",
+      15.days => "within last month",
+      1.month - 2.seconds => "within last month",
+      1.month => "within last 3 months",
+      3.months - 2.seconds => "within last 3 months",
+      3.months => "within last year",
+      1.year - 2.seconds => "within last year",
+      1.year => "within last 2 years",
+      2.years - 2.seconds => "within last 2 years",
+      2.years => "more than 2 years ago",
+      10.years => "more than 2 years ago",
+    }.each do |time, expected_result|
+      it "is #{expected_result.inspect} for #{time.ago.inspect}" do
+        expect(helper.recent_distance_in_words(time.ago)).to be == expected_result
+      end
+    end
+  end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -71,9 +71,12 @@ RSpec.describe ApplicationHelper, type: :helper do
       2.years - 2.seconds => "within last 2 years",
       2.years => "more than 2 years ago",
       10.years => "more than 2 years ago",
+      nil => nil,
+      "" => nil,
+      " " => nil,
     }.each do |time, expected_result|
-      it "is #{expected_result.inspect} for #{time.ago.inspect}" do
-        expect(helper.recent_distance_in_words(time.ago)).to be == expected_result
+      it "is #{expected_result.inspect} for #{time.try(:ago).inspect}" do
+        expect(helper.recent_distance_in_words(time.try(:ago))).to be == expected_result
       end
     end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -53,16 +53,4 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(helper.description).to be == "Some other text"
     end
   end
-
-  describe "#category_description" do
-    it "returns a default for a Category without description" do
-      category = Category.new name: "Indescribable Category"
-      expect(helper.category_description(category)).to be == "No description yet"
-    end
-
-    it "returns a given description of a Category" do
-      category = Category.new name: "Described Category", description: "Some description"
-      expect(helper.category_description(category)).to be == "Some description"
-    end
-  end
 end

--- a/spec/models/github_repo_spec.rb
+++ b/spec/models/github_repo_spec.rb
@@ -65,6 +65,29 @@ RSpec.describe GithubRepo, type: :model do
     end
   end
 
+  describe "#total_issues_count" do
+    it "is nil if the repo has no data" do
+      expect(described_class.new.total_issues_count).to be_nil
+    end
+
+    it "is nil if the repo has issues disabled" do
+      repo = described_class.new(
+        closed_issues_count: 10,
+        open_issues_count: 5
+      )
+      expect(repo.total_issues_count).to be_nil
+    end
+
+    it "is the sum of issues if issues enabled and data available" do
+      repo = described_class.new(
+        closed_issues_count: 10,
+        open_issues_count: 5,
+        has_issues: true
+      )
+      expect(repo.total_issues_count).to be == 10 + 5
+    end
+  end
+
   describe "#issue_closure_rate" do
     it "is nil if the repo has no data" do
       expect(described_class.new.issue_closure_rate).to be_nil
@@ -72,6 +95,10 @@ RSpec.describe GithubRepo, type: :model do
 
     it "is nil if the repo has data but issues are disabled" do
       expect(described_class.new(closed_issues_count: 10, open_issues_count: 5).issue_closure_rate).to be_nil
+    end
+
+    it "is nil if the repo had no issues" do
+      expect(described_class.new(closed_issues_count: 0, open_issues_count: 0).issue_closure_rate).to be_nil
     end
 
     it "is the expected float if the repo has data" do
@@ -85,6 +112,15 @@ RSpec.describe GithubRepo, type: :model do
       expect(described_class.new.pull_request_acceptance_rate).to be_nil
     end
 
+    it "is nil if the repo had no PRs" do
+      repo = described_class.new(
+        open_pull_requests_count: 0,
+        merged_pull_requests_count: 0,
+        closed_pull_requests_count: 0
+      )
+      expect(repo.pull_request_acceptance_rate).to be_nil
+    end
+
     it "is the expected float if the repo has PR data" do
       repo = described_class.new(
         open_pull_requests_count: 7,
@@ -95,9 +131,9 @@ RSpec.describe GithubRepo, type: :model do
     end
   end
 
-  describe "#total_pull_requests" do
+  describe "#total_pull_requests_count" do
     it "is nil if PR data is missing" do
-      expect(described_class.new.total_pull_requests).to be_nil
+      expect(described_class.new.total_pull_requests_count).to be_nil
     end
 
     it "is the sum of open, closed and merged PRs" do
@@ -106,7 +142,7 @@ RSpec.describe GithubRepo, type: :model do
         merged_pull_requests_count: 11,
         closed_pull_requests_count: 3
       )
-      expect(repo.total_pull_requests).to be == 7 + 11 + 3
+      expect(repo.total_pull_requests_count).to be == 7 + 11 + 3
     end
   end
 end

--- a/spec/models/github_repo_spec.rb
+++ b/spec/models/github_repo_spec.rb
@@ -64,4 +64,49 @@ RSpec.describe GithubRepo, type: :model do
       expect(described_class.new(path: "foo/bar", has_issues: true).issues_url).to be == expected_url
     end
   end
+
+  describe "#issue_closure_rate" do
+    it "is nil if the repo has no data" do
+      expect(described_class.new.issue_closure_rate).to be_nil
+    end
+
+    it "is nil if the repo has data but issues are disabled" do
+      expect(described_class.new(closed_issues_count: 10, open_issues_count: 5).issue_closure_rate).to be_nil
+    end
+
+    it "is the expected float if the repo has data" do
+      repo = described_class.new(has_issues: true, closed_issues_count: 10, open_issues_count: 5)
+      expect(repo.issue_closure_rate).to be == (10 * 100.0 / 15)
+    end
+  end
+
+  describe "#pull_request_acceptance_rate" do
+    it "is nil if PR data is missing" do
+      expect(described_class.new.pull_request_acceptance_rate).to be_nil
+    end
+
+    it "is the expected float if the repo has PR data" do
+      repo = described_class.new(
+        open_pull_requests_count: 7,
+        merged_pull_requests_count: 11,
+        closed_pull_requests_count: 3
+      )
+      expect(repo.pull_request_acceptance_rate).to be == (11 * 100.0) / (7 + 11 + 3)
+    end
+  end
+
+  describe "#total_pull_requests" do
+    it "is nil if PR data is missing" do
+      expect(described_class.new.total_pull_requests).to be_nil
+    end
+
+    it "is the sum of open, closed and merged PRs" do
+      repo = described_class.new(
+        open_pull_requests_count: 7,
+        merged_pull_requests_count: 11,
+        closed_pull_requests_count: 3
+      )
+      expect(repo.total_pull_requests).to be == 7 + 11 + 3
+    end
+  end
 end

--- a/spec/models/github_spec.rb
+++ b/spec/models/github_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Github, type: :model do
       [nil, "", "wat"] => nil,
       ["fakegithub.com/rails/rails"] => nil,
       ["http://github.com/{github_username}/{project_name}"] => nil,
+      ["http://github.com/foo/bar#readme"] => "foo/bar",
       ["http://github.com/rails/rails"] => "rails/rails",
       ["foobar", "http://github.com/rails/rails"] => "rails/rails",
     }.each do |args, expected_name|

--- a/spec/services/github_client_spec.rb
+++ b/spec/services/github_client_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe GithubClient do
+  let(:token) { "Hello World" }
+  let(:client) { described_class.new token: token }
+
+  it "raises an InvalidResponseStatus when the response has status 400" do
+    stub_request(:head, "https://github.com/rspec/rspec")
+      .to_return(status: 200)
+
+    stub_request(:post, "https://api.github.com/graphql")
+      .to_return(status: 400)
+
+    expect { client.fetch_repository("rspec/rspec") }.to raise_error(
+      described_class::InvalidResponseStatus, /status=400/
+    )
+  end
+end


### PR DESCRIPTION
Followup to #94 

- [x] Some gems apparently include anchors in their urls, which used to work fine with the existing github APIv3, but is now causing 404s, i.e. `mwpastore/rack-session-smart_cookie#readme`
- [x] Incorporate those new metrics into the UI
- [x] Add a description how to set up the, now required, github OAuth token
- [x] Sometimes, the graphql response ends up being `nil`, leading to `undefined method `dig' for nil:NilClass`s. Subsequent runs against the same URL pass - so error handling seems to be off
- [x] Aggregate metrics like issue_closure_rate or pr_acceptance_rate, possibly explicitly saved into the DB for further overall analytics