### PR TITLE
UI: Category Cards & Living Styleguide

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,8 @@ gem "rack-ssl-enforcer"
 
 gem "github_webhook"
 
+gem "high_voltage"
+
 gem "http"
 
 gem "sidekiq"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,6 +137,7 @@ GEM
       ruby2ruby (~> 2.4)
       ruby_parser (~> 3.10)
     hashdiff (0.3.7)
+    high_voltage (3.1.0)
     http (4.0.0)
       addressable (~> 2.3)
       http-cookie (~> 1.0)
@@ -392,6 +393,7 @@ DEPENDENCIES
   guard-rspec
   guard-rubocop
   hairtrigger
+  high_voltage
   http
   launchy
   listen (>= 3.0.5, < 3.2)

--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -118,16 +118,6 @@ footer.footer
   h3
     @extend .is-size-4
     padding: 0.75rem 0
-    border-bottom: 2px solid $light
-  .categories
-    @extend .columns, .is-multiline
-    padding: 0.75rem 0
-    .category
-      @extend .column, .is-full, .is-half-desktop, .control
-  a.button
-    @extend .is-light, .is-fullwidth, .is-inline-block, .has-text-left
-    overflow: hidden
-    text-overflow: ellipsis
 
 .project
   header

--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -41,7 +41,7 @@ $navbar-tab-hover-background-color: transparent
 $navbar-tab-active-background-color: transparent
 
 @import "bulma/bulma"
-@import "components/category_card"
+@import "components/**/*"
 
 .border-bottom
   border-bottom: 1px solid $light

--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -41,6 +41,7 @@ $navbar-tab-hover-background-color: transparent
 $navbar-tab-active-background-color: transparent
 
 @import "bulma/bulma"
+@import "components/category_card"
 
 .border-bottom
   border-bottom: 1px solid $light

--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -85,13 +85,13 @@ header.main
     @extend .is-size-2, .is-size-3-mobile
 
   .meta
-    @extend .column, .is-size-5, .is-size-6-mobile, .is-narrow-tablet, .has-text-right-tablet
+    @extend .column, .is-narrow-tablet, .has-text-right-tablet
+  .score
+    @extend .is-size-5, .is-size-6-mobile
   .description
     @extend .is-size-5, .is-size-6-mobile, .has-text-grey-dark
   .categories
     margin-top: 0.75rem
-    a
-      @extend .button, .is-light
 
 section.main
   min-height: 75vh

--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -131,12 +131,8 @@ footer.footer
 
 .project
   header
-    @extend .columns, .is-mobile
-    h3
-      @extend .column, .is-size-4
-
-  .score
-    @extend .is-size-5, .has-text-right
+    .score
+      @extend .is-size-5, .has-text-right
 
   .description
     @extend .has-text-grey

--- a/app/assets/stylesheets/components/category_card.sass
+++ b/app/assets/stylesheets/components/category_card.sass
@@ -6,11 +6,18 @@
 
 .category-card
   @extend .card
+  border-radius: $radius
   width: 100%
   display: flex
   flex-direction: column
   align-items: stretch
   align-content: stretch
+  // When used within a bulma hero, the link text color is forced to black
+  .card-header-icon
+    color: $primary
+  a.card-header
+    &:hover
+      background: $white-ter
   &.inline
     width: auto
     display: inline-block

--- a/app/assets/stylesheets/components/category_card.sass
+++ b/app/assets/stylesheets/components/category_card.sass
@@ -11,6 +11,10 @@
   flex-direction: column
   align-items: stretch
   align-content: stretch
+  &.inline
+    width: auto
+    display: inline-block
+    margin: 10px
   .card-content
     flex: 1
   footer

--- a/app/assets/stylesheets/components/category_card.sass
+++ b/app/assets/stylesheets/components/category_card.sass
@@ -1,0 +1,25 @@
+.category-cards
+  &.four
+    @extend .column, .is-half, .is-one-quarter-desktop, .is-flex
+  &.two
+    @extend .column, .is-full, .is-half-desktop, .is-flex
+
+.category-card
+  @extend .card
+  width: 100%
+  display: flex
+  flex-direction: column
+  align-items: stretch
+  align-content: stretch
+  .card-content
+    flex: 1
+  footer
+    @extend .card-footer
+    .buttons
+      @extend .card-footer-item
+      a
+        @extend .button, .is-small
+        &.project
+          @extend .is-outlined, .is-primary
+        &.other
+          @extend .is-white

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -68,4 +68,8 @@ module ApplicationHelper
   def active_when(controller:)
     "is-active" if controller_name == controller.to_s
   end
+
+  def category_card(category, compact: false)
+    render partial: "components/category_card", locals: { category: category, compact: compact }
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -69,7 +69,17 @@ module ApplicationHelper
     "is-active" if controller_name == controller.to_s
   end
 
-  def category_card(category, compact: false)
-    render partial: "components/category_card", locals: { category: category, compact: compact }
+  def category_card(category, compact: false, inline: false)
+    extra_classes = inline ? %w[inline] : []
+    locals = {
+      category:      category,
+      compact:       compact,
+      extra_classes: extra_classes,
+    }
+    render partial: "components/category_card", locals: locals
+  end
+
+  def component_example(heading, &block)
+    render "components/component_example", heading: heading, &block
   end
 end

--- a/app/views/categories/_list.html.slim
+++ b/app/views/categories/_list.html.slim
@@ -1,5 +1,0 @@
-.buttons
-  - categories.each do |category|
-      a.button.is-light href=category_path(category)
-        span.icon: i.fa.fa-folder
-        span= category.name

--- a/app/views/components/_category_card.html.slim
+++ b/app/views/components/_category_card.html.slim
@@ -1,4 +1,4 @@
-.category-card
+.category-card class=extra_classes
   = link_to category, class: "card-header" do
     p.card-header-icon
       span.icon: i.fa.fa-folder

--- a/app/views/components/_category_card.html.slim
+++ b/app/views/components/_category_card.html.slim
@@ -1,0 +1,21 @@
+.category-card
+  = link_to category, class: "card-header" do
+    p.card-header-icon
+      span.icon: i.fa.fa-folder
+    p.card-header-title
+      = category.name
+
+  - unless compact
+    .card-content
+      small.content= category.description
+
+    footer
+      .buttons
+        - limit = 2
+        - category.projects.first(limit).each do |project|
+          = link_to project, class: "project" do
+            strong= project.permalink
+
+        - if category.projects.count > limit
+          = link_to category, class: "other" do
+            = "and #{category.projects.count - limit} more"

--- a/app/views/components/_component_example.html.slim
+++ b/app/views/components/_component_example.html.slim
@@ -1,0 +1,3 @@
+section.section: .container
+  .content: h3= heading
+  = yield

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -137,6 +137,10 @@ html lang="en"
               li: a href="https://data.ruby-toolbox.com"
                 span.icon: i.fa.fa-table
                 span Production Database Exports
+              - unless Rails.env.production?
+                li: a href=page_path("components")
+                  span.icon: i.fa.fa-code
+                  span UI Styleguide
 
         hr
 

--- a/app/views/pages/components.html.slim
+++ b/app/views/pages/components.html.slim
@@ -4,6 +4,6 @@
     h2 Components Overview
 
 section.section: .container
-  .component-list.columns
+  .component-list.columns.is-multiline
     - HighVoltage.page_ids.select {|id| id.start_with? "components/" }.sort.each do |path|
       .column.is-half= link_to path.split("/").last.humanize, page_path(path), class: "button is-outlined is-fullwidth is-info"

--- a/app/views/pages/components.html.slim
+++ b/app/views/pages/components.html.slim
@@ -4,6 +4,12 @@
     h2 Components Overview
 
 section.section: .container
+  .content
+    markdown:
+      This is styleguide gives an overview of common UI components used across the site. The base UI framework used is [Bulma](https://bulma.io/documentation/), please refer to it's documentation for more generic topics.
+
+      This is page is of course a work-in-progress ;)
+
   .component-list.columns.is-multiline
     - HighVoltage.page_ids.select {|id| id.start_with? "components/" }.sort.each do |path|
       .column.is-half= link_to path.split("/").last.humanize, page_path(path), class: "button is-outlined is-fullwidth is-info"

--- a/app/views/pages/components.html.slim
+++ b/app/views/pages/components.html.slim
@@ -1,0 +1,9 @@
+.hero
+  section.section: .container
+    p.heading= link_to "Ruby Toolbox UI Components Styleguide", "/pages/components"
+    h2 Components Overview
+
+section.section: .container
+  .component-list.columns
+    - HighVoltage.page_ids.select {|id| id.start_with? "components/" }.sort.each do |path|
+      .column.is-half= link_to path.split("/").last.humanize, page_path(path), class: "button is-outlined is-fullwidth is-info"

--- a/app/views/pages/components/category_card.html.slim
+++ b/app/views/pages/components/category_card.html.slim
@@ -1,0 +1,29 @@
+section.section: .container
+  - categories = Category.limit(8)
+  .columns.is-multiline
+    - categories.each do |category|
+      .category-cards.four
+        = category_card category
+
+  .columns.is-multiline
+    - categories.each do |category|
+      .category-cards.four
+        = category_card category, compact: true
+
+  .columns.is-multiline
+    - categories.each do |category|
+      .category-cards.two
+        = category_card category, compact: false
+
+  .columns.is-multiline
+    - categories.each do |category|
+      .category-cards.two
+        = category_card category, compact: true
+
+  .columns
+    .column
+      .columns.is-multiline
+        - categories.each do |category|
+          .category-cards.two
+            = category_card category, compact: true
+    .column

--- a/app/views/pages/components/category_card.html.slim
+++ b/app/views/pages/components/category_card.html.slim
@@ -1,3 +1,8 @@
+.hero
+  section.section: .container
+    p.heading= link_to "Ruby Toolbox UI Components Styleguide", "/pages/components"
+    h2= current_page.split("/").last.humanize
+
 - categories = Category.limit(8)
 
 = component_example "Full card in four column grid" do

--- a/app/views/pages/components/category_card.html.slim
+++ b/app/views/pages/components/category_card.html.slim
@@ -3,7 +3,7 @@
     p.heading= link_to "Ruby Toolbox UI Components Styleguide", "/pages/components"
     h2= current_page.split("/").last.humanize
 
-- categories = Category.limit(8)
+- categories = Category.limit(8).includes(:projects)
 
 = component_example "Full card in four column grid" do
   .columns.is-multiline

--- a/app/views/pages/components/category_card.html.slim
+++ b/app/views/pages/components/category_card.html.slim
@@ -1,25 +1,30 @@
-section.section: .container
-  - categories = Category.limit(8)
+- categories = Category.limit(8)
+
+= component_example "Full card in four column grid" do
   .columns.is-multiline
     - categories.each do |category|
       .category-cards.four
         = category_card category
 
+= component_example "Compact card in four column grid" do
   .columns.is-multiline
     - categories.each do |category|
       .category-cards.four
         = category_card category, compact: true
 
+= component_example "Full card in two column grid" do
   .columns.is-multiline
     - categories.each do |category|
       .category-cards.two
         = category_card category, compact: false
 
+= component_example "Compact card in two column grid" do
   .columns.is-multiline
     - categories.each do |category|
       .category-cards.two
         = category_card category, compact: true
 
+= component_example "The grid obviously uses just it's container" do
   .columns
     .column
       .columns.is-multiline
@@ -27,3 +32,18 @@ section.section: .container
           .category-cards.two
             = category_card category, compact: true
     .column
+      .columns.is-multiline
+        - categories.each do |category|
+          .category-cards.two
+            = category_card category
+
+= component_example "Omit the wrapping grid to stack" do
+  .columns
+    .column
+      - categories.each do |category|
+        = category_card category, compact: true
+    .column Other column
+
+= component_example "Cards can be displayed inline" do
+  - categories.each do |category|
+    = category_card category, compact: true, inline: true

--- a/app/views/projects/_project.html.slim
+++ b/app/views/projects/_project.html.slim
@@ -1,17 +1,27 @@
 .project.box
-  header
-    h3.is-size-4
-      // Note that rails url helpers escape slashes (as seen in github-based projects) and this breaks.
-      a href="/projects/#{project.permalink}"
-        = project.permalink
-    .column: .score
-      span.icon
-        i.fa.fa-flask
-      span= project.score
+  header.level.is-mobile
+    .level-left
+      .level-item
+        // Note that rails url helpers escape slashes (as seen in github-based projects) and this breaks.
+        h3.is-size-4
+          a href="/projects/#{project.permalink}"
+            = project.permalink
+
+    .level-right
+      - if local_assigns[:show_categories] and project.categories.any?
+        .level-item.categories.is-hidden-touch
+          - project.categories.each do |category|
+            = category_card category, compact: true, inline: true
+      .level-item.score
+        span.icon
+          i.fa.fa-flask
+        span= project.score
 
   - if local_assigns[:show_categories] and project.categories.any?
-    .columns: .category-list.column
-      = render partial: "categories/list", locals: { categories: project.categories }
+    .columns.is-hidden-desktop: .column
+      - project.categories.each do |category|
+        = category_card category, compact: true, inline: true
+
 
   .columns: .links.column
     = render partial: "projects/links", locals: { project: project }

--- a/app/views/projects/show.html.slim
+++ b/app/views/projects/show.html.slim
@@ -14,14 +14,10 @@
         span.icon
           i.fa.fa-flask
         span= @project.score
+
       .categories
-        ul
-          - @project.categories.each do |category|
-            li
-              .control
-                a href=category_path(category)
-                  span.icon: i.fa.fa-folder
-                  span= category.name
+        - @project.categories.each do |category|
+          = category_card category, compact: true, inline: true
 
   .columns: .links.column
     = render partial: "projects/links", locals: { project: @project }

--- a/app/views/searches/show.html.slim
+++ b/app/views/searches/show.html.slim
@@ -23,9 +23,11 @@
 - if @search
   section.section.search-results: .container
     - if @search.categories.any?
-      .columns: .column.categories
+      .columns: .column
         h2.subtitle.is-4 Categories
-        = render partial: "categories/list", locals: { categories: @search.categories }
+        .columns.is-multiline
+          - @search.categories.each do |category|
+            .category-cards.four= category_card category
 
     - if @search.projects.any?
       .columns: .column.projects

--- a/app/views/welcome/home.html.slim
+++ b/app/views/welcome/home.html.slim
@@ -14,9 +14,7 @@ section.section
         .category-group
           h3.is-size-4
             = group.name
-          .categories
+          .columns.is-multiline
             - group.categories.each do |category|
-              .category
-                a.button href=category_path(category)
-                  span.icon: i.fa.fa-folder
-                  span= category.name
+              .category-cards.two
+                = category_card category, compact: true

--- a/spec/features/styleguide_spec.rb
+++ b/spec/features/styleguide_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Styleguide Display", type: :feature do
+  it "can display all pages of the styleguide" do
+    group = CategoryGroup.create! permalink: "group1", name: "Group"
+    category = Category.create! permalink: "widgets", name: "Widgets", category_group: group
+    category.projects << Project.create!(permalink: "rspec", score: 25)
+
+    visit "/pages/components"
+    within ".hero" do
+      expect(page).to have_text "Ruby Toolbox UI Components Styleguide"
+      expect(page).to have_text "Components Overview"
+    end
+
+    page_links = page.find_all(".component-list a")
+    expect(page_links.size).to be > 0
+
+    page_links.each do |link|
+      visit link["href"]
+      within ".hero" do
+        expect(page).to have_text link.text
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces new, unified category card component. 

It also marks the beginning of an effort to clean up and unify styling across the site into reusable components to get rid of the current, chaotic sprinkles of bulma-specific CSS classes within the views.

To that end, this card is used via a simple helper that calls the underlying partial.

This PR also introduces a very simple "living styleguide" to document, showcase and test components and their intended use in isolation. After deploy, the page will be available via https://www.ruby-toolbox.com/pages/components

The styleguide is rendered using the [high_voltage gem](https://github.com/thoughtbot/high_voltage), which is also newly introduced here. The gem will also be used for the upcoming docs/guides section.

The new card component is introduced across the page in it's different styles, and will also be helpful for showing popular categories nicely via #335 

Here's a bunch of before/after screenshots combined into looping gifs (with `convert -delay 100 -loop 0 old.png new.png out.gif`):

![search](https://user-images.githubusercontent.com/13972/49883326-bf884980-fe32-11e8-87c4-5bc72ffa7b30.gif)

---

![categories](https://user-images.githubusercontent.com/13972/49883324-bf884980-fe32-11e8-9cde-338367bd1b92.gif)

---

![mobile_project_details](https://user-images.githubusercontent.com/13972/49883325-bf884980-fe32-11e8-9d22-a16db6690881.gif)

---

![search_multi_category](https://user-images.githubusercontent.com/13972/49883327-bf884980-fe32-11e8-9c0c-e94122ba4317.gif)
