### PR TITLE
Do not use 'new' javascript stuff

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,29 +14,28 @@
 //= require turbolinks
 //= require_tree .
 
-document.addEventListener("turbolinks:load", function() {
+document.addEventListener("turbolinks:load", function () {
   // Snippet to enable the bulma burger menu in mobile
   // taken from https://bulma.io/documentation/components/navbar/#navbar-menu
 
   // Get all "navbar-burger" elements
-  const $navbarBurgers = Array.prototype.slice.call(document.querySelectorAll('.navbar-burger'), 0);
+  var $navbarBurgers = Array.prototype.slice.call(document.querySelectorAll('.navbar-burger'), 0);
 
   // Check if there are any navbar burgers
   if ($navbarBurgers.length > 0) {
 
     // Add a click event on each of them
-    $navbarBurgers.forEach( el => {
-      el.addEventListener('click', () => {
+    $navbarBurgers.forEach(function (el) {
+      el.addEventListener('click', function () {
 
         // Get the target from the "data-target" attribute
-        const target = el.dataset.target;
-        const $target = document.getElementById(target);
+        var target = el.dataset.target;
+        var $target = document.getElementById(target);
 
         // Toggle the "is-active" class on both the "navbar-burger" and the "navbar-menu"
         el.classList.toggle('is-active');
         $target.classList.toggle('is-active');
-
       });
     });
   }
-})
+});


### PR DESCRIPTION
I didn't pay attention - the bulma snippet for the hamburger introduced in #347 uses ES2015+ features, and since we don't use any javascript except for rails' ujs and turbolinks so far I think it's not worth it to go all in on webpacker/babel js compilation. Therefore, this PR converts it to old-school JS (via [babel's online REPL](https://babeljs.io/repl) ;)

[The error that happened on deployment of master to Heroku](https://travis-ci.org/rubytoolbox/rubytoolbox/builds/466477957) was:

```
yarn install v1.5.1
       [1/4] Resolving packages...
       [2/4] Fetching packages...
       [3/4] Linking dependencies...
       [4/4] Building fresh packages...
       Done in 0.38s.
       rake aborted!
       Uglifier::Error: Unexpected token: keyword (const). To use ES6 syntax, harmony mode must be enabled with Uglifier.new(:harmony => true).
```