### PR TITLE
Respect linebreaks in gem descriptions

### DIFF
--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -51,6 +51,9 @@ $text: #222
 .border-bottom
   border-bottom: 1px solid $light
 
+.pre-wrap
+  white-space: pre-wrap
+
 header.section
   padding: 1.5rem
   @extend .border-bottom

--- a/app/views/projects/_project.html.slim
+++ b/app/views/projects/_project.html.slim
@@ -16,6 +16,6 @@
   .columns: .links.column
     = render partial: "projects/links", locals: { project: project }
 
-  .columns: .description.column= project.description
+  .columns: .description.pre-wrap.column= project.description
 
   = render partial: "projects/metrics", locals: { project: project }

--- a/app/views/projects/show.html.slim
+++ b/app/views/projects/show.html.slim
@@ -26,7 +26,7 @@
   .columns: .links.column
     = render partial: "projects/links", locals: { project: @project }
 
-  .columns: .description.column= @project.description
+  .columns: .description.pre-wrap.column= @project.description
 
 section.section: .container: .project
   = render partial: "projects/metrics", locals: { project: @project }


### PR DESCRIPTION
This adds a CSS rule to respect line breaks given in rubygem descriptions. I am not yet sure whether this is actually good, it depends very much on the way the description is written. Maybe it would also make sense to split this into ignoring linebreaks in list views like search / categories, and respecting white space in project detail view?

## Before

![www ruby-toolbox com_projects_rake](https://user-images.githubusercontent.com/13972/37806335-b00a9e7c-2e3f-11e8-80bf-d01b126cd550.png)
![www ruby-toolbox com_categories_daemonizing](https://user-images.githubusercontent.com/13972/37806338-b0435cbc-2e3f-11e8-93a3-db5b1a937627.png)

## After

![localhost_5000_projects_rake](https://user-images.githubusercontent.com/13972/37806334-afed2770-2e3f-11e8-9b6f-72d79a461936.png)
![localhost_5000_categories_daemonizing](https://user-images.githubusercontent.com/13972/37806337-b027c4ca-2e3f-11e8-83ea-182e38babc66.png)
