### PR TITLE
Ignore common exceptions from showing up in appsignal

### DIFF
--- a/config/appsignal.yml
+++ b/config/appsignal.yml
@@ -1,0 +1,21 @@
+#
+# To get Appsignal running, remember to:
+#
+#   * Set the APPSIGNAL_PUSH_API_KEY env variable
+#   * Set up the deploy hook, i.e. via https://devcenter.heroku.com/articles/appsignal#add-a-deploy-hook-in-heroku
+#
+# See https://docs.appsignal.com/ruby/configuration/
+default: &defaults
+  # It's easier to set this once and for all here instead of remembering
+  # to set the env variable APPSIGNAL_APP_NAME on every deployment env
+  name: Ruby Toolbox
+  # See https://docs.appsignal.com/ruby/configuration/ignore-errors.html
+  # Prevent exceptions that happen in normal operation from showing up
+  # in appsignal error reporting
+  ignore_errors:
+    - ActiveRecord::RecordNotFound
+
+development:
+  <<: *defaults
+production:
+  <<: *defaults


### PR DESCRIPTION
There's a few legacy routes for projects and quite frequently some weird invalid permalinks coming in from crawlers etc, and they always cause an exception notification on appsignal. Since the `ActiveRecord::RecordNotFound` is used for regular 404 triggering, this does not represent an exceptional situation and should just be handled gracefully - hence, we ignore it.

This also adds the default app name for appsignal to the yml config, which makes it one less thing to configure when setting up a new deployment.