### PR TITLE
Minor UI tweaks

### DIFF
--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -45,9 +45,9 @@ $navbar-tab-active-background-color: transparent
 .border-bottom
   border-bottom: 1px solid $light
 
-header
+header.main
+  @extend .border-bottom
   .navbar
-    @extend .border-bottom
     img
       max-height: 35px
 

--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -121,8 +121,12 @@ footer.footer
   .categories
     @extend .columns, .is-multiline
     padding: 0.75rem 0
+    .category
+      @extend .column, .is-full, .is-half-desktop, .control
   a.button
     @extend .is-light, .is-fullwidth, .is-inline-block, .has-text-left
+    overflow: hidden
+    text-overflow: ellipsis
 
 .project
   header

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -42,7 +42,7 @@ html lang="en"
     = auto_discovery_link_tag :rss, blog_index_url(format: :rss)
 
   body
-    header.container
+    header.main: .container
       nav.navbar aria-label="main navigation" role="navigation"
         .navbar-brand
           = link_to "/", title: title(default: true), class: "navbar-item" do

--- a/app/views/welcome/home.html.slim
+++ b/app/views/welcome/home.html.slim
@@ -7,8 +7,8 @@
           span.icon: i.fa.fa-newspaper-o
           span Read the announcement blog post
 
-.container
-  section.section
+section.section
+  .container
     .columns.is-multiline
       - @groups.each do |group|
         .category-group

--- a/app/views/welcome/home.html.slim
+++ b/app/views/welcome/home.html.slim
@@ -16,8 +16,7 @@ section.section
             = group.name
           .categories
             - group.categories.each do |category|
-              .column.is-half-desktop
-                .control
-                  a.button href=category_path(category)
-                    span.icon: i.fa.fa-folder
-                    span= category.name
+              .category
+                a.button href=category_path(category)
+                  span.icon: i.fa.fa-folder
+                  span= category.name


### PR DESCRIPTION
* Fixes a minor glitch on the new navbar via #347 where the subtle border did not stretch across the entire window anymore
* There was an extra padding on the left and right of the category listing page due to the wrong order of section and container elements, leading it to not be aligned with the header and footer sides
* In tablet view the responsive wrapping of the columns did not work correctly, leading to arbitrary column widths and overflowing text
* Updates the SVG main logo to have the same whitespace on top as on the bottom, leading to vertical alignment across the header bar

Before & After:

![www ruby-toolbox com_ 3](https://user-images.githubusercontent.com/13972/49805025-6944d900-fd54-11e8-8fb6-010ec47ae910.png)
![localhost_5000_ 3](https://user-images.githubusercontent.com/13972/49805026-6944d900-fd54-11e8-98bf-80d7985ada15.png)
