### PR TITLE
Github catalog update webhook endpoint

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,2 @@
+SIDEKIQ_PASSWORD=testing
+GITHUB_WEBHOOK_SECRET=helloworld

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -75,6 +75,11 @@ Style/TrailingCommaInArrayLiteral:
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
 
+Style/ClassAndModuleChildren:
+  Exclude:
+    # Prefer rails convention
+    - 'app/controllers/**/*'
+
 RSpec/FilePath:
   Exclude:
     - 'spec/integration/*'

--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,8 @@ gem "forgery"
 gem "rack-canonical-host"
 gem "rack-ssl-enforcer"
 
+gem "github_webhook"
+
 gem "http"
 
 gem "sidekiq"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,10 @@ GEM
       thor (~> 0.19.1)
     forgery (0.7.0)
     formatador (0.2.5)
+    github_webhook (1.1.1)
+      activesupport (>= 4)
+      rack (>= 1.3)
+      railties (>= 4)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     guard (2.14.2)
@@ -381,6 +385,7 @@ DEPENDENCIES
   feedjira
   foreman
   forgery
+  github_webhook
   guard-bundler
   guard-rspec
   guard-rubocop

--- a/app/controllers/webhooks/github_controller.rb
+++ b/app/controllers/webhooks/github_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Webhooks::GithubController < ApplicationController
+  include GithubWebhook::Processor
+
+  def github_page_build(_payload)
+    CatalogImportJob.perform_async
+  end
+
+  private
+
+  def webhook_secret(_payload)
+    ENV.fetch "GITHUB_WEBHOOK_SECRET"
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,10 @@ Rails.application.routes.draw do
   resource  :search, only: %i[show]
   resources :blog, only: %i[index show], constraints: { id: /[^\.]+/ }
 
+  namespace :webhooks do
+    post "github", to: "github#create", defaults: { formats: :json }
+  end
+
   Sidekiq::Web.use Rack::Auth::Basic do |_username, password|
     ActiveSupport::SecurityUtils.secure_compare(
       ::Digest::SHA256.hexdigest(password),

--- a/spec/controllers/webhooks/github_controller_spec.rb
+++ b/spec/controllers/webhooks/github_controller_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Webhooks::GithubController, type: :controller do
+  describe "POST create" do
+    let(:request_body) { { foo: :bar }.to_json }
+    let(:event_name) { "page_build" }
+    let(:secret) { ENV.fetch("GITHUB_WEBHOOK_SECRET") }
+    let(:signature) { OpenSSL::HMAC.hexdigest OpenSSL::Digest.new("sha1"), secret, request_body }
+
+    def do_request
+      request.headers["X-GitHub-Event"] = event_name
+      request.headers["Content-Type"] = "application/json"
+      request.headers["X-Hub-Signature"] = "sha1=#{signature}"
+
+      post :create, body: request_body
+    end
+
+    describe "with valid event and signature" do
+      it "responds with success" do
+        expect(do_request).to be_successful
+      end
+
+      it "queues a catalog import job on valid signature and page_build event" do
+        expect(CatalogImportJob).to receive(:perform_async)
+        do_request
+      end
+    end
+
+    describe "with invalid signature" do
+      let(:signature) { "INVALID" }
+
+      it "raises an GithubWebhook::Processor::SignatureError on invalid signature" do
+        expect { do_request }.to raise_error GithubWebhook::Processor::SignatureError
+      end
+
+      it "does not queue CatalogImportJob" do
+        expect(CatalogImportJob).not_to receive(:perform_async)
+        begin
+          do_request
+        rescue GithubWebhook::Processor::SignatureError
+          "this is fine"
+        end
+      end
+    end
+
+    describe "with invalid event" do
+      let(:event_name) { "cupcake!!!" }
+
+      it "raises UnsupportedEventError" do
+        expect { do_request }.to raise_error GithubWebhook::Processor::UnsupportedGithubEventError
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds an endpoint at `POST /webhooks/github` for receiving github page build notifications. This enables syncing [the catalog](https://github.com/rubytoolbox/catalog) on every update right away instead of waiting for the hourly cron to kick in.