### PR TITLE
Destroy orphaned github repo records

### DIFF
--- a/app/jobs/remote_update_scheduler_job.rb
+++ b/app/jobs/remote_update_scheduler_job.rb
@@ -2,13 +2,18 @@
 
 #
 # This sidekiq background job enqueues gem and github repo
-# data updates.
+# data updates and purges orphaned github repo records.
 #
 # It tries to distribute updates evenly throughout the day
 # to avoid creating a thundering herd at midnight.
 #
 class RemoteUpdateSchedulerJob < ApplicationJob
   def perform
+    # If a repo reference changes from a gem, we leave the repo
+    # behind in the db. This purges it afterwards since we don't need it
+    # anymore
+    GithubRepo.without_projects.destroy_all
+
     Rubygem.update_batch.each do |name|
       RubygemUpdateJob.perform_async name
     end

--- a/app/models/github_repo.rb
+++ b/app/models/github_repo.rb
@@ -16,6 +16,11 @@ class GithubRepo < ApplicationRecord
       .pluck(:path)
   end
 
+  def self.without_projects
+    joins("LEFT JOIN projects ON projects.github_repo_path = github_repos.path")
+      .where(projects: { permalink: nil })
+  end
+
   def path=(path)
     super Github.normalize_path(path)
   end

--- a/spec/jobs/remote_update_scheduler_job_spec.rb
+++ b/spec/jobs/remote_update_scheduler_job_spec.rb
@@ -18,6 +18,13 @@ RSpec.describe RemoteUpdateSchedulerJob, type: :job do
     do_perform
   end
 
+  it "purges all github repos without projects from the db" do
+    relation = instance_double ActiveRecord::Relation
+    allow(GithubRepo).to receive(:without_projects).and_return(relation)
+    expect(relation).to receive(:destroy_all)
+    do_perform
+  end
+
   # I am not aware of a better way to test consecutive calls here,
   # if you know one, please send a PR :)
   #

--- a/spec/models/github_repo_spec.rb
+++ b/spec/models/github_repo_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe GithubRepo, type: :model do
-  def create_repo!(path:, updated_at:)
+  def create_repo!(path:, updated_at: 1.day.ago)
     GithubRepo.create! path:             path,
                        updated_at:       updated_at,
                        stargazers_count: 1,
@@ -28,6 +28,18 @@ RSpec.describe GithubRepo, type: :model do
       end
 
       expect(described_class.update_batch).to match %w[foo/outdated1 foo/outdated2]
+    end
+  end
+
+  describe ".without_projects" do
+    before do
+      create_repo! path: "foo/linked"
+      Project.create! permalink: "foo/linked", github_repo_path: "foo/linked"
+      create_repo! path: "foo/orphaned"
+    end
+
+    it "contains records without associated projects" do
+      expect(described_class.without_projects.pluck(:path)).to be == %w[foo/orphaned]
     end
   end
 


### PR DESCRIPTION
I'm seeing a whole lot of failing github syncs due to invalid repo references on Appsignal. Basically this is a consequence of #246, where I added a fix to drop `.git` suffixes from gem's github repo refs because they break with graphql queries. Since we subsequently create a new db record with that adjusted repo path `foo/bar` permalink, the old `foo/bar.git` repo remained. Since we perform data sync on all github repo db records recurringly, these repos now get stuck in sad sidekiq retry hell ad infinitum. This should fix that problem.