### PR TITLE
Metric Rankings

### DIFF
--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -139,6 +139,16 @@ footer.footer
         // Compensate for default icon padding in heading above
         margin-left: 5px
 
+      i.rank
+        margin-left: 5px
+        &.rank-1
+          transform: rotate(135deg)
+        &.rank-2
+          transform: rotate(90deg)
+        &.rank-3
+          transform: rotate(45deg)
+
+
 article.blog-post
   @extend .column, .content, .is-three-fifths-desktop, .is-offset-one-fifth-desktop
   font-size: 125%

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,12 +1,44 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
-  def metric(label, value, icon:)
-    render partial: "projects/metric", locals: { label: label, value: value, icon: icon }
+  def metric(label, value, icon:, name: nil)
+    render partial: "projects/metric", locals: { label: label, value: value, icon: icon, name: name }
   end
 
   def project_link(label, url, icon:)
     render partial: "projects/link", locals: { label: label, url: url, icon: icon }
+  end
+
+  def global_stats
+    @global_stats ||= GlobalStats.new
+  end
+
+  def rank(metric:, value:)
+    return unless metric
+    rank = global_stats.rank metric, value
+    return unless rank
+    content_tag "i", "", class: "fa #{rank_icon(rank)} rank rank-#{rank}", title: rank_tooltip(rank)
+  end
+
+  def rank_icon(rank)
+    case rank
+    when 5
+      "fa-angle-double-up"
+    else
+      "fa-caret-up"
+    end
+  end
+
+  RANK_LABELS = {
+    1 => "Lower half of all projects",
+    2 => "Upper half of all projects",
+    3 => "Upper quarter of all projects",
+    4 => "Top 5% of all projects",
+    5 => "Top 1% of all projects",
+  }.freeze
+
+  def rank_tooltip(rank)
+    RANK_LABELS[rank]
   end
 
   # why

--- a/app/models/global_stats.rb
+++ b/app/models/global_stats.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class GlobalStats
+  QUANTILES = [0.0, 0.5, 0.75, 0.95, 0.99].sort.freeze
+
+  # To be replaced in real-life with
+  #
+  # * Periodical task that calculates and caches the data
+  # * Quick retrieval of the pre-calculated data from redis or pg
+  # * Static buckets shall probably remain to ease tests
+  #
+  STATIC_BUCKETS = {
+    rubygem_downloads: [0, 5000, 10_000, 75_000, 1_250_000],
+    github_repo_stargazers_count: [0, 2, 7, 102, 772],
+    github_repo_forks_count: [0, 0, 2, 21, 127],
+    github_repo_watchers_count: [0, 1, 3, 21, 75],
+  }.freeze
+
+  attr_accessor :buckets
+  private :buckets, :buckets=
+
+  def initialize(buckets: STATIC_BUCKETS)
+    self.buckets = buckets
+  end
+
+  def rank(metric, value)
+    metric_buckets = buckets[metric.to_sym]
+    return unless metric_buckets
+    (metric_buckets.reverse.index { |minimum| value >= minimum } - 5) * -1
+  end
+end

--- a/app/views/projects/_metric.html.slim
+++ b/app/views/projects/_metric.html.slim
@@ -15,3 +15,4 @@
           = "#{time_ago_in_words(value)} ago"
       - else
         = value
+      = rank metric: name, value: value

--- a/app/views/projects/_metrics.html.slim
+++ b/app/views/projects/_metrics.html.slim
@@ -4,10 +4,10 @@
     strong
       | Popularity
   .column: .metrics
-    = metric "Downloads", project.rubygem_downloads, icon: "download"
-    = metric "Stars", project.github_repo_stargazers_count, icon: "star"
-    = metric "Forks", project.github_repo_forks_count, icon: "code-fork"
-    = metric "Watchers", project.github_repo_watchers_count, icon: "eye"
+    = metric "Downloads", project.rubygem_downloads, icon: "download", name: :rubygem_downloads
+    = metric "Stars", project.github_repo_stargazers_count, icon: "star", name: :github_repo_stargazers_count
+    = metric "Forks", project.github_repo_forks_count, icon: "code-fork", name: :github_repo_forks_count
+    = metric "Watchers", project.github_repo_watchers_count, icon: "eye", name: :github_repo_watchers_count
 
 - if project.rubygem_releases_count
   .metrics
@@ -18,7 +18,7 @@
     .column: .metrics
       = metric "Current version", project.rubygem_current_version, icon: "diamond"
       = metric "Total releases", project.rubygem_releases_count, icon: "archive"
-      = metric "First release", project.rubygem_first_release_on, icon: "file-o"
+      = metric "First release", project.rubygem_first_release_on, icon: "file-o", name: :rubygem_first_release_on
       = metric "Latest release", project.rubygem_latest_release_on, icon: "file-text-o"
 - if local_assigns[:expanded_view]
   - if project.github_repo_issue_closure_rate

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -80,4 +80,47 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
   end
+
+  describe "#global_stats" do
+    it "returns a GlobalStats instance" do
+      expect(helper.global_stats).to be_a GlobalStats
+    end
+
+    it "memoizes the instance" do
+      expect(helper.global_stats.object_id).to be == helper.global_stats.object_id
+    end
+  end
+
+  describe "#rank" do
+    it "renders an icon for the given rank" do
+      expected = "<i class=\"fa fa-caret-up rank rank-2\" title=\"Upper half of all projects\"></i>"
+      expect(helper.rank(metric: :rubygem_downloads, value: 5000)).to be == expected
+    end
+  end
+
+  describe "#rank_icon" do
+    it "is 'fa-angle-double-up' when rank is 5" do
+      expect(helper.rank_icon(5)).to be == "fa-angle-double-up"
+    end
+
+    it "is 'fa-caret-up' when rank is below 5" do
+      expect(helper.rank_icon(rand(5))).to be == "fa-caret-up"
+    end
+  end
+
+  describe "#rank_tooltip" do
+    {
+      nil => nil,
+      "" => nil,
+      1 => "Lower half of all projects",
+      2 => "Upper half of all projects",
+      3 => "Upper quarter of all projects",
+      4 => "Top 5% of all projects",
+      5 => "Top 1% of all projects",
+    }.each do |rank, expected_label|
+      it "returns #{expected_label.inspect} for rank #{rank}" do
+        expect(helper.rank_tooltip(rank)).to be == expected_label
+      end
+    end
+  end
 end

--- a/spec/models/global_stats_spec.rb
+++ b/spec/models/global_stats_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe GlobalStats, type: :model do
+  let(:stats) { described_class.new }
+
+  describe "#rank" do
+    it "is nil for unknown metric" do
+      expect(stats.rank(:widget_count, 0)).to be nil
+    end
+
+    it "is 1 when value is 0 in bottom bucket" do
+      expect(stats.rank(:rubygem_downloads, 0)).to be == 1
+    end
+
+    it "is 2 when value falls in second bucket" do
+      expect(stats.rank(:rubygem_downloads, 7500)).to be == 2
+    end
+
+    it "is 3 when value falls in third bucket" do
+      expect(stats.rank(:rubygem_downloads, 25_000)).to be == 3
+    end
+
+    it "is 4 when value falls in fourth bucket" do
+      expect(stats.rank(:rubygem_downloads, 100_000)).to be == 4
+    end
+
+    it "is 5 when value falls in top group for given metric" do
+      expect(stats.rank(:rubygem_downloads, 1_250_001)).to be == 5
+    end
+  end
+end


### PR DESCRIPTION
**tl;dr: I want to add annotations to all metrics visible on the site to give a bit of perspective where the given value for the project you're looking at stands in the grander scheme of the ruby ecosystem and need your feedback :heart:**

---

Current state on master:

![www ruby-toolbox com_categories_background_jobs 1](https://user-images.githubusercontent.com/13972/41940554-608f9910-7999-11e8-98cd-9b2436ae6afa.png)

After this change:

![localhost_5000_categories_background_jobs](https://user-images.githubusercontent.com/13972/41939756-fe82ccb2-7996-11e8-9d0c-db499693d09c.png)

Fetching this kind of data is fairly straightforward using postgres percentile functions, like so:

```sql
SELECT unnest(percentile_disc(array[0.1, 0.25, 0.5, 0.75, 0.85, 0.95, 0.99, 1.0])
       WITHIN GROUP (ORDER BY downloads ASC))
   FROM rubygems;
```

While I did some db-backed prototyping I opted to for now go with hard-coded values to first discuss and decide upon some UI/UX headaches this has been giving me.

For now I'm focussing only on the "top row" of project metrics. Later down the road I'd like to expand this:

* Use it for all metrics (including the date ones, i.e. first gem release date etc)
* Add detailed explanation pages upon click on a metric: Showing a distribution graph for the metric, maybe an explanation as to why this metric is interesting when rating a project, and, i.e., the top 100 projects in that measurement

But, here's the current challenges:

## The numbers

To give some background, here's a little breakdown of the distribution of the numbers for the 4 metrics under discussion here:

|      | Gem Downloads | Stargazers | Forks | Watchers | 
|------|---------------|------------|-------|----------| 
| 10%  | 1101          | 0          | 0     | 1        | 
| 25%  | 1926          | 0          | 0     | 1        | 
| 50%  | 3981          | 2          | 0     | 1        | 
| 75%  | 10300         | 7          | 2     | 3        | 
| 85%  | 18807         | 18         | 5     | 6        | 
| 95%  | 79188         | 103        | 21    | 21       | 
| 99%  | 1486655       | 782        | 129   | 76       | 
| 100% | 250153777     | 104573     | 18091 | 6054     | 

As you can see easily, the gap to the absolute top projects is very large, then there is a top 1-10% of projects, and bascially everything else has very similar numbers.

This makes it pretty hard to find meaningful "buckets" to display on the site. I picked the following buckets for display, this is absolutely up for discussion though: `0.5, 0.75, 0.95, 0.99`

Secondly, I find it tough to display this on the site in a clear yet unobtrusive way. I went with arrow-icons and tool-tips, but particularly because of the "top-heavy" buckets I picked, this is somewhat nonsensical:

![bildschirmfoto vom 2018-06-26 22 40 00](https://user-images.githubusercontent.com/13972/41939743-f6ec3646-7996-11e8-94c4-e8032c82b91d.png)
![bildschirmfoto vom 2018-06-26 22 40 07](https://user-images.githubusercontent.com/13972/41939744-f708f038-7996-11e8-81a1-2277c5d4404b.png)

Maybe a "school grades" ranking system, and/or color coding would work better? With school grades we have the issue that the systems vary vastly across the world. I think color coded indicators might be more clearly distinguishable at a glance, but those are hard to get right with regard to color blind people.

As an additional thought, I don't want to discourage the majority of gem owners whose projects don't "belong to the top 1%" by only showing "negative" indicators. This might be alleviated a bit once other metrics like issue closure rate etc. become part of this, but it's something I'm also trying to pay attention to.

---

So, long story short: I would appreciate your feedback on those two questions:

* Based on the data shown above, what percentile buckets should we pick?
* How can we best display this data in a clear, unobtrusive way within the project view?

Thanks :)