### PR TITLE
Eager-load projects for categories on search

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -91,6 +91,8 @@ group :test do
 
   gem "feedjira"
 
+  gem "db-query-matchers"
+
   gem "rails-controller-testing"
   gem "simplecov", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,9 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
+    db-query-matchers (0.9.0)
+      activesupport (>= 4.0, <= 6.0)
+      rspec (~> 3.0)
     diff-lcs (1.3)
     docile (1.3.0)
     domain_name (0.5.20180417)
@@ -384,6 +387,7 @@ DEPENDENCIES
   capybara (>= 2.15, < 4.0)
   chromedriver-helper
   coffee-rails (~> 4.2)
+  db-query-matchers
   dotenv-rails
   feedjira
   foreman

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -32,7 +32,7 @@ class Category < ApplicationRecord
                   ranked_by: ":tsearch"
 
   def self.search(query)
-    search_scope(query)
+    includes(:projects).search_scope(query)
   end
 
   def self.find_for_show!(permalink)

--- a/app/views/pages/components/category_card.html.slim
+++ b/app/views/pages/components/category_card.html.slim
@@ -11,6 +11,10 @@
       .category-cards.four
         = category_card category
 
+  .notification.is-warning
+    span.icon: i.fa.fa-warning
+    span Remember to eager-load the projects association when displaying categories with the full card to prevent n+1 queries
+
 = component_example "Compact card in four column grid" do
   .columns.is-multiline
     - categories.each do |category|

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -18,6 +18,16 @@ RSpec.describe Category, type: :model do
 
       expect(Category.search("mock")).to be == [category]
     end
+
+    it "eager-loads associated projects" do
+      5.times do |i|
+        category = Category.create! name: "widgets #{i}", permalink: i.to_s, category_group: group
+        category.projects << Project.create!(permalink: i.to_s)
+      end
+
+      scope = Category.search("widgets")
+      expect { scope.flat_map { |category| category.projects.map(&:permalink) } } .to make_database_queries(count: 3)
+    end
   end
 
   describe ".by_rank" do


### PR DESCRIPTION
Followup to #350 - since we now also show a the top project names on the category search result cards they should be eager loaded.