### PR TITLE
Fix common github sync issues

### DIFF
--- a/app/models/github.rb
+++ b/app/models/github.rb
@@ -7,8 +7,8 @@ module Github
   def self.detect_repo_name(*urls)
     urls.map(&:presence).compact.each do |url|
       next unless ALLOWED_HOSTS.include? URI.parse(url).host
-      match = url.match %r{github\.com\/([^\/]+\/[^\/\#\.]+)}
-      return match[1] if match
+      match = url.match %r{github\.com\/([^\/]+\/[^\/\#]+)}
+      return match[1].gsub(/\.git\Z/, "") if match
     rescue URI::InvalidURIError
       next
     end

--- a/app/models/github.rb
+++ b/app/models/github.rb
@@ -7,7 +7,7 @@ module Github
   def self.detect_repo_name(*urls)
     urls.map(&:presence).compact.each do |url|
       next unless ALLOWED_HOSTS.include? URI.parse(url).host
-      match = url.match %r{github\.com\/([^\/]+\/[^\/\#]+)}
+      match = url.match %r{github\.com\/([^\/]+\/[^\/\#\.]+)}
       return match[1] if match
     rescue URI::InvalidURIError
       next

--- a/app/models/github_ignore.rb
+++ b/app/models/github_ignore.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class GithubIgnore < ApplicationRecord
+  self.primary_key = :path
+
+  def self.track!(path)
+    find_or_create_by! path: path
+  end
+
+  def self.ignored?(path)
+    !where(path: path).count.zero?
+  end
+
+  def self.expire!(timeframe: 14.days)
+    where("created_at < ?", timeframe.ago).destroy_all
+  end
+end

--- a/app/services/cron.rb
+++ b/app/services/cron.rb
@@ -7,13 +7,14 @@
 #
 class Cron
   def run(time: Time.current.utc)
-    RemoteUpdateSchedulerJob.perform_async
-    CatalogImportJob.perform_async
-
     case time.hour
     when 0
       RubygemsSyncJob.perform_async
     end
+
+    RemoteUpdateSchedulerJob.perform_async
+    CatalogImportJob.perform_async
+    GithubIgnore.expire!
   rescue StandardError => err
     Appsignal.set_error err
     raise err

--- a/app/services/github_client/repository_data.rb
+++ b/app/services/github_client/repository_data.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class GithubClient
+  # Please write unit tests for me...
   class RepositoryData
     attr_accessor :raw_data
     private :raw_data=
@@ -95,6 +96,8 @@ class GithubClient
 
     def average_recent_committed_at
       edges = raw_data.dig("defaultBranchRef", "target", "history", "edges")
+      # Yip, sometimes published gems reference an empty github repo
+      return unless edges
       dates = edges.map { |edge| Time.zone.parse edge.dig("node", "authoredDate") }
       Time.zone.at dates.map(&:to_i).sum / dates.count
     end

--- a/db/migrate/20180718195202_create_github_ignores.rb
+++ b/db/migrate/20180718195202_create_github_ignores.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateGithubIgnores < ActiveRecord::Migration[5.2]
+  def change
+    create_table :github_ignores, id: false do |t|
+      t.string :path, null: false
+      t.timestamps
+    end
+
+    add_index :github_ignores, :path, unique: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -167,6 +167,17 @@ CREATE TABLE public.category_groups (
 
 
 --
+-- Name: github_ignores; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE public.github_ignores (
+    path character varying NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
 -- Name: github_repos; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -333,6 +344,13 @@ CREATE UNIQUE INDEX index_category_groups_on_permalink ON public.category_groups
 
 
 --
+-- Name: index_github_ignores_on_path; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE UNIQUE INDEX index_github_ignores_on_path ON public.github_ignores USING btree (path);
+
+
+--
 -- Name: index_github_repos_on_path; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -453,6 +471,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180127211755'),
 ('20180221214013'),
 ('20180322231205'),
-('20180322231848');
+('20180322231848'),
+('20180718195202');
 
 

--- a/spec/models/github_ignore_spec.rb
+++ b/spec/models/github_ignore_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe GithubIgnore, type: :model do
+  let(:path) { "foo/bar" }
+
+  describe ".track!" do
+    it "creates a tracking record" do
+      expect { described_class.track! path }
+        .to change { described_class.where(path: path).count }
+        .from(0)
+        .to(1)
+    end
+
+    it "does not create a duplicate tracking record" do
+      described_class.track! path
+      expect { described_class.track! path }
+        .not_to change { described_class.where(path: path).count }
+        .from(1)
+    end
+  end
+
+  describe ".ignored?" do
+    it "is false when not ignored" do
+      expect(described_class.ignored?(path)).to be false
+    end
+
+    it "is true when ignored" do
+      described_class.track! path
+      expect(described_class.ignored?(path)).to be true
+    end
+  end
+
+  describe ".expire!" do
+    before do
+      described_class.track! path
+      described_class.find(path).update! created_at: 14.days.ago - 1
+      described_class.track! "other/repo"
+      described_class.find("other/repo").update! created_at: 14.days.ago + 1
+    end
+
+    it "removes any records that have been created more than 14 days ago" do
+      expect { described_class.expire! }
+        .to change(described_class, :count)
+        .from(2)
+        .to(1)
+    end
+
+    it "allows to specify a custom timeframe" do
+      expect { described_class.expire! timeframe: 13.days }
+        .to change(described_class, :count)
+        .from(2)
+        .to(0)
+    end
+  end
+end

--- a/spec/models/github_spec.rb
+++ b/spec/models/github_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Github, type: :model do
       ["http://github.com/foo/bar#readme"] => "foo/bar",
       ["http://github.com/rails/rails"] => "rails/rails",
       ["http://github.com/rails/rails.git"] => "rails/rails",
+      ["http://github.com/rails/rails.allowed"] => "rails/rails.allowed",
       ["foobar", "http://github.com/rails/rails"] => "rails/rails",
     }.each do |args, expected_name|
       it "is #{expected_name.inspect} when given #{args.inspect}" do

--- a/spec/models/github_spec.rb
+++ b/spec/models/github_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Github, type: :model do
       ["http://github.com/{github_username}/{project_name}"] => nil,
       ["http://github.com/foo/bar#readme"] => "foo/bar",
       ["http://github.com/rails/rails"] => "rails/rails",
+      ["http://github.com/rails/rails.git"] => "rails/rails",
       ["foobar", "http://github.com/rails/rails"] => "rails/rails",
     }.each do |args, expected_name|
       it "is #{expected_name.inspect} when given #{args.inspect}" do

--- a/spec/services/cron_spec.rb
+++ b/spec/services/cron_spec.rb
@@ -19,6 +19,11 @@ RSpec.describe Cron, type: :service do
     cron.run time: time_at(rand(24))
   end
 
+  it "invokes GithubIgnore.expire every hour" do
+    expect(GithubIgnore).to receive(:expire!)
+    cron.run time: time_at(rand(24))
+  end
+
   it "enqueues RubygemsSyncJob at 0 am" do
     expect(RubygemsSyncJob).to receive(:perform_async)
     cron.run time: time_at(0)


### PR DESCRIPTION
Following on #245 this deals with a bunch of common issues when syncing repos from github based on the repo reference found in the rubygem links:

* Sometimes the reference has `.git` appended, which leads to a bunch of interesting problems in [conjunction with Githubs GraphQL API](https://platform.github.community/t/repository-redirects-in-api-v4-graphql/4417)
* Some repos are plain and simply gone without any futher notice
* Some repos are referenced from a gem, yet empty

Most notably, for 100% gone 404 repos this puts the repo on an ignore list for 2 weeks, ensuring that it will not pollute github with unneccessary requests. It also drops the `.git` part at the end of detected repo urls, and ensures the sync does not crash if there are no commits on the repo at all.

I could not find info on allowed characters in repo names on github, so I assume `.` is permitted, hence it's only restricting the `.git` ending