### PR TITLE
Index gems with only pre-release versions as well

### DIFF
--- a/app/jobs/rubygems_sync_job.rb
+++ b/app/jobs/rubygems_sync_job.rb
@@ -24,9 +24,23 @@ class RubygemsSyncJob < ApplicationJob
     @local_gems ||= Rubygem.pluck(:name)
   end
 
+  # Very similar code is also used in https://github.com/rubytoolbox/catalog/blob/master/spec/catalog_spec.rb#L40-L70
+  # it might make sense to extract this into a tiny shared library to avoid
+  # drift between the logic
   def remote_gems
-    @remote_gems ||= ::Gem::Source.new("https://rubygems.org")
-                                  .load_specs(:latest)
-                                  .map(&:name)
+    @remote_gems ||= published_gems | prerelease_gems
+  end
+
+  def published_gems
+    @published_gems ||= ::Gem::Source.new("https://rubygems.org")
+                                     .load_specs(:latest)
+                                     .map(&:name)
+  end
+
+  def prerelease_gems
+    @prerelease_gems ||= ::Gem::Source.new("https://rubygems.org")
+                                      .load_specs(:prerelease)
+                                      .map(&:name)
+                                      .uniq
   end
 end


### PR DESCRIPTION
Based on my finding noted in https://github.com/rubytoolbox/catalog/pull/165

The way ruby toolbox was fetching the remote gem specs so far had a blind spot: Gems that have only prerelease versions available were not indexed. This PR changes that, so a whole bunch of gems that have not been available on the toolbox should start showing up after this is merged and deployed.