### PR TITLE
Add links to gitter community chatroom

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <img src="./app/assets/images/logo/regular.svg" width="400px" alt="The Ruby Toolbox"/>
 
-  [![Build Status](https://travis-ci.org/rubytoolbox/rubytoolbox.svg?branch=master)](https://travis-ci.org/rubytoolbox/rubytoolbox) [![Depfu](https://badges.depfu.com/badges/84ab24dbd83e15c8dfd36144e10d14f2/overview.svg)](https://depfu.com/github/rubytoolbox/rubytoolbox)
+  [![Build Status](https://travis-ci.org/rubytoolbox/rubytoolbox.svg?branch=master)](https://travis-ci.org/rubytoolbox/rubytoolbox) [![Depfu](https://badges.depfu.com/badges/84ab24dbd83e15c8dfd36144e10d14f2/overview.svg)](https://depfu.com/github/rubytoolbox/rubytoolbox) [![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/rubytoolbox/Lobby)
 
   **Explore and compare open source Ruby libraries**
 </div>

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -109,6 +109,9 @@ html lang="en"
               li: a href="https://github.com/rubytoolbox/rubytoolbox/blob/master/CODE_OF_CONDUCT.md"
                 span.icon: i.fa.fa-users
                 span Code of Conduct
+              li: a href="https://gitter.im/rubytoolbox/Lobby"
+                span.icon: i.fa.fa-comments
+                span Community Chat Room
               li: a href=feed_url
                 span.icon: i.fa.fa-rss-square
                 span RSS Feed


### PR DESCRIPTION
Since I will be spending proper desk time through december and january working on this, it makes sense to have a community chat room at least for this time (usually I don't set up this kind of thing because of the obvious problems of several-day lag in chat communications ;) 

What I like in particular about gitter is that you login solely with your github account, and the channel can also be read without logging in publicly.

Since github announced this week they have acquired a product named spectrum (https://spectrum.chat), I also took a brief look at that. It seems very similar to https://twist.com/, however I would prefer to keep longer, feature-specific discussion on github issues and "just" use the chat for a more generic, low-barrier entrypoint for questions and discussions.

My usual desk times should be Monday-Thursday from 10AM to 4PM central european time (CET), I put that also on the gitter channel title :clock4: : 