### PR TITLE
Adjust for actual expected github webhook payload

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web:    bundle exec puma --threads 4:$RAILS_MAX_THREADS
-worker: bundle exec sidekiq --concurrency $RAILS_MAX_THREADS
+worker: bundle exec sidekiq --concurrency $RAILS_MAX_THREADS -q priority -q default

--- a/app/controllers/webhooks/github_controller.rb
+++ b/app/controllers/webhooks/github_controller.rb
@@ -19,7 +19,9 @@ class Webhooks::GithubController < ApplicationController
   # status on the default branch instead.
   #
   def build_deployed?(payload)
-    payload.dig("state") == "success" && payload.dig("branches", "name") == payload.dig("repository", "default_branch")
+    default_branch = payload.dig("repository", "default_branch")
+    referenced_branches = payload.dig("branches")&.map { |branch| branch.dig("name") }
+    payload.dig("state") == "success" && referenced_branches&.include?(default_branch)
   end
 
   def webhook_secret(_payload)

--- a/app/jobs/catalog_import_job.rb
+++ b/app/jobs/catalog_import_job.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CatalogImportJob < ApplicationJob
+  sidekiq_options queue: :priority
+
   def perform
     response = http_client.get catalog_url
     raise "Failed to fetch catalog, response status was #{response.status}" unless response.status == 200

--- a/spec/controllers/webhooks/github_controller_spec.rb
+++ b/spec/controllers/webhooks/github_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Webhooks::GithubController, type: :controller do
     let(:request_body) do
       {
         state:      state,
-        branches:   { name: branch },
+        branches:   [{ name: branch }],
         repository: { default_branch: "master" },
       }
     end


### PR DESCRIPTION
This is getting embarrassing... Another followup to #339 and #341. I had overlooked that the `branches` key in the github payload actually contains an array of branches, not a single hash. This fixes that and finally makes this work.

I also introduced a "priority" queue in sidekiq that the catalog import gets placed on, otherwise if we have a huge number of recurring stats fetch jobs in the queue the "instant" sync is not so instant anymore :)