### PR TITLE
Include category descriptions in full text search

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -21,10 +21,10 @@ class Category < ApplicationRecord
 
   include PgSearch
   pg_search_scope :search_scope,
-                  against:   :name_tsvector,
+                  against:   %i[name_tsvector description_tsvector],
                   using:     {
                     tsearch: {
-                      tsvector_column: %w[name_tsvector],
+                      tsvector_column: %w[name_tsvector description_tsvector],
                       prefix:          true,
                       dictionary:      "simple",
                     },

--- a/db/migrate/20181213102703_add_category_description_ts_vector.rb
+++ b/db/migrate/20181213102703_add_category_description_ts_vector.rb
@@ -1,22 +1,22 @@
 # frozen_string_literal: true
 
-class AddCategoryTsVectorColumn < ActiveRecord::Migration[5.1]
+class AddCategoryDescriptionTsVector < ActiveRecord::Migration[5.2]
   # See https://github.com/Casecommons/pg_search/wiki/Building-indexes
   def up
-    vector_column = "name_tsvector"
+    vector_column = "description_tsvector"
     add_column :categories, vector_column, :tsvector
     add_index :categories, vector_column, using: "gin"
 
     trigger_name = "categories_update_#{vector_column}_trigger"
     create_trigger(trigger_name, compatibility: 1).on(:categories).before(:insert, :update) do
-      "new.#{vector_column} := to_tsvector('pg_catalog.simple', coalesce(new.name, ''));"
+      "new.#{vector_column} := to_tsvector('pg_catalog.simple', coalesce(new.description, ''));"
     end
 
     execute "UPDATE categories SET permalink = permalink"
   end
 
   def down
-    remove_column :categories, "name_tsvector"
-    drop_trigger "categories_update_name_tsvector_trigger", :categories, compatibility: 1
+    remove_column :categories, "description_tsvector"
+    drop_trigger "categories_update_description_tsvector_trigger", :categories, compatibility: 1
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -51,6 +51,20 @@ COMMENT ON EXTENSION pg_stat_statements IS 'track execution statistics of all SQ
 
 
 --
+-- Name: categories_update_description_tsvector_trigger(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.categories_update_description_tsvector_trigger() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    new.description_tsvector := to_tsvector('pg_catalog.simple', coalesce(new.description, ''));
+    RETURN NEW;
+END;
+$$;
+
+
+--
 -- Name: categories_update_name_tsvector_trigger(); Type: FUNCTION; Schema: public; Owner: -
 --
 
@@ -120,7 +134,8 @@ CREATE TABLE public.categories (
     updated_at timestamp without time zone NOT NULL,
     category_group_permalink public.citext NOT NULL,
     name_tsvector tsvector,
-    rank integer
+    rank integer,
+    description_tsvector tsvector
 );
 
 
@@ -315,6 +330,13 @@ CREATE INDEX index_categories_on_category_group_permalink ON public.categories U
 
 
 --
+-- Name: index_categories_on_description_tsvector; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_categories_on_description_tsvector ON public.categories USING gin (description_tsvector);
+
+
+--
 -- Name: index_categories_on_name_tsvector; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -399,6 +421,13 @@ CREATE UNIQUE INDEX index_rubygems_on_name ON public.rubygems USING btree (name)
 
 
 --
+-- Name: categories categories_update_description_tsvector_trigger; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER categories_update_description_tsvector_trigger BEFORE INSERT OR UPDATE ON public.categories FOR EACH ROW EXECUTE PROCEDURE public.categories_update_description_tsvector_trigger();
+
+
+--
 -- Name: categories categories_update_name_tsvector_trigger; Type: TRIGGER; Schema: public; Owner: -
 --
 
@@ -480,6 +509,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180322231848'),
 ('20180718195202'),
 ('20181205134522'),
-('20181210092238');
+('20181210092238'),
+('20181213102703');
 
 

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -7,16 +7,24 @@ RSpec.describe Category, type: :model do
     CategoryGroup.create! permalink: "unimportant", name: "unimportant"
   end
   let(:category) do
-    Category.create! permalink: "mocking", name: "Mocking Frameworks", category_group: group
+    Category.create! permalink:      "mocking",
+                     name:           "Mocking Frameworks",
+                     description:    "Widgets Factory",
+                     category_group: group
   end
 
   describe ".search" do
-    it "can find a matching category" do
+    it "can find a matching category by name" do
       category
       Category.create! permalink: "foo", name: "Foo", category_group: group
       Category.create! permalink: "bar", name: "Bar", category_group: group
 
       expect(Category.search("mock")).to be == [category]
+    end
+
+    it "can find a matching category by description" do
+      category
+      expect(Category.search("widget")).to be == [category]
     end
 
     it "eager-loads associated projects" do


### PR DESCRIPTION
This increases findability of categories since we're not limited to just the words in the name, but also to the wider keyword namespace provided by the description. Example: Searching for "web application" or "web development" did not find the web app frameworks category before, now it does.

Maybe to further expand on this it would be helpful to also maintain some "hidden" keywords that apply to the search, but first lets see how this goes and focus on providing good descriptions for all categories that contain some reasonable search words inside the description itself