### PR TITLE
Shorten long health labels to avoid breaking container on mobile

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,5 +40,5 @@ en:
     rubygem_stale: No release in over a year
     low_commit_activity: Low commit activity in last 3 years
     no_commit_activity: No commit activity in last 3 years
-    healthy: The project appears to be in a healthy, maintained state
-    rubygem_long_running: Has been around for more than 5 years and still receives updates
+    healthy: The project is in a healthy, maintained state
+    rubygem_long_running: A long-lived project that still receives updates


### PR DESCRIPTION
On mobile these two labels for #355 were a bit too long, making them break out of their container. Also, the specific "5 years" for long-lived projects could give the wrong impression that the project was exactly 5 years old, so I generalized that as well.

I looked into making the label text wrap into multiple lines, but this is not currently supported by the Bulma framework, and rolling our own seems a bit excessive considering that we use the tag addons for the icon and both would need to grow in height in sync. It's probably a good idea to have the text concise anyway :)