### PR TITLE
Project health checks and display

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -84,9 +84,8 @@ Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
 
 Style/ClassAndModuleChildren:
-  Exclude:
-    # Prefer rails convention
-    - 'app/controllers/**/*'
+  # Against rails conventions
+  Enabled: false
 
 RSpec/FilePath:
   Exclude:

--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -32,6 +32,7 @@ $weight-bold:     700
 $red: #A61414
 $link: $red
 $primary: $red
+$success: #59A80F
 $text: #222
 
 $navbar-height: 5rem

--- a/app/assets/stylesheets/components/project_health_tag.sass
+++ b/app/assets/stylesheets/components/project_health_tag.sass
@@ -1,0 +1,14 @@
+.project-health-tags
+  @extend .field, .is-grouped, .is-grouped-multiline
+
+.project-health-tag
+  @extend .control
+  &.level-green
+    .tag
+      @extend .is-success
+  &.level-yellow
+    .tag
+      @extend .is-warning
+  &.level-red
+    .tag
+      @extend .is-danger

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -79,6 +79,10 @@ module ApplicationHelper
     render partial: "components/category_card", locals: locals
   end
 
+  def project_health_tag(health_status)
+    render "components/project_health_tag", status: health_status
+  end
+
   def component_example(heading, &block)
     render "components/component_example", heading: heading, &block
   end

--- a/app/models/github_repo.rb
+++ b/app/models/github_repo.rb
@@ -9,6 +9,9 @@ class GithubRepo < ApplicationRecord
            inverse_of:  :github_repo,
            dependent:   :nullify
 
+  has_many :rubygems,
+           through: :projects
+
   def self.update_batch
     where("updated_at < ? ", 24.hours.ago.utc)
       .order(updated_at: :asc)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -26,6 +26,7 @@ class Project < ApplicationRecord
              inverse_of:  :projects
 
   scope :includes_associations, -> { includes(:github_repo, :rubygem, :categories) }
+  scope :with_score, -> { where.not(score: nil) }
 
   include PgSearch
   pg_search_scope :search_scope,
@@ -42,7 +43,7 @@ class Project < ApplicationRecord
                   ranked_by: ":tsearch * (#{table_name}.score + 1) * (#{table_name}.score + 1)"
 
   def self.search(query)
-    where.not(score: nil).includes_associations.search_scope(query).limit(25)
+    with_score.includes_associations.search_scope(query).limit(25)
   end
 
   delegate :current_version,
@@ -70,6 +71,8 @@ class Project < ApplicationRecord
            :homepage_url,
            :watchers_count,
            :description,
+           :archived?,
+           :repo_pushed_at,
            :wiki_url,
            :issues_url,
            :url,

--- a/app/models/project/health.rb
+++ b/app/models/project/health.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+#
+# Creates a health assessment for given project instance based on health checks defined
+# in Project::Health::Checks
+#
+class Project::Health
+  class Status
+    attr_accessor :key, :level, :icon, :check_block
+    def initialize(key, level, icon, &check_block)
+      self.key = key
+      self.level = level
+      self.icon = icon
+      self.check_block = check_block
+
+      raise ArgumentError, "Unknown level #{level}" unless %i[red yellow green].include? level
+      raise I18n::MissingTranslation.new(I18n.locale, i18n_key) unless I18n.exists? i18n_key
+    end
+
+    def label
+      I18n.t i18n_key
+    end
+
+    def applies?(project)
+      !!check_block.call(project)
+    end
+
+    private
+
+    def i18n_key
+      "project_health.#{key}"
+    end
+  end
+
+  HEALTHY_STATUS = Project::Health::Status.new(:healthy, :green, :heartbeat, &:present?)
+
+  attr_accessor :project, :checks
+  private :project=, :checks=
+
+  def initialize(project)
+    self.project = project
+    self.checks = Checks::ALL
+  end
+
+  def status
+    @status ||= checks.select { |check| check.applies? project }.presence || [HEALTHY_STATUS]
+  end
+end

--- a/app/models/project/health/checks.rb
+++ b/app/models/project/health/checks.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Project::Health::Checks
+  GITHUB_REPO_ARCHIVED = Project::Health::Status.new(:github_repo_archived, :red, :github, &:github_repo_archived?)
+
+  GITHUB_REPO_GONE = Project::Health::Status.new(:github_repo_gone, :red, :github) do |project|
+    project.github_repo_path? &&
+      project.github_repo.nil?
+  end
+
+  GITHUB_REPO_NO_COMMIT_ACTIVITY = Project::Health::Status.new(:no_commit_activity, :red, :github) do |project|
+    project.github_repo_repo_pushed_at &&
+      project.github_repo_repo_pushed_at < 3.years.ago
+  end
+
+  GITHUB_REPO_LOW_COMMIT_ACTIVITY = Project::Health::Status.new(:low_commit_activity, :yellow, :github) do |project|
+    !GITHUB_REPO_NO_COMMIT_ACTIVITY.applies?(project) &&
+      project.github_repo_average_recent_committed_at &&
+      project.github_repo_average_recent_committed_at < 3.years.ago
+  end
+
+  GITHUB_REPO_OPEN_ISSUES = Project::Health::Status.new(:github_repo_open_issues, :yellow, :github) do |project|
+    project.github_repo_total_issues_count &&
+      project.github_repo_total_issues_count > 5 &&
+      project.github_repo_issue_closure_rate < 75
+  end
+
+  RUBYGEM_ABANDONED = Project::Health::Status.new(:rubygem_abandoned, :red, :diamond) do |project|
+    project.rubygem_latest_release_on &&
+      project.rubygem_latest_release_on < 3.years.ago
+  end
+
+  RUBYGEM_STALE = Project::Health::Status.new(:rubygem_stale, :yellow, :diamond) do |project|
+    !RUBYGEM_ABANDONED.applies?(project) &&
+      project.rubygem_latest_release_on &&
+      project.rubygem_latest_release_on < 1.year.ago
+  end
+
+  RUBYGEM_LONG_RUNNING = Project::Health::Status.new(:rubygem_long_running, :green, :diamond) do |project|
+    project.rubygem_latest_release_on &&
+      project.rubygem_first_release_on &&
+      project.rubygem_first_release_on < 5.years.ago &&
+      project.rubygem_latest_release_on > 1.year.ago
+  end
+
+  ALL = [
+    GITHUB_REPO_ARCHIVED,
+    GITHUB_REPO_GONE,
+    GITHUB_REPO_NO_COMMIT_ACTIVITY,
+    RUBYGEM_ABANDONED,
+    GITHUB_REPO_LOW_COMMIT_ACTIVITY,
+    GITHUB_REPO_OPEN_ISSUES,
+    RUBYGEM_STALE,
+    RUBYGEM_LONG_RUNNING,
+  ].freeze
+end

--- a/app/views/components/_project_health_tag.html.slim
+++ b/app/views/components/_project_health_tag.html.slim
@@ -1,0 +1,5 @@
+.project-health-tag class="level-#{status.level}"
+  .tags.has-addons
+    span.tag
+      span.icon: i.fa class="fa-#{status.icon}"
+    strong.tag= status.label

--- a/app/views/pages/components/project_health_tag.html.slim
+++ b/app/views/pages/components/project_health_tag.html.slim
@@ -1,0 +1,10 @@
+.hero
+  section.section: .container
+    p.heading= link_to "Ruby Toolbox UI Components Styleguide", "/pages/components"
+    h2= current_page.split("/").last.humanize
+
+= component_example "Project Health tags" do
+  .project-health-tags
+    = project_health_tag Project::Health::HEALTHY_STATUS
+    - Project::Health::Checks::ALL.each do |status|
+      = project_health_tag status

--- a/app/views/projects/_project.html.slim
+++ b/app/views/projects/_project.html.slim
@@ -17,6 +17,11 @@
           i.fa.fa-flask
         span= project.score
 
+  .columns: .column
+    .project-health-tags
+      - Project::Health.new(project).status.each do |status|
+        = project_health_tag status
+
   - if local_assigns[:show_categories] and project.categories.any?
     .columns.is-hidden-desktop: .column
       - project.categories.each do |category|

--- a/app/views/projects/show.html.slim
+++ b/app/views/projects/show.html.slim
@@ -19,6 +19,11 @@
         - @project.categories.each do |category|
           = category_card category, compact: true, inline: true
 
+  .columns: .column
+    .project-health-tags
+      - Project::Health.new(@project).status.each do |status|
+        = project_health_tag status
+
   .columns: .links.column
     = render partial: "projects/links", locals: { project: @project }
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,12 +33,12 @@ en:
   tagline: Know your options!
   description: Explore and compare open source Ruby libraries
   project_health:
-    github_repo_archived: GitHub repository is archived
-    github_repo_gone: The GitHub repo is gone
-    github_repo_open_issues: There's a lot of unresolved issues
-    rubygem_abandoned: No rubygems release in more than 3 years
-    rubygem_stale: No rubygems release in 1 year
-    low_commit_activity: Very low commit activity in last 3 years
+    github_repo_archived: Repository is archived
+    github_repo_gone: Repository is gone
+    github_repo_open_issues: There's a lot of open issues
+    rubygem_abandoned: No release in over 3 years
+    rubygem_stale: No release in over a year
+    low_commit_activity: Low commit activity in last 3 years
     no_commit_activity: No commit activity in last 3 years
-    healthy: The project appears to be in a healthy maintained state
-    rubygem_long_running: This project has been around for a long time and still gets updates
+    healthy: The project appears to be in a healthy, maintained state
+    rubygem_long_running: Has been around for more than 5 years and still receives updates

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,3 +32,13 @@ en:
   name: The Ruby Toolbox
   tagline: Know your options!
   description: Explore and compare open source Ruby libraries
+  project_health:
+    github_repo_archived: GitHub repository is archived
+    github_repo_gone: The GitHub repo is gone
+    github_repo_open_issues: There's a lot of unresolved issues
+    rubygem_abandoned: No rubygems release in more than 3 years
+    rubygem_stale: No rubygems release in 1 year
+    low_commit_activity: Very low commit activity in last 3 years
+    no_commit_activity: No commit activity in last 3 years
+    healthy: The project appears to be in a healthy maintained state
+    rubygem_long_running: This project has been around for a long time and still gets updates

--- a/spec/models/project/health/checks_spec.rb
+++ b/spec/models/project/health/checks_spec.rb
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Project::Health::Checks, type: :model do
+  describe "GITHUB_REPO_ARCHIVED" do
+    let(:check) { described_class::GITHUB_REPO_ARCHIVED }
+
+    it "applies when project has github_repo_archived" do
+      project = instance_double Project, github_repo_archived?: true
+      expect(check.applies?(project)).to be true
+    end
+
+    it "does not apply when project does not have github_repo_archived" do
+      project = instance_double Project, github_repo_archived?: false
+      expect(check.applies?(project)).to be false
+    end
+  end
+
+  describe "GITHUB_REPO_GONE" do
+    let(:check) { described_class::GITHUB_REPO_GONE }
+
+    it "applies when project has a github_repo_path but no corresponding db record" do
+      project = instance_double Project, github_repo_path?: true, github_repo: nil
+      expect(check.applies?(project)).to be true
+    end
+
+    it "does not apply when project has github_repo" do
+      project = instance_double Project, github_repo_path?: true, github_repo: "123"
+      expect(check.applies?(project)).to be false
+    end
+
+    it "does not apply when project has no github_repo_path" do
+      project = instance_double Project, github_repo_path?: false
+      expect(check.applies?(project)).to be false
+    end
+  end
+
+  describe "GITHUB_REPO_NO_COMMIT_ACTIVITY" do
+    let(:check) { described_class::GITHUB_REPO_NO_COMMIT_ACTIVITY }
+
+    it "applies when project has a github_repo_repo_pushed_at more than 3 years ago" do
+      project = instance_double Project, github_repo_repo_pushed_at: 3.years.ago - 1.minute
+      expect(check.applies?(project)).to be true
+    end
+
+    it "does not apply when project has no github_repo_repo_pushed_at" do
+      project = instance_double Project, github_repo_repo_pushed_at: nil
+      expect(check.applies?(project)).to be false
+    end
+
+    it "does not apply when project has recent github_repo_repo_pushed_at" do
+      project = instance_double Project, github_repo_repo_pushed_at: 3.years.ago + 1.minute
+      expect(check.applies?(project)).to be false
+    end
+  end
+
+  describe "GITHUB_REPO_LOW_COMMIT_ACTIVITY" do
+    let(:check) { described_class::GITHUB_REPO_LOW_COMMIT_ACTIVITY }
+
+    it "applies when project has github_repo_average_recent_committed_at more than 3 years ago" do
+      allow(described_class::GITHUB_REPO_NO_COMMIT_ACTIVITY).to receive(:applies?)
+      project = instance_double Project, github_repo_average_recent_committed_at: 3.years.ago - 1.minute
+      expect(check.applies?(project)).to be true
+    end
+
+    it "does not apply if no commit activity check applies as well" do
+      allow(described_class::GITHUB_REPO_NO_COMMIT_ACTIVITY).to receive(:applies?).and_return(true)
+      project = instance_double Project, github_repo_average_recent_committed_at: 3.years.ago - 1.minute
+      expect(check.applies?(project)).to be false
+    end
+
+    it "does not apply when github_repo_average_recent_committed_at is less than 3 years ago" do
+      allow(described_class::GITHUB_REPO_NO_COMMIT_ACTIVITY).to receive(:applies?)
+      project = instance_double Project, github_repo_average_recent_committed_at: 3.years.ago + 1.minute
+      expect(check.applies?(project)).to be false
+    end
+  end
+
+  describe "GITHUB_REPO_OPEN_ISSUES" do
+    let(:check) { described_class::GITHUB_REPO_OPEN_ISSUES }
+
+    it "applies when project has more than 5 total issues and closure rate is below 75" do
+      project = instance_double Project, github_repo_total_issues_count: 6, github_repo_issue_closure_rate: 74.9
+      expect(check.applies?(project)).to be true
+    end
+
+    it "does not apply when project does not have more than 5 issues" do
+      project = instance_double Project, github_repo_total_issues_count: 5, github_repo_issue_closure_rate: 74.9
+      expect(check.applies?(project)).to be false
+    end
+
+    it "does not apply when project has high clousre rate" do
+      project = instance_double Project, github_repo_total_issues_count: 6, github_repo_issue_closure_rate: 75.1
+      expect(check.applies?(project)).to be false
+    end
+
+    it "does not apply when project has no issues" do
+      project = instance_double Project, github_repo_total_issues_count: nil
+      expect(check.applies?(project)).to be false
+    end
+  end
+
+  describe "RUBYGEM_ABANDONED" do
+    let(:check) { described_class::RUBYGEM_ABANDONED }
+
+    it "applies when gem had no release in more than 3 years" do
+      project = instance_double Project, rubygem_latest_release_on: 3.years.ago - 1.minute
+      expect(check.applies?(project)).to be true
+    end
+
+    it "does not apply when gem had release within last than 3 years" do
+      project = instance_double Project, rubygem_latest_release_on: 3.years.ago + 1.minute
+      expect(check.applies?(project)).to be false
+    end
+
+    it "does not apply when gem had no release" do
+      project = instance_double Project, rubygem_latest_release_on: nil
+      expect(check.applies?(project)).to be false
+    end
+  end
+
+  describe "RUBYGEM_STALE" do
+    let(:check) { described_class::RUBYGEM_STALE }
+
+    before do
+      allow(described_class::RUBYGEM_ABANDONED).to receive(:applies?)
+    end
+
+    it "applies when gem had no release in more than last year" do
+      project = instance_double Project, rubygem_latest_release_on: 1.year.ago - 1.minute
+      expect(check.applies?(project)).to be true
+    end
+
+    it "does not apply when RUBYGEM_ABANDONED check applies" do
+      allow(described_class::RUBYGEM_ABANDONED).to receive(:applies?).and_return(true)
+      project = instance_double Project, rubygem_latest_release_on: 1.year.ago - 1.minute
+      expect(check.applies?(project)).to be false
+    end
+
+    it "does not apply when gem had release within last year" do
+      project = instance_double Project, rubygem_latest_release_on: 1.year.ago + 1.minute
+      expect(check.applies?(project)).to be false
+    end
+
+    it "does not apply when gem had no release" do
+      project = instance_double Project, rubygem_latest_release_on: nil
+      expect(check.applies?(project)).to be false
+    end
+  end
+
+  describe "RUBYGEM_LONG_RUNNING" do
+    let(:check) { described_class::RUBYGEM_LONG_RUNNING }
+
+    it "applies when gem is older than 5 years and had a release within last year" do
+      project = instance_double Project,
+                                rubygem_first_release_on:  5.years.ago - 1.minute,
+                                rubygem_latest_release_on: 1.year.ago + 1.minute
+      expect(check.applies?(project)).to be true
+    end
+
+    it "does not apply when gem is newer than 5 years" do
+      project = instance_double Project,
+                                rubygem_first_release_on:  5.years.ago + 1.minute,
+                                rubygem_latest_release_on: 1.year.ago + 1.minute
+      expect(check.applies?(project)).to be false
+    end
+
+    it "does not apply when gem has no release within last year" do
+      project = instance_double Project,
+                                rubygem_first_release_on:  5.years.ago - 1.minute,
+                                rubygem_latest_release_on: 1.year.ago - 1.minute
+      expect(check.applies?(project)).to be false
+    end
+
+    it "does not apply when project has no releases" do
+      project = instance_double Project,
+                                rubygem_first_release_on:  nil,
+                                rubygem_latest_release_on: nil
+      expect(check.applies?(project)).to be false
+    end
+  end
+end


### PR DESCRIPTION
Detection of unmaintained projects came in highest in the recent [community survey](https://www.ruby-toolbox.com/blog/2018-12-04/survey-results).

This PR adds project health checks to make it easier to make a quick assessment of the maintenance status of a project.

See [checks.rb](https://github.com/rubytoolbox/rubytoolbox/blob/536d73f3c66f9e36b67dc7701ef24cbb44333de2/app/models/project/health/checks.rb) for the currently defined checks. For starters it's mostly about commit and release activity, hopefully over time we can add a few more of these.

The assessments have 3 levels: Green, yellow and red, depending on the status. 

* For red I picked a timeframe of 3 years (no gem release in 3 years, no commits in 3 years)
* For yellow it's 1 year of inactivity

![bildschirmfoto vom 2018-12-13 16 12 51](https://user-images.githubusercontent.com/13972/49947621-f83b2800-fef1-11e8-8309-c3a68fe3705e.png)

Let's see how this goes. From a cursory glance across categories the indication seems nice, at the very least it seems to be working well on some very popular and well-maintained projects as well as some clearly unmaintained ones. Once this is live I'd like to gather some feedback, for example if we have a lot of gems that have no release in a year but work perfectly fine maybe the timeframe should be changed - in the end it's just supposed to give some guidance, making a one-size-fits-all solution likely is impossible anyway due to the huge variety of libraries we have out there.

Here's what it looks like:

![health](https://user-images.githubusercontent.com/13972/50002801-a05bfa00-ffa1-11e8-8740-0e52087a6980.gif)

