### PR TITLE
Bugfixes for github sync edge cases

### DIFF
--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -36,17 +36,18 @@ class GithubClient
     response = http_client.head File.join("https://github.com", path)
     case response.status
     when 200
-      path
+      return path
     # Instead of following 301s, the broken github path
     # (either coming from the catalog for github-only projects,
     # or from a rubygems urls) should somehow be flagged and
     # remapped locally, but this needs some more consideration
     # regarding the various possible cases
     when 301, 302
-      Github.detect_repo_name response.headers["Location"]
-    else
-      raise UnknownRepoError, "Cannot find repo #{path} on github :("
+      location = Github.detect_repo_name response.headers["Location"]
+      return location if location
     end
+
+    raise UnknownRepoError, "Cannot find repo #{path} on github :("
   end
 
   def handle_response(response)

--- a/app/services/github_client/repository_data.rb
+++ b/app/services/github_client/repository_data.rb
@@ -118,7 +118,10 @@ class GithubClient
     end
 
     def time(key)
-      Time.zone.parse raw_data.dig(key.to_s).presence
+      value = raw_data.dig(key.to_s).presence
+      return unless value
+
+      Time.zone.parse value
     end
   end
 end

--- a/spec/cassettes/github/org_reference.yml
+++ b/spec/cassettes/github/org_reference.yml
@@ -1,0 +1,75 @@
+---
+http_interactions:
+- request:
+    method: head
+    uri: https://github.com/orgs/acdcorp
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - github.com
+      User-Agent:
+      - http.rb/4.0.0
+  response:
+    status:
+      code: 302
+      message: Found
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Wed, 05 Dec 2018 12:14:33 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Connection:
+      - close
+      Status:
+      - 302 Found
+      Cache-Control:
+      - no-cache
+      Vary:
+      - X-PJAX
+      Location:
+      - https://github.com/acdcorp
+      Set-Cookie:
+      - _gh_sess=YUE2VTRycmZiVStnaDk4OHpaY2VlWGU5Y1h6V1JKNWxKZENrb05ZWVpXZTlwWlV2S09HZ0RYc0g2MVVUS0hzMDZ6QU14WkU1cTZzQ2hxVlVQVUpPcWlFYkREak9sM2lRdlMrbkxsbkZ0dUk9LS02ZUdFVzdUQkptTTBVYUNnTS82UWJnPT0%3D--02334c0e9c1e3e1f563fd0258259ecf92161a0e1;
+        path=/; secure; HttpOnly
+      - has_recent_activity=1; path=/; expires=Wed, 05 Dec 2018 13:14:33 -0000
+      - logged_in=no; domain=.github.com; path=/; expires=Sun, 05 Dec 2038 12:14:33
+        -0000; secure; HttpOnly
+      X-Request-Id:
+      - 98f8b363-bda8-4797-b1cf-8a3cde46f0f0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Expect-Ct:
+      - max-age=2592000, report-uri="https://api.github.com/_private/browser/errors"
+      Content-Security-Policy:
+      - 'default-src ''none''; base-uri ''self''; block-all-mixed-content; connect-src
+        ''self'' uploads.github.com status.github.com collector.githubapp.com api.github.com
+        www.google-analytics.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com
+        github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com
+        wss://live.github.com; font-src assets-cdn.github.com; form-action ''self''
+        github.com gist.github.com; frame-ancestors ''none''; frame-src render.githubusercontent.com;
+        img-src ''self'' data: assets-cdn.github.com identicons.github.com collector.githubapp.com
+        github-cloud.s3.amazonaws.com *.githubusercontent.com; manifest-src ''self'';
+        media-src ''none''; script-src assets-cdn.github.com; style-src ''unsafe-inline''
+        assets-cdn.github.com'
+      X-Github-Request-Id:
+      - 95FE:4590:3115399:5E1E1FB:5C07C129
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 05 Dec 2018 12:14:33 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/graphql/empty.yml
+++ b/spec/cassettes/graphql/empty.yml
@@ -1,0 +1,151 @@
+---
+http_interactions:
+- request:
+    method: head
+    uri: https://github.com/therabidbanana/eventbright
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - github.com
+      User-Agent:
+      - http.rb/4.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Wed, 05 Dec 2018 12:28:06 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Connection:
+      - close
+      Status:
+      - 200 OK
+      Cache-Control:
+      - no-cache
+      Vary:
+      - X-PJAX
+      Set-Cookie:
+      - _gh_sess=VVp4OTBmbzY0cUMvRVNGUWMwRWJyUFBpRUFROSt4RDRVTk1OSm9RUkEwYnl4RUJSL2pnUWRLMXpIMVpqZFB4WWJITHViQjR3THVZTDNjbFA5bjlFendtUnNjMVhSTWNhb0g3MFprK0w5Nk1iRmlOQUcvWnNFcDZwWDBBRXlZMThpR0V3S2NpOThkQmJvWkNzTGNNMUNid3p5RmRrZ0l0WngwN2g4WkJWekNlTEFvckpIMDAxSUYrck1uR0VYNmdpbEU1S0pNeFFSY2Z5M0ZYN2pvamNFTUF0SXArN2Z4OGtwZ3BEMFBLVkNlTzNBUVVHSDNkekp6WFp2Tk9ZSC9Yd0lGWTVMOUJvN2JsbjNFL21zUzNDSlE9PS0tSlE1clVpR2hWTk5YZWF5bVcycmdHUT09--a9e9b3edea6accf392044d2bbe743af420c28de2;
+        path=/; secure; HttpOnly
+      - has_recent_activity=1; path=/; expires=Wed, 05 Dec 2018 13:28:06 -0000
+      X-Request-Id:
+      - 1a10dea6-4d64-4f0e-a547-8792b03b06ba
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Expect-Ct:
+      - max-age=2592000, report-uri="https://api.github.com/_private/browser/errors"
+      Content-Security-Policy:
+      - 'default-src ''none''; base-uri ''self''; block-all-mixed-content; connect-src
+        ''self'' uploads.github.com status.github.com collector.githubapp.com api.github.com
+        www.google-analytics.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com
+        github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com
+        wss://live.github.com; font-src assets-cdn.github.com; form-action ''self''
+        github.com gist.github.com; frame-ancestors ''none''; frame-src render.githubusercontent.com;
+        img-src ''self'' data: assets-cdn.github.com identicons.github.com collector.githubapp.com
+        github-cloud.s3.amazonaws.com *.githubusercontent.com; manifest-src ''self'';
+        media-src ''none''; script-src assets-cdn.github.com; style-src ''unsafe-inline''
+        assets-cdn.github.com'
+      X-Github-Request-Id:
+      - A210:4590:312F685:5E4FB58:5C07C456
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 05 Dec 2018 12:28:06 GMT
+- request:
+    method: post
+    uri: https://api.github.com/graphql
+    body:
+      encoding: UTF-8
+      string: '{"query":"{\n  repository(owner: \"therabidbanana\", name: \"eventbright\")
+        {\n    nameWithOwner\n    forks {\n      totalCount\n    }\n    stargazers
+        {\n      totalCount\n    }\n    watchers {\n      totalCount\n    }\n    createdAt\n    defaultBranchRef
+        {\n      name\n      target {\n        ... on Commit {\n          history(first:
+        50) {\n            edges {\n              node {\n                authoredDate\n              }\n            }\n          }\n        }\n      }\n    }\n    description\n    hasIssuesEnabled\n    hasWikiEnabled\n    homepageUrl\n    isArchived\n    isFork\n    isMirror\n    licenseInfo
+        {\n      key\n    }\n    primaryLanguage {\n      name\n    }\n    pushedAt\n    closedIssues:
+        issues(states: CLOSED) {\n      totalCount\n    }\n    openIssues: issues(states:
+        OPEN) {\n      totalCount\n    }\n    closedPullRequests: pullRequests(states:
+        CLOSED) {\n      totalCount\n    }\n    openPullRequests: pullRequests(states:
+        OPEN) {\n      totalCount\n    }\n    mergedPullRequests: pullRequests(states:
+        MERGED) {\n      totalCount\n    }\n  }\n\n  rateLimit {\n    limit\n    cost\n    remaining\n    resetAt\n  }\n}\n"}'
+    headers:
+      Authorization:
+      - bearer <GITHUB_TOKEN>
+      User-Agent:
+      - ruby-toolbox.com API client
+      Connection:
+      - close
+      Host:
+      - api.github.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Wed, 05 Dec 2018 12:28:07 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '730'
+      Connection:
+      - close
+      Status:
+      - 200 OK
+      Cache-Control:
+      - no-cache
+      X-Oauth-Scopes:
+      - public_repo
+      X-Accepted-Oauth-Scopes:
+      - repo
+      X-Github-Media-Type:
+      - github.v4; format=json
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '1071'
+      X-Ratelimit-Reset:
+      - '1544014350'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - DF0D:2EDB:1CA4918:3E5A3F6:5C07C456
+    body:
+      encoding: UTF-8
+      string: '{"data":{"repository":{"nameWithOwner":"therabidbanana/eventbright","forks":{"totalCount":0},"stargazers":{"totalCount":1},"watchers":{"totalCount":1},"createdAt":"2011-05-29T16:16:46Z","defaultBranchRef":null,"description":"Renamed
+        to eventbrite:","hasIssuesEnabled":true,"hasWikiEnabled":true,"homepageUrl":"http://www.github.com/therabidbanana/eventbrite","isArchived":false,"isFork":false,"isMirror":false,"licenseInfo":null,"primaryLanguage":null,"pushedAt":null,"closedIssues":{"totalCount":0},"openIssues":{"totalCount":0},"closedPullRequests":{"totalCount":0},"openPullRequests":{"totalCount":0},"mergedPullRequests":{"totalCount":0}},"rateLimit":{"limit":5000,"cost":1,"remaining":1071,"resetAt":"2018-12-05T12:52:30Z"}}}'
+    http_version: 
+  recorded_at: Wed, 05 Dec 2018 12:28:07 GMT
+recorded_with: VCR 4.0.0

--- a/spec/integration/github_client_spec.rb
+++ b/spec/integration/github_client_spec.rb
@@ -38,6 +38,14 @@ RSpec.describe GithubClient, :real_http do
     end
   end
 
+  describe "for invalid reference to an org", vcr: { cassette_name: "github/org_reference" } do
+    it "raises a GithubClient::UnknownRepoError" do
+      expect { client.fetch_repository("orgs/acdcorp") }.to raise_error(
+        GithubClient::UnknownRepoError, /Cannot find repo/
+      )
+    end
+  end
+
   describe "for unknown repo", vcr: { cassette_name: "graphql/fails" } do
     it "raises a GithubClient::UnknownRepoError" do
       expect { client.fetch_repository("thisverylikely/fails") }.to raise_error(

--- a/spec/integration/github_client_spec.rb
+++ b/spec/integration/github_client_spec.rb
@@ -54,6 +54,15 @@ RSpec.describe GithubClient, :real_http do
     end
   end
 
+  describe "for empty repo", vcr: { cassette_name: "graphql/empty" } do
+    it "successfully fetches the repo" do
+      expected_attributes = {
+        pushed_at: nil,
+      }
+      expect(client.fetch_repository("therabidbanana/eventbright")).to have_attributes(expected_attributes)
+    end
+  end
+
   # This is currently not possible with Github's GraphQL API :(
   # https://platform.github.community/t/repository-redirects-in-api-v4-graphql/4417
   #


### PR DESCRIPTION
* Some repo refs picked from rubygems reference `orgs/foobar`, which, if the org exists, redirects to the organization of said name, leading to a `NoMethodError "split"` on the redirect location target
* Some repo refs picked from rubygems point at empty repos... The repository data parser was choking when passing `nil` for the last `pushedAt` to `Time.parse` in those cases