### PR TITLE
Metric Labels and Rendering Cleanup

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,8 +1,14 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
-  def metric(label, value, icon:)
-    render partial: "projects/metric", locals: { label: label, value: value, icon: icon }
+  def project_metrics(project, *metrics)
+    metrics.map do |metric|
+      render partial: "projects/metric", locals: {
+        label: t(:label, scope: "metrics.#{metric}"),
+        value: project.public_send(metric),
+        icon:  t(:icon, scope: "metrics.#{metric}"),
+      }
+    end.inject(&:+)
   end
 
   def project_link(label, url, icon:)

--- a/app/views/projects/_metric.html.slim
+++ b/app/views/projects/_metric.html.slim
@@ -13,5 +13,7 @@
       - elsif value.kind_of? Date or value.kind_of? Time
         time datetime=value.iso8601 title=l(value)
           = "#{time_ago_in_words(value)} ago"
+      - elsif value.kind_of? Array
+        = value.to_sentence
       - else
         = value

--- a/app/views/projects/_metrics.html.slim
+++ b/app/views/projects/_metrics.html.slim
@@ -4,8 +4,7 @@
     strong
       | Popularity
   .column: .metrics
-    - %i[rubygem_downloads github_repo_stargazers_count github_repo_forks_count github_repo_watchers_count].each do |metric|
-      = metric t(:label, scope: "metrics.#{metric}"), project.public_send(metric), icon: t(:icon, scope: "metrics.#{metric}")
+    = project_metrics project, :rubygem_downloads, :github_repo_stargazers_count, :github_repo_forks_count, :github_repo_watchers_count
 
 - if project.rubygem_releases_count
   .metrics
@@ -14,8 +13,7 @@
       strong
         | Releases
     .column: .metrics
-      - %i[rubygem_current_version rubygem_releases_count rubygem_first_release_on rubygem_latest_release_on].each do |metric|
-        = metric t(:label, scope: "metrics.#{metric}"), project.public_send(metric), icon: t(:icon, scope: "metrics.#{metric}")
+      = project_metrics project, :rubygem_current_version, :rubygem_releases_count, :rubygem_first_release_on, :rubygem_latest_release_on
 
 - if local_assigns[:expanded_view]
   - if project.github_repo_issue_closure_rate
@@ -25,8 +23,7 @@
         strong
           | Issues
       .column: .metrics
-        - %i[github_repo_open_issues_count github_repo_closed_issues_count github_repo_total_issues_count github_repo_issue_closure_rate].each do |metric|
-          = metric t(:label, scope: "metrics.#{metric}"), project.public_send(metric), icon: t(:icon, scope: "metrics.#{metric}")
+        = project_metrics project, :github_repo_open_issues_count, :github_repo_closed_issues_count, :github_repo_total_issues_count, :github_repo_issue_closure_rate
 
   - if project.github_repo_pull_request_acceptance_rate
     .metrics
@@ -35,8 +32,7 @@
         strong
           | Pull Requests
       .column: .metrics
-        - %i[github_repo_open_pull_requests_count github_repo_closed_pull_requests_count github_repo_merged_pull_requests_count github_repo_pull_request_acceptance_rate].each do |metric|
-          = metric t(:label, scope: "metrics.#{metric}"), project.public_send(metric), icon: t(:icon, scope: "metrics.#{metric}")
+        = project_metrics project, :github_repo_open_pull_requests_count, :github_repo_closed_pull_requests_count, :github_repo_merged_pull_requests_count, :github_repo_pull_request_acceptance_rate
 
   .metrics
     .label
@@ -44,8 +40,7 @@
       strong
         | Development
     .column: .metrics
-      - %i[github_repo_primary_language rubygem_licenses github_repo_average_recent_committed_at rubygem_reverse_dependencies_count].each do |metric|
-        = metric t(:label, scope: "metrics.#{metric}"), project.public_send(metric), icon: t(:icon, scope: "metrics.#{metric}")
+      = project_metrics project, :github_repo_primary_language, :rubygem_licenses, :github_repo_average_recent_committed_at, :rubygem_reverse_dependencies_count
 
 - else
   .metrics
@@ -54,8 +49,7 @@
       strong
         | Activity
     .column: .metrics
-      - %i[github_repo_issue_closure_rate github_repo_pull_request_acceptance_rate github_repo_average_recent_committed_at rubygem_reverse_dependencies_count].each do |metric|
-          = metric t(:label, scope: "metrics.#{metric}"), project.public_send(metric), icon: t(:icon, scope: "metrics.#{metric}")
+      = project_metrics project, :github_repo_issue_closure_rate, :github_repo_pull_request_acceptance_rate, :github_repo_average_recent_committed_at, :rubygem_reverse_dependencies_count
 
   .columns: .column.has-text-right
     a.button.is-outlined href="/projects/#{project.permalink}"

--- a/app/views/projects/_metrics.html.slim
+++ b/app/views/projects/_metrics.html.slim
@@ -44,10 +44,9 @@
       strong
         | Development
     .column: .metrics
-      = metric t(:label, scope: "metrics.github_repo_primary_language"), project.github_repo_primary_language, icon: t(:icon, scope: "metrics.github_repo_primary_language")
-      = metric "Licenses", project.rubygem_licenses.try(:to_sentence), icon: "legal"
-      = metric "Average date of last 50 commits", recent_distance_in_words(project.github_repo_average_recent_committed_at), icon: "link"
-      = metric t(:label, scope: "metrics.rubygem_reverse_dependencies_count"), project.rubygem_reverse_dependencies_count, icon: t(:icon, scope: "metrics.rubygem_reverse_dependencies_count")
+      - %i[github_repo_primary_language rubygem_licenses github_repo_average_recent_committed_at rubygem_reverse_dependencies_count].each do |metric|
+        = metric t(:label, scope: "metrics.#{metric}"), project.public_send(metric), icon: t(:icon, scope: "metrics.#{metric}")
+
 - else
   .metrics
     .label

--- a/app/views/projects/_metrics.html.slim
+++ b/app/views/projects/_metrics.html.slim
@@ -4,10 +4,8 @@
     strong
       | Popularity
   .column: .metrics
-    = metric "Downloads", project.rubygem_downloads, icon: "download"
-    = metric "Stars", project.github_repo_stargazers_count, icon: "star"
-    = metric "Forks", project.github_repo_forks_count, icon: "code-fork"
-    = metric "Watchers", project.github_repo_watchers_count, icon: "eye"
+    - %i[rubygem_downloads github_repo_stargazers_count github_repo_forks_count github_repo_watchers_count].each do |metric|
+      = metric t(:label, scope: "metrics.#{metric}"), project.public_send(metric), icon: t(:icon, scope: "metrics.#{metric}")
 
 - if project.rubygem_releases_count
   .metrics
@@ -16,10 +14,9 @@
       strong
         | Releases
     .column: .metrics
-      = metric "Current version", project.rubygem_current_version, icon: "diamond"
-      = metric "Total releases", project.rubygem_releases_count, icon: "archive"
-      = metric "First release", project.rubygem_first_release_on, icon: "file-o"
-      = metric "Latest release", project.rubygem_latest_release_on, icon: "file-text-o"
+      - %i[rubygem_current_version rubygem_releases_count rubygem_first_release_on rubygem_latest_release_on].each do |metric|
+        = metric t(:label, scope: "metrics.#{metric}"), project.public_send(metric), icon: t(:icon, scope: "metrics.#{metric}")
+
 - if local_assigns[:expanded_view]
   - if project.github_repo_issue_closure_rate
     .metrics
@@ -28,10 +25,8 @@
         strong
           | Issues
       .column: .metrics
-        = metric "Open", project.github_repo_open_issues_count, icon: "bug"
-        = metric "Closed", project.github_repo_closed_issues_count, icon: "check"
-        = metric "Total Issues", project.github_repo_total_issues_count, icon: "bug"
-        = metric "Closure Rate", project.github_repo_issue_closure_rate, icon: "percent"
+        - %i[github_repo_open_issues_count github_repo_closed_issues_count github_repo_total_issues_count github_repo_issue_closure_rate].each do |metric|
+          = metric t(:label, scope: "metrics.#{metric}"), project.public_send(metric), icon: t(:icon, scope: "metrics.#{metric}")
 
   - if project.github_repo_pull_request_acceptance_rate
     .metrics
@@ -40,10 +35,8 @@
         strong
           | Pull Requests
       .column: .metrics
-        = metric "Open", project.github_repo_open_pull_requests_count, icon: "code-fork"
-        = metric "Rejected", project.github_repo_closed_pull_requests_count, icon: "times"
-        = metric "Merged", project.github_repo_merged_pull_requests_count, icon: "check"
-        = metric "Acceptance Rate", project.github_repo_pull_request_acceptance_rate, icon: "percent"
+        - %i[github_repo_open_pull_requests_count github_repo_closed_pull_requests_count github_repo_merged_pull_requests_count github_repo_pull_request_acceptance_rate].each do |metric|
+          = metric t(:label, scope: "metrics.#{metric}"), project.public_send(metric), icon: t(:icon, scope: "metrics.#{metric}")
 
   .metrics
     .label
@@ -51,10 +44,10 @@
       strong
         | Development
     .column: .metrics
-      = metric "Primary Language", project.github_repo_primary_language, icon: "code"
+      = metric t(:label, scope: "metrics.github_repo_primary_language"), project.github_repo_primary_language, icon: t(:icon, scope: "metrics.github_repo_primary_language")
       = metric "Licenses", project.rubygem_licenses.try(:to_sentence), icon: "legal"
       = metric "Average date of last 50 commits", recent_distance_in_words(project.github_repo_average_recent_committed_at), icon: "link"
-      = metric "Reverse Dependencies", project.rubygem_reverse_dependencies_count, icon: "compress"
+      = metric t(:label, scope: "metrics.rubygem_reverse_dependencies_count"), project.rubygem_reverse_dependencies_count, icon: t(:icon, scope: "metrics.rubygem_reverse_dependencies_count")
 - else
   .metrics
     .label
@@ -62,10 +55,9 @@
       strong
         | Activity
     .column: .metrics
-      = metric "Issue Closure Rate", project.github_repo_issue_closure_rate, icon: "percent"
-      = metric "Pull Request Acceptance Rate", project.github_repo_pull_request_acceptance_rate, icon: "percent"
-      = metric "Average date of last 50 commits", recent_distance_in_words(project.github_repo_average_recent_committed_at), icon: "link"
-      = metric "Reverse Dependencies", project.rubygem_reverse_dependencies_count, icon: "compress"
+      - %i[github_repo_issue_closure_rate github_repo_pull_request_acceptance_rate github_repo_average_recent_committed_at rubygem_reverse_dependencies_count].each do |metric|
+          = metric t(:label, scope: "metrics.#{metric}"), project.public_send(metric), icon: t(:icon, scope: "metrics.#{metric}")
+
   .columns: .column.has-text-right
     a.button.is-outlined href="/projects/#{project.permalink}"
       span.icon: i.fa.fa-plus

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -97,3 +97,9 @@ en:
     rubygem_reverse_dependencies_count:
       label: Reverse Dependencies
       icon: compress
+    rubygem_licenses:
+      label: Licenses
+      icon: legal
+    github_repo_average_recent_committed_at:
+      label: Average date of last 50 commits
+      icon: link

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,3 +42,58 @@ en:
     no_commit_activity: No commit activity in last 3 years
     healthy: The project is in a healthy, maintained state
     rubygem_long_running: A long-lived project that still receives updates
+  metrics:
+    rubygem_downloads:
+      label: Downloads
+      icon: download
+    github_repo_stargazers_count:
+      label: Stars
+      icon: star
+    github_repo_forks_count:
+      label: Forks
+      icon: code-fork
+    github_repo_watchers_count:
+      label: Watchers
+      icon: eye
+    rubygem_current_version:
+      label: Current version
+      icon: diamond
+    rubygem_releases_count:
+      label: Total releases
+      icon: archive
+    rubygem_first_release_on:
+      label: First release
+      icon: file-o
+    rubygem_latest_release_on:
+      label: Latest release
+      icon: file-text-o
+    github_repo_open_issues_count:
+      label: Open Issues
+      icon: bug
+    github_repo_closed_issues_count:
+      label: Closed Issues
+      icon: check
+    github_repo_total_issues_count:
+      label: Total Issues
+      icon: bug
+    github_repo_issue_closure_rate:
+      label: Issue Closure Rate
+      icon: percent
+    github_repo_open_pull_requests_count:
+      label: Open Pull Requests
+      icon: code-fork
+    github_repo_closed_pull_requests_count:
+      label: Closed Pull Requests
+      icon: times
+    github_repo_merged_pull_requests_count:
+      label: Merged Pull Requests
+      icon: check
+    github_repo_pull_request_acceptance_rate:
+      label: Pull Request Acceptance Rate
+      icon: percent
+    github_repo_primary_language:
+      label: Primary Language
+      icon: code
+    rubygem_reverse_dependencies_count:
+      label: Reverse Dependencies
+      icon: compress

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -3,27 +3,30 @@
 require "rails_helper"
 
 RSpec.describe ApplicationHelper, type: :helper do
-  describe "#metric" do
-    let(:metric) { helper.metric("FooBar", 22_123_122, icon: "download") }
+  describe "#project_metrics" do
+    let(:project) { instance_double(Project, rubygem_downloads: 22_123_122) }
+    let(:project_metrics) { helper.project_metrics(project, :rubygem_downloads) }
 
-    it "renders the given label" do
-      expect(metric).to include("<span>FooBar</span>")
+    it "renders the expected label" do
+      expect(project_metrics).to include("<span>Downloads</span>")
     end
 
     it "renders the given icon" do
-      expect(metric).to include("<i class=\"fa fa-download\"></i>")
+      expect(project_metrics).to include("<i class=\"fa fa-download\"></i>")
     end
 
     it "renders the given, pretty-printed value" do
-      expect(metric).to include("<strong>22,123,122</strong>")
+      expect(project_metrics).to include("<strong>22,123,122</strong>")
     end
 
     it "does not pretty-print when the value is not an integer" do
-      expect(helper.metric("FooBar", "Hello", icon: "star")).to include "<strong>Hello</strong>"
+      allow(project).to receive(:rubygem_downloads).and_return("Hello")
+      expect(project_metrics).to include "<strong>Hello</strong>"
     end
 
     it "renders only the container when the value is blank" do
-      expect(helper.metric("FooBar", "", icon: "star")).to be == "<div class=\"metric\"></div>"
+      allow(project).to receive(:rubygem_downloads)
+      expect(project_metrics).to be == "<div class=\"metric\"></div>"
     end
   end
 

--- a/spec/integration/i18n_spec.rb
+++ b/spec/integration/i18n_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe I18n do
+  describe "#metrics" do
+    it "has a valid icon for each metric" do
+      expect(described_class.t(:metrics).map { |_, t| t }).to all(satisfy { |t| t[:icon].present? })
+    end
+
+    it "has a valid label for each metric" do
+      expect(described_class.t(:metrics).map { |_, t| t }).to all(satisfy { |t| t[:label].present? })
+    end
+
+    it "only has valid metric names" do
+      expect(described_class.t(:metrics).map(&:first)).to all(satisfy { |m| Project.new.respond_to? m })
+    end
+  end
+end


### PR DESCRIPTION
This is a preparatory refactoring for further usage of the available metrics and their labels & icons within the UI, for example in upcoming help pages as well as custom project order dropdowns.

The labels and icons are moved into the I18n locale database, which also enabled to clean up the actual slim partial that renders the metrics a bit.