### PR TITLE
Upgrade Bulma, import all of it

### DIFF
--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -34,19 +34,7 @@ $link: $red
 $primary: $red
 $text: #222
 
-@import "bulma/sass/utilities/_all"
-@import "bulma/sass/base/_all"
-@import "bulma/sass/grid/_all"
-@import "bulma/sass/layout/_all"
-@import "bulma/sass/components/level"
-@import "bulma/sass/elements/box"
-@import "bulma/sass/elements/button"
-@import "bulma/sass/elements/container"
-@import "bulma/sass/elements/content"
-@import "bulma/sass/elements/form"
-@import "bulma/sass/elements/icon"
-@import "bulma/sass/elements/other"
-@import "bulma/sass/elements/title"
+@import "bulma/bulma"
 
 .border-bottom
   border-bottom: 1px solid $light

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "rubytoolbox",
   "private": false,
   "dependencies": {
-    "bulma": "^0.6.0"
+    "bulma": "^0.7.0"
   },
   "version": "1.0.0",
   "main": "index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,7 @@
 # yarn lockfile v1
 
 
-bulma@^0.6.0:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/bulma/-/bulma-0.6.1.tgz#5f21a77c0c06f7d80051c06628c23516081bd649"
+bulma@^0.7.0:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/bulma/-/bulma-0.7.2.tgz#8e944377b74c7926558830d38d8e19eaf49f5fb6"
+  integrity sha512-6JHEu8U/1xsyOst/El5ImLcZIiE2JFXgvrz8GGWbnDLwTNRPJzdAM0aoUM1Ns0avALcVb6KZz9NhzmU53dGDcQ==


### PR DESCRIPTION
This PR upgrades [Bulma](https://bulma.io/documentation/), the css framework used for the Ruby Toolbox, from 0.6.1 to the latest 0.7.2

I also decided to do away with the individual imports, they are quite cumbersome since on upgrades they sometimes make stuff break and if I want to use a different part of the framework I have to hunt down the correct file, while the gain is quite negligible: 38kb before, 50kb after gzipped, and I still need to import some additional components like the responsive main menu, so let's just keep it simple here...