### PR TITLE
Database Exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Yarn is used to manage frontend dependencies for the project. It can be installe
 
 1. Start postgres and redis
 1. Install the project's dependencies by running `bundle install`
-1. Prepare the database with `rake db:setup` (**Note that this is currently semi-useful until [#147](https://github.com/rubytoolbox/rubytoolbox/issues/147) is fixed**)
+1. Prepare the database with `rake db:setup`
+1. *Optional but recommended*: Import a [production database dump](https://data.ruby-toolbox.com) using `bin/pull_database`
 1. Install the frontend dependencies using `yarn install`
 1. In order to access the Github GraphQL API for pulling repo data, you need to [create a OAuth token as per Github's documentation](https://developer.github.com/v4/guides/forming-calls/#authenticating-with-graphql). No auth scopes are needed. Place the token as `GITHUB_TOKEN=yourtoken` in `.env.local` and `.env.local.test`.
 1. Run the services with `foreman start`. You can access the site at `http://localhost:5000`

--- a/bin/pull_database
+++ b/bin/pull_database
@@ -1,0 +1,45 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+APP_PATH = File.expand_path("../config/application", __dir__)
+require_relative "../config/environment"
+
+#
+# This script would likely appreciate to be moved to some proper, tested code
+#
+
+require "open-uri"
+
+puts "== Fetching public database snapshots =="
+backups = Oj.load open("https://data.ruby-toolbox.com/backups.json")
+most_recent_download_url = backups.first["download_url"]
+
+puts "Most recent database dump available is from #{backups.first["created_at"]}"
+
+Dir.mktmpdir do |dir|
+  destination = File.join dir, "rubytoolbox.dump"
+
+  puts "Downloading dump to #{destination}"
+
+  download = open most_recent_download_url
+
+  File.open destination, "w+" do |file|
+    IO.copy_stream download, file
+  end
+
+  puts "Dump downloaded successfully"
+
+  target_database = ApplicationRecord.configurations[Rails.env]["database"]
+
+  puts "== Running pg_restore against #{target_database}"
+
+  result = system "pg_restore --clean --create --no-owner --dbname=#{Shellwords.escape(target_database)} #{Shellwords.escape(destination)}"
+
+  if result
+    puts "Database successfully imported"
+  else
+    STDERR.puts "Database import failed :("
+    exit 1
+  end
+end
+

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
 #
@@ -6,3 +7,7 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+# rubocop:disable Rails/Output
+puts "Note: You can use `bin/pull_database` to fetch and import a production database dump from https://data.ruby-toolbox.com"
+# rubocop:enable Rails/Output


### PR DESCRIPTION
This PR closes #147 and #73 by providing:

* Automated daily database snapshots hosted on separate infrastructure (see https://github.com/rubytoolbox/backup_publisher where the actual lifting to enable this went down)
* A `bin/pull_database` script to fetch the latest public dump and import it into the relevant Rails.env's local postgres DB

It also adds a note regarding this to the README setup instructions, adds a footer link to https://data.ruby-toolbox.com and contains a blog post that announces the whole thing