### PR TITLE
Sticky top navigation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,8 @@ gem "sidekiq"
 gem "redcarpet"
 gem "slim-rails"
 
+gem "retriable"
+
 # Shorter request logs
 gem "lograge"
 # Needed for logstash json_event formatter for lograge

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -257,6 +257,7 @@ GEM
     regexp_parser (1.3.0)
     request_store (1.4.1)
       rack (>= 1.4)
+    retriable (3.1.2)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -414,6 +415,7 @@ DEPENDENCIES
   rails (~> 5.2.0)
   rails-controller-testing
   redcarpet
+  retriable
   rspec-rails
   rubocop
   rubocop-rspec

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -18,7 +18,7 @@
 document.addEventListener("turbolinks:load", function () {
   // Make the sticky top nav hide on scroll, re-appear on scrolling up.
   // See https://wicky.nillia.ms/headroom.js/
-  new Headroom(document.querySelector("header.main .navbar")).init();
+  new Headroom(document.querySelector("header.main .navbar"), { offset: 250 }).init();
 
   // Snippet to enable the bulma burger menu in mobile
   // taken from https://bulma.io/documentation/components/navbar/#navbar-menu

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,9 +12,12 @@
 //
 //= require rails-ujs
 //= require turbolinks
+//= require headroom.js/dist/headroom
 //= require_tree .
 
 document.addEventListener("turbolinks:load", function () {
+  new Headroom(document.querySelector("header.main .navbar")).init();
+
   // Snippet to enable the bulma burger menu in mobile
   // taken from https://bulma.io/documentation/components/navbar/#navbar-menu
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,6 +16,8 @@
 //= require_tree .
 
 document.addEventListener("turbolinks:load", function () {
+  // Make the sticky top nav hide on scroll, re-appear on scrolling up.
+  // See https://wicky.nillia.ms/headroom.js/
   new Headroom(document.querySelector("header.main .navbar")).init();
 
   // Snippet to enable the bulma burger menu in mobile

--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -50,6 +50,8 @@ $navbar-tab-active-background-color: transparent
 header.main
   @extend .border-bottom
   .navbar
+    @extend .is-fixed-top
+
     img
       max-height: 35px
 
@@ -96,6 +98,7 @@ header.main
 
 section.main
   min-height: 75vh
+  margin-top: 5rem
 
 footer.footer
   @extend .has-text-grey-dark

--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -52,6 +52,16 @@ header.main
     box-shadow: $box-shadow
     @extend .is-fixed-top
 
+    &.headroom
+      will-change: transform
+      transition: transform 200ms linear
+
+    &.headroom--pinned
+      transform: translateY(0%)
+
+    &.headroom--unpinned
+      transform: translateY(-100%)
+
     img
       max-height: 30px
 

--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -35,7 +35,7 @@ $primary: $red
 $success: #59A80F
 $text: #222
 
-$navbar-height: 5rem
+$navbar-height: 4.5rem
 $navbar-item-hover-background-color: transparent
 $navbar-item-active-background-color: transparent
 $navbar-tab-hover-background-color: transparent
@@ -48,12 +48,12 @@ $navbar-tab-active-background-color: transparent
   border-bottom: 1px solid $light
 
 header.main
-  @extend .border-bottom
   .navbar
+    box-shadow: $box-shadow
     @extend .is-fixed-top
 
     img
-      max-height: 35px
+      max-height: 30px
 
     // These values are hard-coded within bulma, we override
     // them here to keep it consistent with the adjacent search icon

--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -98,7 +98,6 @@ header.main
 
 section.main
   min-height: 75vh
-  margin-top: 5rem
 
 footer.footer
   @extend .has-text-grey-dark

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -1,5 +1,5 @@
 doctype html
-html lang="en"
+html.has-navbar-fixed-top lang="en"
   head
     title= title
     = csrf_meta_tags

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -42,8 +42,8 @@ html lang="en"
     = auto_discovery_link_tag :rss, blog_index_url(format: :rss)
 
   body
-    header.main: .container
-      nav.navbar aria-label="main navigation" role="navigation"
+    header.main
+      nav.navbar aria-label="main navigation" role="navigation": .container
         .navbar-brand
           = link_to "/", title: title(default: true), class: "navbar-item" do
             = image_tag "logo/regular.svg", alt: title(default: true)

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -67,3 +67,15 @@ By setting `RAILS_SERVE_STATIC_FILES` to true the Rails app will be hosting the 
 [redis]: https://redis.io/
 [sidekiq-web]: https://github.com/mperham/sidekiq/wiki/Monitoring#web-ui
 [sidekiq]: http://ruby-toolbox.com/projects/sidekiq
+
+---
+
+# Development Configuration
+
+## Autocorrect Rubocop offenses when running with Guard
+
+Set `AUTOCORRECT=true` when running `guard` for continuouos testing to automatically fix any auto-correctable rubocop offenses that are found.
+
+## Run feature specs in real Chrome
+
+By default capybara acceptance tests are run via Chrome Headless. By passing `CHROME_DEBUG=true` when running the tests the regular `selenium_chrome` driver will be used instead, allowing visual debugging.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "rubytoolbox",
   "private": false,
   "dependencies": {
-    "bulma": "^0.7.0"
+    "bulma": "^0.7.0",
+    "headroom.js": "^0.9.4"
   },
   "version": "1.0.0",
   "main": "index.js",

--- a/spec/features/mobile_navigation_spec.rb
+++ b/spec/features/mobile_navigation_spec.rb
@@ -24,4 +24,19 @@ RSpec.describe "Mobile Navigation", type: :feature, js: true do
       end
     end
   end
+
+  it "has the sticky main nav re-appear when scrolling back up" do
+    Capybara.current_session.current_window.resize_to 450, 900
+    visit "/"
+
+    expect(page).to have_selector("header.main .navbar", visible: true)
+
+    page.execute_script "window.scrollBy(0,10000)"
+
+    expect(page).to have_selector("header.main .navbar", visible: false)
+
+    page.execute_script "window.scrollBy(0,-1)"
+
+    expect(page).to have_selector("header.main .navbar", visible: true)
+  end
 end

--- a/spec/features/mobile_navigation_spec.rb
+++ b/spec/features/mobile_navigation_spec.rb
@@ -29,14 +29,31 @@ RSpec.describe "Mobile Navigation", type: :feature, js: true do
     Capybara.current_session.current_window.resize_to 450, 900
     visit "/"
 
-    expect(page).to have_selector("header.main .navbar", visible: true)
+    navbar_selector = "header.main .navbar"
 
-    page.execute_script "window.scrollBy(0,10000)"
+    expect(page).to have_selector(navbar_selector, visible: true)
+    expect(element_top_position(navbar_selector)).to be_zero
 
-    expect(page).to have_selector("header.main .navbar", visible: false)
+    scroll_by 1000
+    sleep 0.3 # We have to wait for the transition
+    expect(element_top_position(navbar_selector)).to be < 0.0
 
-    page.execute_script "window.scrollBy(0,-1)"
+    scroll_by(-100)
+    sleep 0.3 # We have to wait for the transition
 
-    expect(page).to have_selector("header.main .navbar", visible: true)
+    expect(element_top_position(navbar_selector)).to be_zero
+  end
+
+  private
+
+  def scroll_by(y) # rubocop:disable Naming/UncommunicativeMethodParamName
+    # Perform the actual scroll
+    page.execute_script "window.scrollBy(0, #{y})"
+    # Dispatch a scroll event - this does not seem to happen in headless chrome using scrollBy
+    page.execute_script "document.dispatchEvent(new Event('scroll'))"
+  end
+
+  def element_top_position(selector)
+    page.evaluate_script("document.querySelector(#{selector.inspect}).getBoundingClientRect().top")
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -50,6 +50,7 @@ end
 Capybara.server = :puma, { Silent: true }
 
 Capybara.javascript_driver = :selenium_chrome_headless
+Capybara.javascript_driver = :selenium_chrome if ENV["CHROME_DEBUG"].present?
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,3 +6,8 @@ bulma@^0.7.0:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/bulma/-/bulma-0.7.2.tgz#8e944377b74c7926558830d38d8e19eaf49f5fb6"
   integrity sha512-6JHEu8U/1xsyOst/El5ImLcZIiE2JFXgvrz8GGWbnDLwTNRPJzdAM0aoUM1Ns0avALcVb6KZz9NhzmU53dGDcQ==
+
+headroom.js@^0.9.4:
+  version "0.9.4"
+  resolved "https://registry.yarnpkg.com/headroom.js/-/headroom.js-0.9.4.tgz#0c4e6b4563bb69df55aecdefaba3227566f2df5a"
+  integrity sha1-DE5rRWO7ad9Vrs3vq6MidWby31o=


### PR DESCRIPTION
This PR makes the top nav sticky / floating. Toolbox pages tend to be long if there's a lot of projects, so this should make it a bit easier to navigate. Also, with #347 and upcoming new nav items the top bar is becoming a bit more than just a place to put the logo / search button into, so making it always visible also makes more sense now in that regard as well.