### PR TITLE
Rank popular categories

### DIFF
--- a/app/jobs/catalog_import_job.rb
+++ b/app/jobs/catalog_import_job.rb
@@ -6,7 +6,9 @@ class CatalogImportJob < ApplicationJob
     raise "Failed to fetch catalog, response status was #{response.status}" unless response.status == 200
 
     catalog_data = JSON.parse response.body
-    CatalogImport.perform(catalog_data)
+    CatalogImport.perform catalog_data
+
+    CategoryRankingJob.perform_async
   end
 
   def catalog_url

--- a/app/jobs/category_ranking_job.rb
+++ b/app/jobs/category_ranking_job.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+#
+# Applies a ranking to categories based on the *two* most included popular projects.
+#
+# Two most popular because this reduces the impact of categories that only have
+# a single library that is especially popular, for this ranking categories with
+# multiple popular choices are more interesting, and this produced reasonable
+# output when run against the actual data :)
+#
+class CategoryRankingJob < ApplicationJob
+  def perform(limit: 16)
+    top_category_ids = Set.new
+    occurences = Hash.new(0)
+
+    categorized_projects_by_score.each do |project|
+      project.category_ids.each { |category_id| occurences[category_id] += 1 }
+      top_category_ids += matching_occurences(occurences)
+
+      break if top_category_ids.size >= limit
+    end
+
+    update_ranking! top_category_ids.first(limit)
+  end
+
+  private
+
+  def categorized_projects_by_score
+    @categorized_projects_by_score ||= Project.includes(:categories)
+                                              .joins(:categories)
+                                              .where.not(score: nil)
+                                              .order(score: :desc)
+  end
+
+  def matching_occurences(occurences)
+    occurences
+      .select { |_, count| count > 1 }
+      .map { |category_id, _| category_id }
+  end
+
+  def update_ranking!(top_category_ids)
+    Category.transaction do
+      Category.update_all rank: nil # rubocop:disable Rails/SkipsModelValidations
+      top_category_ids.each_with_index do |category_id, rank|
+        Category.find(category_id).update! rank: rank + 1
+      end
+    end
+  end
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -17,6 +17,8 @@ class Category < ApplicationRecord
   has_many :projects, -> { order(score: :desc) },
            through: :categorizations
 
+  scope :by_rank, -> { where.not(rank: nil).order(rank: :asc) }
+
   include PgSearch
   pg_search_scope :search_scope,
                   against:   :name_tsvector,

--- a/db/migrate/20181210092238_add_rank_to_categories.rb
+++ b/db/migrate/20181210092238_add_rank_to_categories.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRankToCategories < ActiveRecord::Migration[5.2]
+  def change
+    add_column :categories, :rank, :integer, default: nil
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -37,20 +37,6 @@ COMMENT ON EXTENSION citext IS 'data type for case-insensitive character strings
 
 
 --
--- Name: fuzzystrmatch; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS fuzzystrmatch WITH SCHEMA public;
-
-
---
--- Name: EXTENSION fuzzystrmatch; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION fuzzystrmatch IS 'determine similarities and distance between strings';
-
-
---
 -- Name: pg_stat_statements; Type: EXTENSION; Schema: -; Owner: -
 --
 
@@ -133,7 +119,8 @@ CREATE TABLE public.categories (
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     category_group_permalink public.citext NOT NULL,
-    name_tsvector tsvector
+    name_tsvector tsvector,
+    rank integer
 );
 
 
@@ -492,6 +479,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180322231205'),
 ('20180322231848'),
 ('20180718195202'),
-('20181205134522');
+('20181205134522'),
+('20181210092238');
 
 

--- a/spec/jobs/catalog_import_job_spec.rb
+++ b/spec/jobs/catalog_import_job_spec.rb
@@ -18,13 +18,7 @@ RSpec.describe CatalogImportJob, type: :job do
     end
 
     it "fetches the catalog" do
-      response = HTTP::Response.new(
-        status:  200,
-        body:    catalog_body,
-        version: "1.1"
-      )
-      expect(job.http_client).to receive(:get).with(job.catalog_url)
-                                              .and_return(response)
+      stub_response
       job.perform
     end
 
@@ -36,6 +30,12 @@ RSpec.describe CatalogImportJob, type: :job do
     it "passes the parsed body to CatalogImport.perform" do
       stub_response
       expect(CatalogImport).to receive(:perform).with(JSON.parse(catalog_body))
+      job.perform
+    end
+
+    it "queues a CategoryRankingJob" do
+      stub_response
+      expect(CategoryRankingJob).to receive(:perform_async)
       job.perform
     end
   end

--- a/spec/jobs/category_ranking_job_spec.rb
+++ b/spec/jobs/category_ranking_job_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CategoryRankingJob, type: :job do
+  let(:job) { described_class.new }
+
+  before do
+    category_group = CategoryGroup.create! permalink: "group", name: "group"
+    Category.create! name: "A", permalink: "a", category_group: category_group
+    b = Category.create! name: "B", permalink: "b", category_group: category_group
+    c = Category.create! name: "C", permalink: "c", category_group: category_group
+
+    Project.create! permalink: "C1", score: 20, categories: [c]
+    Project.create! permalink: "C2", score: 10, categories: [c]
+    Project.create! permalink: "B1", score: 15, categories: [b]
+    Project.create! permalink: "B2", score: 3, categories: [b]
+  end
+
+  describe "#perform" do
+    it "sets expected category ranks" do
+      expect { job.perform }
+        .to change { Category.by_rank.pluck(:name, :rank) }
+        .from([])
+        .to([["C", 1], ["B", 2]])
+    end
+
+    it "updates the ranks correctly on subsequent runs" do
+      described_class.new.perform
+
+      Project.create! permalink: "A1", score: 25, categories: [Category.find("a")]
+      Project.create! permalink: "A2", score: 20, categories: [Category.find("a")]
+
+      expect { job.perform }
+        .to change { Category.by_rank.pluck(:name) }
+        .from(%w[C B])
+        .to(%w[A C B])
+    end
+
+    it "respects a given custom limit" do
+      expect { job.perform(limit: 1) }
+        .to change { Category.by_rank.pluck(:name) }
+        .to(%w[C])
+    end
+  end
+end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -20,6 +20,16 @@ RSpec.describe Category, type: :model do
     end
   end
 
+  describe ".by_rank" do
+    it "returns only ranked categories, ordered by rank" do
+      Category.create! permalink: "A", name: "A", category_group: group
+      Category.create! permalink: "B", name: "B", category_group: group, rank: 2
+      Category.create! permalink: "C", name: "C", category_group: group, rank: 1
+
+      expect(Category.by_rank.pluck(:permalink)).to be == %w[C B]
+    end
+  end
+
   describe "#catalog_show_url" do
     it "is the url where the category definition can be seen on github" do
       expected = "https://github.com/rubytoolbox/catalog/tree/master/catalog/unimportant/mocking.yml"


### PR DESCRIPTION
This adds a background job to identify and rank the "most popular" categories. After some experimentation I settled on ranking categories based on the two most popular projects in the category, as this prevents categories that only really have one highly popular library from being overemphasized in the ranking. The method applied here produced (*imho*) reasonable results, as of the time being:

* [Web App Frameworks](https://www.ruby-toolbox.com/categories/web_app_frameworks)
* [JSON Parsers](https://www.ruby-toolbox.com/categories/JSON_Parsers)
* [Scripting Frameworks](https://www.ruby-toolbox.com/categories/scripting_frameworks)
* [Test Frameworks](https://www.ruby-toolbox.com/categories/testing_frameworks)
* [Template Engines](https://www.ruby-toolbox.com/categories/template_engines)
* [E-Mail Delivery](https://www.ruby-toolbox.com/categories/e_mail)
* [HTTP clients](https://www.ruby-toolbox.com/categories/http_clients)
* [JavaScript Tools](https://www.ruby-toolbox.com/categories/javascript_tools)
* [CSS Tools](https://www.ruby-toolbox.com/categories/css_with_ruby)
* [Concurrent Processing](https://www.ruby-toolbox.com/categories/Concurrent_Processing)
* [Browser testing](https://www.ruby-toolbox.com/categories/browser_testing)
* [Ruby Core Extensions](https://www.ruby-toolbox.com/categories/Ruby_Core_Extensions)
* [Command Line Option Parsers](https://www.ruby-toolbox.com/categories/CLI_Option_Parsers)
* [Code Metrics](https://www.ruby-toolbox.com/categories/code_metrics)
* [SQL Database Adapters](https://www.ruby-toolbox.com/categories/SQL_Database_Adapters)
* [Web Servers](https://www.ruby-toolbox.com/categories/web_servers)

It's obviously very rails/web-dev-centric, but that also reflects what ruby is being used for most of the time just fine, and there's a bunch of other categories like test frameworks, concurrent processing, CLI option parsing and code metrics that have general utility as well, so I think it's a fair representation of "relevant" stuff.

This is currently not shown, but will be used in the new landing page via #335 
