### PR TITLE
Navigation Menu

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,6 +42,14 @@ RSpec/DescribeClass:
 # When setting up message expectations, 5 is frequently too little
 RSpec/ExampleLength:
   Max: 10
+  Exclude:
+    # Not efficient for acceptance tests
+    - 'spec/features/**/*'
+
+RSpec/MultipleExpectations:
+  Exclude:
+    # Not efficient for acceptance tests
+    - 'spec/features/**/*'
 
 # Prefer to use the up-front message expectations
 RSpec/MessageSpies:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ services:
 - redis
 addons:
   postgresql: '9.6'
+  # See https://docs.travis-ci.com/user/chrome
+  chrome: stable
 # Cache bundle between builds
 # See https://docs.travis-ci.com/user/caching/
 cache:

--- a/Gemfile
+++ b/Gemfile
@@ -82,9 +82,11 @@ end
 group :test do
   # Adds support for Capybara system testing and selenium driver
   gem "capybara", ">= 2.15", "< 4.0"
+  gem "launchy"
   gem "selenium-webdriver"
   # Easy installation and use of chromedriver to run system tests with Chrome
   gem "chromedriver-helper"
+
 
   gem "feedjira"
 

--- a/Gemfile
+++ b/Gemfile
@@ -87,7 +87,6 @@ group :test do
   # Easy installation and use of chromedriver to run system tests with Chrome
   gem "chromedriver-helper"
 
-
   gem "feedjira"
 
   gem "rails-controller-testing"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,6 +152,8 @@ GEM
     io-like (0.3.0)
     jaro_winkler (1.5.1)
     json (2.1.0)
+    launchy (2.4.3)
+      addressable (~> 2.3)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -391,6 +393,7 @@ DEPENDENCIES
   guard-rubocop
   hairtrigger
   http
+  launchy
   listen (>= 3.0.5, < 3.2)
   lograge
   logstash-event

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,3 +13,30 @@
 //= require rails-ujs
 //= require turbolinks
 //= require_tree .
+
+document.addEventListener("turbolinks:load", function() {
+  // Snippet to enable the bulma burger menu in mobile
+  // taken from https://bulma.io/documentation/components/navbar/#navbar-menu
+
+  // Get all "navbar-burger" elements
+  const $navbarBurgers = Array.prototype.slice.call(document.querySelectorAll('.navbar-burger'), 0);
+
+  // Check if there are any navbar burgers
+  if ($navbarBurgers.length > 0) {
+
+    // Add a click event on each of them
+    $navbarBurgers.forEach( el => {
+      el.addEventListener('click', () => {
+
+        // Get the target from the "data-target" attribute
+        const target = el.dataset.target;
+        const $target = document.getElementById(target);
+
+        // Toggle the "is-active" class on both the "navbar-burger" and the "navbar-menu"
+        el.classList.toggle('is-active');
+        $target.classList.toggle('is-active');
+
+      });
+    });
+  }
+})

--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -34,17 +34,47 @@ $link: $red
 $primary: $red
 $text: #222
 
+$navbar-height: 5rem
+$navbar-item-hover-background-color: transparent
+$navbar-item-active-background-color: transparent
+$navbar-tab-hover-background-color: transparent
+$navbar-tab-active-background-color: transparent
+
 @import "bulma/bulma"
 
 .border-bottom
   border-bottom: 1px solid $light
 
-header.section
-  padding: 1.5rem
-  @extend .border-bottom
-  img
-    max-width: 100%
-    height: 35px
+header
+  .navbar
+    @extend .border-bottom
+    img
+      max-height: 35px
+
+    // These values are hard-coded within bulma, we override
+    // them here to keep it consistent with the adjacent search icon
+    // in mobile view
+    .navbar-burger
+      margin-left: 0
+      &:hover
+        background: transparent
+        span
+          color: $primary
+      span
+        height: 2px
+
+    // Make the mobile search direct icon appear similar to the
+    // navbar burger and ensure it's nicely aligned
+    .mobile-search
+      margin-left: auto
+      @extend .is-hidden-desktop
+      height: $navbar-height
+      width: $navbar-height
+      .icon
+        display: inline-block
+        margin: 0 auto
+        width: auto
+        transform: scale(1.1)
 
 .hero
   @extend .border-bottom

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -64,4 +64,8 @@ module ApplicationHelper
 
     matching_distance&.last || "more than 2 years ago"
   end
+
+  def active_when(controller:)
+    "is-active" if controller_name == controller.to_s
+  end
 end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -42,26 +42,39 @@ html lang="en"
     = auto_discovery_link_tag :rss, blog_index_url(format: :rss)
 
   body
-    header.section: .container
-      nav.level.is-mobile
-        .level-left
-          .level-item
-            = link_to "/", title: title(default: true) do
-              = image_tag "logo/regular.svg", alt: title(default: true)
-        .level-right
-          - unless controller_name == "searches"
-            .is-hidden-tablet
-              = link_to search_path, class: "button is-white is-large" do
-                span.icon: i.fa.fa-search
-          .search-form.level-item.is-hidden-mobile
-            = form_tag search_path, method: :get do
-              .field.has-addons.has-addons-centered
-                .control
-                  input.input placeholder="Search" type="text" name="q" value=@query
-                .control
-                  button.button type="submit"
-                    span.icon: i.fa.fa-search
-                    span Search
+    header.container
+      nav.navbar aria-label="main navigation" role="navigation"
+        .navbar-brand
+          = link_to "/", title: title(default: true), class: "navbar-item" do
+            = image_tag "logo/regular.svg", alt: title(default: true)
+
+          a.navbar-item.mobile-search href=search_path
+            span.icon: i.fa.fa-search
+
+          a.navbar-burger.burger aria-expanded="false" data-target="mainMenu" aria-label="menu" role="button"
+            span aria-hidden="true"
+            span aria-hidden="true"
+            span aria-hidden="true"
+
+        .navbar-menu#mainMenu
+          .navbar-end
+            a.navbar-item href="/" class=active_when(controller: "welcome")
+              span.icon: i.fa.fa-home
+              span Home
+
+            a.navbar-item href=blog_index_path class=active_when(controller: "blog")
+              span.icon: i.fa.fa-rss-square
+              span News
+
+            .navbar-item
+              = form_tag search_path, method: :get do
+                .field.has-addons.has-addons-centered
+                  .control.is-expanded
+                    input.input placeholder="Search" type="text" name="q" value=@query
+                  .control
+                    button.button type="submit"
+                      span.icon: i.fa.fa-search
+                      span Search
 
 
     section.main

--- a/spec/features/mobile_navigation_spec.rb
+++ b/spec/features/mobile_navigation_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Mobile Navigation", type: :feature, js: true do
+  it "has a toggle-able hamburger navigation on mobile" do
+    Capybara.current_session.current_window.resize_to 450, 900
+
+    visit "/"
+
+    within "header .navbar" do
+      expect(page).not_to have_css(".navbar-menu")
+
+      page.find("a.navbar-burger").click
+
+      expect(page).to have_css(".navbar-menu")
+      within ".navbar-menu" do
+        expect(page).to have_text("Home")
+        expect(page).to have_text("News")
+
+        fill_in :q, with: "My Search"
+        click_button "Search"
+        expect(page.title).to be == "Search results for 'My Search' - The Ruby Toolbox"
+      end
+    end
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -80,4 +80,18 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
   end
+
+  describe "#active_when" do
+    it "is 'is-active' when given controller matches current controller name" do
+      expect(helper.active_when(controller: "test")).to be == "is-active"
+    end
+
+    it "is 'is-active' when matching controller is given as symbol" do
+      expect(helper.active_when(controller: :test)).to be == "is-active"
+    end
+
+    it "is nil when given controller name does not match current controller name" do
+      expect(helper.active_when(controller: "foo")).to be nil
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -38,12 +38,18 @@ Dir[Rails.root.join("spec", "support", "**", "*.rb")].each { |f| require f }
 ActiveRecord::Migration.maintain_test_schema!
 
 VCR.configure do |c|
+  c.ignore_hosts "localhost", "127.0.0.1"
   c.cassette_library_dir = Rails.root.join("spec", "cassettes")
   c.default_cassette_options = { record: :new_episodes }
   c.hook_into :webmock
   c.configure_rspec_metadata!
   c.filter_sensitive_data("<GITHUB_TOKEN>") { ENV["GITHUB_TOKEN"] }
 end
+
+# To clean up test output, comment this line to
+Capybara.server = :puma, { Silent: true }
+
+Capybara.javascript_driver = :selenium_chrome_headless
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures


### PR DESCRIPTION
This converts the current, custom top navigation bar to a proper [Bulma navbar](https://bulma.io/documentation/components/navbar/)

Before:

![bildschirmfoto vom 2018-12-11 12 47 14](https://user-images.githubusercontent.com/13972/49798732-54137e80-fd43-11e8-809a-a8667f82deed.png)

After:

![bildschirmfoto vom 2018-12-11 12 47 32](https://user-images.githubusercontent.com/13972/49798744-5bd32300-fd43-11e8-8b56-792f864945cd.png)

This will allow for some actual navigation links to point to things in the top bar. It also features the usual mobile hamburger:

![bildschirmfoto vom 2018-12-11 12 49 52](https://user-images.githubusercontent.com/13972/49798805-802eff80-fd43-11e8-8b64-725cb1c0087c.png)

Since this is the first time some actual javascript code is added to the site I added a very basic test using chrome headless, including setting up the little tidbits of wiring to make it work.