### PR TITLE
Listen to github CI status instead of page build event for catalog update

### DIFF
--- a/app/controllers/webhooks/github_controller.rb
+++ b/app/controllers/webhooks/github_controller.rb
@@ -3,11 +3,23 @@
 class Webhooks::GithubController < ApplicationController
   include GithubWebhook::Processor
 
-  def github_page_build(_payload)
+  def github_status(payload)
+    return unless build_deployed? payload
+
     CatalogImportJob.perform_async
   end
 
   private
+
+  #
+  # The catalog JSON export is built on CI and then deployed manually to
+  # github pages, which does not seem to trigger a `page_build` notification
+  # event webhook from github. Therefore, we watch for the successful CI
+  # status on the default branch instead.
+  #
+  def build_deployed?(payload)
+    payload.dig("state") == "success" && payload.dig("branches", "name") == payload.dig("repository", "default_branch")
+  end
 
   def webhook_secret(_payload)
     ENV.fetch "GITHUB_WEBHOOK_SECRET"


### PR DESCRIPTION
Followup to #339 because that approach did not do the trick yet.

It seems that github only emits the `page_build` event on "native" builds from GH pages. However, the [toolbox's catalog](https://github.com/rubytoolbox/catalog) runs some simple ruby code on Travis CI, then does a manual deployment to github pages.

To circumvent this problem this PR switches over to listen for successful CI status events from github on the default branch of the repo.