### PR TITLE
Wait a litte before triggering catalog sync from github pages

### DIFF
--- a/app/controllers/webhooks/github_controller.rb
+++ b/app/controllers/webhooks/github_controller.rb
@@ -7,7 +7,7 @@ class Webhooks::GithubController < ApplicationController
   def github_status(payload)
     return unless build_deployed? payload
 
-    CatalogImportJob.perform_async
+    CatalogImportJob.perform_in 30.seconds
   end
 
   private

--- a/spec/controllers/webhooks/github_controller_spec.rb
+++ b/spec/controllers/webhooks/github_controller_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Webhooks::GithubController, type: :controller do
       end
 
       it "queues a catalog import job on valid signature and page_build event" do
-        expect(CatalogImportJob).to receive(:perform_async)
+        expect(CatalogImportJob).to receive(:perform_in).with(30.seconds)
         do_request
       end
     end
@@ -45,7 +45,7 @@ RSpec.describe Webhooks::GithubController, type: :controller do
       end
 
       it "does not queue CatalogImportJob" do
-        expect(CatalogImportJob).not_to receive(:perform_async)
+        expect(CatalogImportJob).not_to receive(:perform_in)
         begin
           do_request
         rescue GithubWebhook::Processor::SignatureError
@@ -60,7 +60,7 @@ RSpec.describe Webhooks::GithubController, type: :controller do
       end
 
       it "does not queue CatalogImportJob" do
-        expect(CatalogImportJob).not_to receive(:perform_async)
+        expect(CatalogImportJob).not_to receive(:perform_in)
         do_request
       end
     end


### PR DESCRIPTION
So now #339 / #340 / #341 / #342 works great, except when the sidekiq job kicks off apparently the github pages deployment is not quite published yet even though we're listening on the travis build success event (which includes deployment to gh-pages). Probably the actual deployment of the page happens asynchronously at github, so let's give it some time to do it's thing and hopefully then it will work just fine. 