### PR TITLE
Custom project list ordering

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,7 +79,7 @@ gem "turbolinks", "~> 5"
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: %i[mri mingw x64_mingw]
-  gem "pry"
+  gem "pry-rails"
   gem "rspec-rails"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,6 +206,8 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (3.0.3)
     puma (3.12.0)
     rack (2.0.6)
@@ -409,7 +411,7 @@ DEPENDENCIES
   overcommit
   pg (~> 0.18)
   pg_search
-  pry
+  pry-rails
   puma (~> 3.11)
   rack-canonical-host
   rack-ssl-enforcer

--- a/app/assets/stylesheets/components/project_order_dropdown.sass
+++ b/app/assets/stylesheets/components/project_order_dropdown.sass
@@ -1,0 +1,10 @@
+.project-order-dropdown
+  @extend .dropdown, .is-hoverable, .is-right
+  .dropdown-trigger
+    button
+      @extend .button, .is-outlined
+  .dropdown-content
+    a
+      @extend .dropdown-item
+    hr
+      @extend .dropdown-divider

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -2,31 +2,14 @@
 
 class CategoriesController < ApplicationController
   def show
-    @category = Category.find_for_show! params[:id], order_by: order_by
+    @category = Category.find_for_show! params[:id], order: current_order
     redirect_to @category if @category.permalink != params[:id]
   end
 
   private
 
-  ORDER_BY = {
-    "rubygem_downloads"                       => "rubygems.downloads DESC NULLS LAST",
-    "rubygem_reverse_dependencies_count"      => "rubygems.reverse_dependencies_count DESC NULLS LAST",
-    "rubygem_first_release_on"                => "rubygems.first_release_on ASC NULLS LAST",
-    "rubygem_latest_release_on"               => "rubygems.latest_release_on DESC NULLS LAST",
-    "rubygem_releases_count"                  => "rubygems.releases_count DESC NULLS LAST",
-    "github_repo_stargazers_count"            => "github_repos.stargazers_count DESC NULLS LAST",
-    "github_repo_forks_count"                 => "github_repos.forks_count DESC NULLS LAST",
-    "github_repo_watchers_count"              => "github_repos.watchers_count DESC NULLS LAST",
-    "github_repo_average_recent_committed_at" => "github_repos.average_recent_committed_at DESC NULLS LAST",
-  }.freeze
-
   def current_order
-    ORDER_BY.key?(params[:order]) ? params[:order] : "score"
+    @current_order ||= Project::Order.new order: params[:order]
   end
-
   helper_method :current_order
-
-  def order_by
-    ORDER_BY[current_order] || "projects.score DESC NULLS LAST"
-  end
 end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -2,7 +2,31 @@
 
 class CategoriesController < ApplicationController
   def show
-    @category = Category.find_for_show! params[:id]
+    @category = Category.find_for_show! params[:id], order_by: order_by
     redirect_to @category if @category.permalink != params[:id]
+  end
+
+  private
+
+  ORDER_BY = {
+    "rubygem_downloads"                       => "rubygems.downloads DESC NULLS LAST",
+    "rubygem_reverse_dependencies_count"      => "rubygems.reverse_dependencies_count DESC NULLS LAST",
+    "rubygem_first_release_on"                => "rubygems.first_release_on ASC NULLS LAST",
+    "rubygem_latest_release_on"               => "rubygems.latest_release_on DESC NULLS LAST",
+    "rubygem_releases_count"                  => "rubygems.releases_count DESC NULLS LAST",
+    "github_repo_stargazers_count"            => "github_repos.stargazers_count DESC NULLS LAST",
+    "github_repo_forks_count"                 => "github_repos.forks_count DESC NULLS LAST",
+    "github_repo_watchers_count"              => "github_repos.watchers_count DESC NULLS LAST",
+    "github_repo_average_recent_committed_at" => "github_repos.average_recent_committed_at DESC NULLS LAST",
+  }.freeze
+
+  def current_order
+    ORDER_BY.key?(params[:order]) ? params[:order] : "score"
+  end
+
+  helper_method :current_order
+
+  def order_by
+    ORDER_BY[current_order] || "projects.score DESC NULLS LAST"
   end
 end

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -3,6 +3,13 @@
 class SearchesController < ApplicationController
   def show
     @query = params[:q].presence
-    @search = Search.new(@query) if @query
+    @search = Search.new(@query, order: current_order) if @query
   end
+
+  private
+
+  def current_order
+    @current_order ||= Project::Order.new order: params[:order], directions: Project::Order::SEARCH_DIRECTIONS
+  end
+  helper_method :current_order
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -97,6 +97,10 @@ module ApplicationHelper
     render "components/project_health_tag", status: health_status
   end
 
+  def project_order_dropdown(order)
+    render "components/project_order_dropdown", order: order
+  end
+
   def component_example(heading, &block)
     render "components/component_example", heading: heading, &block
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,12 +1,20 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
+  def metric_icon(metric)
+    "fa-" + t(:icon, scope: "metrics.#{metric}")
+  end
+
+  def metric_label(metric)
+    t(:label, scope: "metrics.#{metric}")
+  end
+
   def project_metrics(project, *metrics)
     metrics.map do |metric|
       render partial: "projects/metric", locals: {
-        label: t(:label, scope: "metrics.#{metric}"),
+        label: metric_label(metric),
         value: project.public_send(metric),
-        icon:  t(:icon, scope: "metrics.#{metric}"),
+        icon:  metric_icon(metric),
       }
     end.inject(&:+)
   end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -35,9 +35,9 @@ class Category < ApplicationRecord
     includes(:projects).search_scope(query)
   end
 
-  def self.find_for_show!(permalink, order_by: "projects.score DESC NULLS LAST")
+  def self.find_for_show!(permalink, order: Project::Order.new)
     includes(:category_group, projects: %i[rubygem github_repo])
-      .order(order_by)
+      .order(order.sql)
       .find(permalink.try(:strip))
   end
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -35,8 +35,10 @@ class Category < ApplicationRecord
     includes(:projects).search_scope(query)
   end
 
-  def self.find_for_show!(permalink)
-    includes(:category_group, projects: %i[rubygem github_repo]).find(permalink.try(:strip))
+  def self.find_for_show!(permalink, order_by: "projects.score DESC NULLS LAST")
+    includes(:category_group, projects: %i[rubygem github_repo])
+      .order(order_by)
+      .find(permalink.try(:strip))
   end
 
   CATALOG_GITHUB_BASE_URL = "https://github.com/rubytoolbox/catalog/"

--- a/app/models/project/order.rb
+++ b/app/models/project/order.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class Project::Order
+  DIRECTIONS = {
+    "score"                                   => "projects.score DESC NULLS LAST",
+    "rubygem_downloads"                       => "rubygems.downloads DESC NULLS LAST",
+    "rubygem_reverse_dependencies_count"      => "rubygems.reverse_dependencies_count DESC NULLS LAST",
+    "rubygem_first_release_on"                => "rubygems.first_release_on ASC NULLS LAST",
+    "rubygem_latest_release_on"               => "rubygems.latest_release_on DESC NULLS LAST",
+    "rubygem_releases_count"                  => "rubygems.releases_count DESC NULLS LAST",
+    "github_repo_stargazers_count"            => "github_repos.stargazers_count DESC NULLS LAST",
+    "github_repo_forks_count"                 => "github_repos.forks_count DESC NULLS LAST",
+    "github_repo_watchers_count"              => "github_repos.watchers_count DESC NULLS LAST",
+    "github_repo_average_recent_committed_at" => "github_repos.average_recent_committed_at DESC NULLS LAST",
+  }.freeze
+
+  attr_reader :ordered_by
+
+  def initialize(order:)
+    self.ordered_by = order
+  end
+
+  def ordered_by=(ordered_by)
+    @ordered_by = DIRECTIONS.key?(ordered_by) ? ordered_by : "score"
+  end
+
+  # Shorthand to check if given order is the current one
+  def is?(order)
+    ordered_by == order
+  end
+
+  def sql
+    DIRECTIONS.fetch ordered_by
+  end
+
+  def available_directions
+    DIRECTIONS.keys
+  end
+end

--- a/app/models/project/order.rb
+++ b/app/models/project/order.rb
@@ -40,14 +40,15 @@ class Project::Order
     Direction.new(:github_repo, :average_recent_committed_at),
   ].freeze
 
-  attr_reader :ordered_by
+  attr_accessor :direction
+  private :direction=, :direction
 
   def initialize(order:)
-    self.ordered_by = order
+    self.direction = DIRECTIONS.find { |d| d.key == order } || DIRECTIONS.first
   end
 
-  def ordered_by=(order)
-    @ordered_by = DIRECTIONS.any? { |d| d.key == order } ? order : "score"
+  def ordered_by
+    direction.key
   end
 
   # Shorthand to check if given order is the current one
@@ -56,7 +57,7 @@ class Project::Order
   end
 
   def sql
-    DIRECTIONS.find { |d| d.key == ordered_by }.sql
+    direction.sql
   end
 
   def available_groups

--- a/app/models/project/order.rb
+++ b/app/models/project/order.rb
@@ -36,4 +36,12 @@ class Project::Order
   def available_directions
     DIRECTIONS.keys
   end
+
+  def available_groups
+    {
+      "default"     => DIRECTIONS.keys.reject { |key| key =~ /^rubygem|github/ },
+      "rubygem"     => DIRECTIONS.keys.select { |key| key.start_with? "rubygem_" },
+      "github_repo" => DIRECTIONS.keys.select { |key| key.start_with? "github_repo_" },
+    }
+  end
 end

--- a/app/models/project/order.rb
+++ b/app/models/project/order.rb
@@ -42,9 +42,13 @@ class Project::Order
     Direction.new(:github_repo, :average_recent_committed_at),
   ].freeze
 
-  SEARCH_DIRECTIONS = [
-    Direction.new(:project, :rank, key: :rank, sql: "#{PgSearch::Configuration.alias('projects')}.rank DESC"),
-  ] + DEFAULT_DIRECTIONS
+  PG_SEARCH_RANK_DIRECTION = Direction.new(
+    :project,
+    :rank,
+    key: :rank,
+    sql: "#{PgSearch::Configuration.alias('projects')}.rank DESC NULLS LAST"
+  )
+  SEARCH_DIRECTIONS = [PG_SEARCH_RANK_DIRECTION] + DEFAULT_DIRECTIONS
 
   attr_accessor :direction, :directions
   private :direction=, :direction, :directions=, :directions

--- a/app/models/project/order.rb
+++ b/app/models/project/order.rb
@@ -51,7 +51,7 @@ class Project::Order
 
   def initialize(order: nil, directions: DEFAULT_DIRECTIONS)
     self.directions = directions
-    self.direction = directions.find { |d| d.key == order } || directions.first
+    self.direction = directions.find { |d| d.key == order } || default_direction
   end
 
   def ordered_by
@@ -69,5 +69,15 @@ class Project::Order
 
   def available_groups
     directions.group_by(&:group)
+  end
+
+  def default_direction?
+    direction == default_direction
+  end
+
+  private
+
+  def default_direction
+    directions.first
   end
 end

--- a/app/models/project/order.rb
+++ b/app/models/project/order.rb
@@ -34,6 +34,7 @@ class Project::Order
     Direction.new(:rubygem, :first_release_on, direction: :asc),
     Direction.new(:rubygem, :latest_release_on),
     Direction.new(:rubygem, :releases_count),
+    Direction.new(:rubygem, :reverse_dependencies_count),
     Direction.new(:github_repo, :stargazers_count),
     Direction.new(:github_repo, :forks_count),
     Direction.new(:github_repo, :watchers_count),

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 class Search
-  attr_accessor :query
-  private :query=
+  attr_accessor :query, :order
+  private :query=, :order=
 
-  def initialize(query)
+  def initialize(query, order: Project::Order.new(directions: Project::Order::SEARCH_DIRECTIONS))
     self.query = query.presence&.strip
+    self.order = order
   end
 
   def query?
@@ -13,7 +14,7 @@ class Search
   end
 
   def projects
-    @projects ||= Project.search(query)
+    @projects ||= Project.search(query, order: order)
   end
 
   def categories

--- a/app/views/categories/show.html.slim
+++ b/app/views/categories/show.html.slim
@@ -34,7 +34,7 @@ section.section: .container
       #page-order-menu.dropdown-menu role="menu"
         .dropdown-content.has-text-left
           - current_order.available_groups.each do |group, directions|
-            - unless group == "default"
+            - unless group == "project"
               hr.dropdown-divider
 
               .dropdown-item
@@ -42,8 +42,8 @@ section.section: .container
                   span.icon: i.fa class="fa-#{t(:icon, scope: "labels.#{group}")}"
                   strong= t(:label, scope: "labels.#{group}")
 
-            - directions.each do |direction|
-              a.dropdown-item href=request.path class=(current_order.is?(direction) ? "is-active" : "")
+            - directions.map(&:key).each do |direction|
+              a.dropdown-item href="#{request.path}?order=#{direction}" class=(current_order.is?(direction) ? "is-active" : "")
                 span.icon: i.fa class=metric_icon(direction)
                 = metric_label direction
 

--- a/app/views/categories/show.html.slim
+++ b/app/views/categories/show.html.slim
@@ -17,7 +17,7 @@
         em This category does not have a description yet. You can <strong><a href="#{@category.catalog_edit_url}">add one on github</a></strong>!
 
 section.section: .container
-  .level
+  .level.is-mobile
     .level-left
     .level-right: .level-item= project_order_dropdown current_order
 

--- a/app/views/categories/show.html.slim
+++ b/app/views/categories/show.html.slim
@@ -16,7 +16,49 @@
       - else
         em This category does not have a description yet. You can <strong><a href="#{@category.catalog_edit_url}">add one on github</a></strong>!
 
-section.section: .container: .columns
-  .column.projects
+section.section: .container
+  .level
+    .level-left
+    .level-right: .level-item
+    // Needs JS integration, see https://github.com/jgthms/bulma/issues/1870
+    .dropdown.is-hoverable.is-right
+      .dropdown-trigger
+        button.button.is-outlined aria-controls="page-order-menu" aria-haspopup="true"
+          span
+            span.icon: i.fa.fa-sort
+            | Order by&nbsp;
+            strong
+              = metric_label current_order
+          span.icon.is-small
+            i.fa.fa-angle-down aria-hidden="true"
+      #page-order-menu.dropdown-menu role="menu"
+        .dropdown-content.has-text-left
+          a.dropdown-item href=request.path class=(current_order == "score" ? "is-active" : "")
+            span.icon: i.fa class=metric_icon(:score)
+            = metric_label(:score)
+
+          hr.dropdown-divider
+
+          .dropdown-item
+            p
+              span.icon: i.fa.fa-diamond
+              strong Rubygem
+          - %w[rubygem_downloads rubygem_reverse_dependencies_count rubygem_first_release_on rubygem_latest_release_on rubygem_releases_count].each do |order_by|
+            a.dropdown-item href=(request.path + "?order=#{order_by}") class=(current_order == order_by ? "is-active" : "")
+              span.icon: i.fa class=metric_icon(order_by)
+              = metric_label order_by
+
+          hr.dropdown-divider
+          .dropdown-item
+            p
+              span.icon: i.fa.fa-github
+              strong GitHub Repo
+          - %w[github_repo_stargazers_count github_repo_forks_count github_repo_watchers_count github_repo_average_recent_committed_at].each do |order_by|
+            a.dropdown-item href=(request.path + "?order=#{order_by}") class=(current_order == order_by ? "is-active" : "")
+              span.icon: i.fa class=metric_icon(order_by)
+              = metric_label order_by
+
+
+  .columns: .column.projects
     - @category.projects.each do |project|
       = render project

--- a/app/views/categories/show.html.slim
+++ b/app/views/categories/show.html.slim
@@ -33,31 +33,19 @@ section.section: .container
             i.fa.fa-angle-down aria-hidden="true"
       #page-order-menu.dropdown-menu role="menu"
         .dropdown-content.has-text-left
-          a.dropdown-item href=request.path class=(current_order.is?("score") ? "is-active" : "")
-            span.icon: i.fa class=metric_icon(:score)
-            = metric_label(:score)
+          - current_order.available_groups.each do |group, directions|
+            - unless group == "default"
+              hr.dropdown-divider
 
-          hr.dropdown-divider
+              .dropdown-item
+                p
+                  span.icon: i.fa class="fa-#{t(:icon, scope: "labels.#{group}")}"
+                  strong= t(:label, scope: "labels.#{group}")
 
-          .dropdown-item
-            p
-              span.icon: i.fa.fa-diamond
-              strong Rubygem
-          - %w[rubygem_downloads rubygem_reverse_dependencies_count rubygem_first_release_on rubygem_latest_release_on rubygem_releases_count].each do |order_by|
-            a.dropdown-item href=(request.path + "?order=#{order_by}") class=(current_order.is?(order_by) ? "is-active" : "")
-              span.icon: i.fa class=metric_icon(order_by)
-              = metric_label order_by
-
-          hr.dropdown-divider
-          .dropdown-item
-            p
-              span.icon: i.fa.fa-github
-              strong GitHub Repo
-          - %w[github_repo_stargazers_count github_repo_forks_count github_repo_watchers_count github_repo_average_recent_committed_at].each do |order_by|
-            a.dropdown-item href=(request.path + "?order=#{order_by}") class=(current_order.is?(order_by) ? "is-active" : "")
-              span.icon: i.fa class=metric_icon(order_by)
-              = metric_label order_by
-
+            - directions.each do |direction|
+              a.dropdown-item href=request.path class=(current_order.is?(direction) ? "is-active" : "")
+                span.icon: i.fa class=metric_icon(direction)
+                = metric_label direction
 
   .columns: .column.projects
     - @category.projects.each do |project|

--- a/app/views/categories/show.html.slim
+++ b/app/views/categories/show.html.slim
@@ -19,33 +19,7 @@
 section.section: .container
   .level
     .level-left
-    .level-right: .level-item
-    // Needs JS integration, see https://github.com/jgthms/bulma/issues/1870
-    .dropdown.is-hoverable.is-right
-      .dropdown-trigger
-        button.button.is-outlined aria-controls="page-order-menu" aria-haspopup="true"
-          span
-            span.icon: i.fa.fa-sort
-            | Order by&nbsp;
-            strong
-              = metric_label current_order.ordered_by
-          span.icon.is-small
-            i.fa.fa-angle-down aria-hidden="true"
-      #page-order-menu.dropdown-menu role="menu"
-        .dropdown-content.has-text-left
-          - current_order.available_groups.each do |group, directions|
-            - unless group == "project"
-              hr.dropdown-divider
-
-              .dropdown-item
-                p
-                  span.icon: i.fa class="fa-#{t(:icon, scope: "labels.#{group}")}"
-                  strong= t(:label, scope: "labels.#{group}")
-
-            - directions.map(&:key).each do |direction|
-              a.dropdown-item href="#{request.path}?order=#{direction}" class=(current_order.is?(direction) ? "is-active" : "")
-                span.icon: i.fa class=metric_icon(direction)
-                = metric_label direction
+    .level-right: .level-item= project_order_dropdown current_order
 
   .columns: .column.projects
     - @category.projects.each do |project|

--- a/app/views/categories/show.html.slim
+++ b/app/views/categories/show.html.slim
@@ -28,12 +28,12 @@ section.section: .container
             span.icon: i.fa.fa-sort
             | Order by&nbsp;
             strong
-              = metric_label current_order
+              = metric_label current_order.ordered_by
           span.icon.is-small
             i.fa.fa-angle-down aria-hidden="true"
       #page-order-menu.dropdown-menu role="menu"
         .dropdown-content.has-text-left
-          a.dropdown-item href=request.path class=(current_order == "score" ? "is-active" : "")
+          a.dropdown-item href=request.path class=(current_order.is?("score") ? "is-active" : "")
             span.icon: i.fa class=metric_icon(:score)
             = metric_label(:score)
 
@@ -44,7 +44,7 @@ section.section: .container
               span.icon: i.fa.fa-diamond
               strong Rubygem
           - %w[rubygem_downloads rubygem_reverse_dependencies_count rubygem_first_release_on rubygem_latest_release_on rubygem_releases_count].each do |order_by|
-            a.dropdown-item href=(request.path + "?order=#{order_by}") class=(current_order == order_by ? "is-active" : "")
+            a.dropdown-item href=(request.path + "?order=#{order_by}") class=(current_order.is?(order_by) ? "is-active" : "")
               span.icon: i.fa class=metric_icon(order_by)
               = metric_label order_by
 
@@ -54,7 +54,7 @@ section.section: .container
               span.icon: i.fa.fa-github
               strong GitHub Repo
           - %w[github_repo_stargazers_count github_repo_forks_count github_repo_watchers_count github_repo_average_recent_committed_at].each do |order_by|
-            a.dropdown-item href=(request.path + "?order=#{order_by}") class=(current_order == order_by ? "is-active" : "")
+            a.dropdown-item href=(request.path + "?order=#{order_by}") class=(current_order.is?(order_by) ? "is-active" : "")
               span.icon: i.fa class=metric_icon(order_by)
               = metric_label order_by
 

--- a/app/views/components/_project_order_dropdown.html.slim
+++ b/app/views/components/_project_order_dropdown.html.slim
@@ -21,6 +21,6 @@
               strong= t(:label, scope: "labels.#{group}")
 
         - directions.map(&:key).each do |direction|
-          a href="#{request.path}?order=#{direction}" class=(order.is?(direction) ? "is-active" : "")
+          a href="#{request.path}?order=#{direction}&q=#{@search&.query}" class=(order.is?(direction) ? "is-active" : "")
             span.icon: i.fa class=metric_icon(direction)
             = metric_label direction

--- a/app/views/components/_project_order_dropdown.html.slim
+++ b/app/views/components/_project_order_dropdown.html.slim
@@ -1,0 +1,26 @@
+.project-order-dropdown
+  .dropdown-trigger
+    button aria-controls="project-order-menu" aria-haspopup="true"
+      span
+        span.icon: i.fa.fa-sort
+        | Order by&nbsp;
+        strong
+          = metric_label order.ordered_by
+      span.icon.is-small
+        i.fa.fa-angle-down aria-hidden="true"
+
+  #project-order-menu.dropdown-menu role="menu"
+    .dropdown-content
+      - order.available_groups.each do |group, directions|
+        - unless group == "project"
+          hr
+
+          .dropdown-item
+            p
+              span.icon: i.fa class="fa-#{t(:icon, scope: "labels.#{group}")}"
+              strong= t(:label, scope: "labels.#{group}")
+
+        - directions.map(&:key).each do |direction|
+          a href="#{request.path}?order=#{direction}" class=(order.is?(direction) ? "is-active" : "")
+            span.icon: i.fa class=metric_icon(direction)
+            = metric_label direction

--- a/app/views/pages/components/project_order_dropdown.html.slim
+++ b/app/views/pages/components/project_order_dropdown.html.slim
@@ -1,0 +1,11 @@
+.hero
+  section.section: .container
+    p.heading= link_to "Ruby Toolbox UI Components Styleguide", "/pages/components"
+    h2= current_page.split("/").last.humanize
+
+= component_example "Project Order By Dropdown" do
+  - [nil, "rubygem_downloads", "github_repo_stargazers_count"].each do |order|
+    .level
+      .level-left
+      .level-right: .level-item
+        = project_order_dropdown Project::Order.new(order: order)

--- a/app/views/pages/components/project_order_dropdown.html.slim
+++ b/app/views/pages/components/project_order_dropdown.html.slim
@@ -5,7 +5,7 @@
 
 = component_example "Project Order By Dropdown" do
   - [nil, "rubygem_downloads", "github_repo_stargazers_count"].each do |order|
-    .level
-      .level-left
+    .level.is-mobile
+      .level-left: .level-item
       .level-right: .level-item
         = project_order_dropdown Project::Order.new(order: order)

--- a/app/views/projects/_metric.html.slim
+++ b/app/views/projects/_metric.html.slim
@@ -2,7 +2,7 @@
   - if value.present?
     .heading
       span.icon
-        i.fa class="fa-#{icon}"
+        i.fa class=icon
       span= label
     strong
       - if value.kind_of? Float

--- a/app/views/projects/_project.html.slim
+++ b/app/views/projects/_project.html.slim
@@ -14,7 +14,7 @@
             = category_card category, compact: true, inline: true
       .level-item.score
         span.icon
-          i.fa.fa-flask
+          i.fa class=metric_icon(:score)
         span= project.score
 
   .columns: .column

--- a/app/views/projects/show.html.slim
+++ b/app/views/projects/show.html.slim
@@ -12,7 +12,7 @@
     .meta
       .score
         span.icon
-          i.fa.fa-flask
+          i.fa class=metric_icon(:score)
         span= @project.score
 
       .categories

--- a/app/views/searches/show.html.slim
+++ b/app/views/searches/show.html.slim
@@ -22,20 +22,34 @@
 
 - if @search
   section.section.search-results: .container
-    - if @search.categories.any?
-      .columns: .column
-        h2.subtitle.is-4 Categories
-        .columns.is-multiline
-          - @search.categories.each do |category|
-            .category-cards.four= category_card category
+    .columns: .column
+      h2.subtitle.is-4 Categories
+      - if current_order.default_direction?
+        - if @search.categories.any?
+          .columns.is-multiline
+            - @search.categories.each do |category|
+              .category-cards.four= category_card category
+        - else
+          .notification.is-default
+            span.icon: i.fa.fa-info-circle
+            span No matching categories were found
+      - else
+        .notification.is-default
+          span.icon: i.fa.fa-info-circle
+          span Category results are hidden when using using a custom project result order
 
-    - if @search.projects.any?
-      .columns: .column.projects
-        .level.is-mobile
-          .level-left: .level-item
-            h2.subtitle.is-4 Projects
-          .level-right: .level-item
-            = project_order_dropdown current_order
+    .columns: .column.projects
+      .level.is-mobile
+        .level-left: .level-item
+          h2.subtitle.is-4 Projects
+        .level-right: .level-item
+          = project_order_dropdown current_order
 
+      - if @search.projects.any?
         - @search.projects.each do |project|
           = render project, show_categories: true
+
+      - else
+        .notification.is-default
+          span.icon: i.fa.fa-info-circle
+          span No matching projects were found

--- a/app/views/searches/show.html.slim
+++ b/app/views/searches/show.html.slim
@@ -31,6 +31,12 @@
 
     - if @search.projects.any?
       .columns: .column.projects
+        .level
+          .level-left
+          .level-right: .level-item
+            = project_order_dropdown current_order
+
+
         h2.subtitle.is-4 Projects
         - @search.projects.each do |project|
           = render project, show_categories: true

--- a/app/views/searches/show.html.slim
+++ b/app/views/searches/show.html.slim
@@ -36,7 +36,7 @@
       - else
         .notification.is-default
           span.icon: i.fa.fa-info-circle
-          span Category results are hidden when using using a custom project result order
+          span Category results are hidden when using a custom project result order
 
     .columns: .column.projects
       .level.is-mobile

--- a/app/views/searches/show.html.slim
+++ b/app/views/searches/show.html.slim
@@ -31,12 +31,11 @@
 
     - if @search.projects.any?
       .columns: .column.projects
-        .level
-          .level-left
+        .level.is-mobile
+          .level-left: .level-item
+            h2.subtitle.is-4 Projects
           .level-right: .level-item
             = project_order_dropdown current_order
 
-
-        h2.subtitle.is-4 Projects
         - @search.projects.each do |project|
           = render project, show_categories: true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,6 +43,9 @@ en:
     healthy: The project is in a healthy, maintained state
     rubygem_long_running: A long-lived project that still receives updates
   metrics:
+    score:
+      label: Project Score
+      icon: flask
     rubygem_downloads:
       label: Downloads
       icon: download

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,6 +42,13 @@ en:
     no_commit_activity: No commit activity in last 3 years
     healthy: The project is in a healthy, maintained state
     rubygem_long_running: A long-lived project that still receives updates
+  labels:
+    rubygem:
+      label: Rubygem
+      icon: diamond
+    github_repo:
+      label: GitHub repo
+      icon: github
   metrics:
     score:
       label: Project Score

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,6 +49,7 @@ en:
     github_repo:
       label: GitHub repo
       icon: github
+
   metrics:
     score:
       label: Project Score

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,6 +51,9 @@ en:
       icon: github
 
   metrics:
+    rank:
+      label: Project Search Rank
+      icon: trophy
     score:
       label: Project Score
       icon: flask

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,7 +53,7 @@ en:
   metrics:
     rank:
       label: Project Search Rank
-      icon: trophy
+      icon: search
     score:
       label: Project Score
       icon: flask

--- a/spec/controllers/categories_controller_spec.rb
+++ b/spec/controllers/categories_controller_spec.rb
@@ -35,6 +35,13 @@ RSpec.describe CategoriesController, type: :controller do
         expect(assigns(:category)).to be == category
       end
 
+      it "passes a project order instance to Category.find_for_show!" do
+        order = Project::Order.new(order: "rubygem_downloads")
+        allow(Project::Order).to receive(:new).with(order: "rubygem_downloads").and_return(order)
+        expect(Category).to receive(:find_for_show!).with(category.id, order: order).and_call_original
+        get :show, params: { id: category.id, order: "rubygem_downloads" }
+      end
+
       describe "case-sensitivity" do
         ["CATegory", " catEGory "].each do |variant|
           it "redirects to the correct variant if accessed via #{variant.inspect}" do

--- a/spec/controllers/searches_controller_spec.rb
+++ b/spec/controllers/searches_controller_spec.rb
@@ -4,9 +4,32 @@ require "rails_helper"
 
 RSpec.describe SearchesController, type: :controller do
   describe "GET #show" do
+    def do_request(query: nil, order: nil)
+      get :show, params: { q: query, order: order }
+    end
+
     it "returns http success" do
-      get :show
+      do_request
       expect(response).to be_successful
+    end
+
+    it "assigns nothing to search when there is no query" do
+      do_request query: " "
+      expect(assigns(:search)).to be_nil
+    end
+
+    it "assigns a Search instance to search when there is a query" do
+      do_request query: "foo"
+      expect(assigns(:search)).to be_a Search
+    end
+
+    it "passes query and a project order instance to Search.new" do
+      order = Project::Order.new(order: "rubygem_downloads")
+      allow(Project::Order).to receive(:new)
+        .with(order: "rubygem_downloads", directions: Project::Order::SEARCH_DIRECTIONS)
+        .and_return(order)
+      expect(Search).to receive(:new).with("hello world", order: order).and_call_original
+      do_request query: "hello world", order: "rubygem_downloads"
     end
   end
 end

--- a/spec/features/category_display_spec.rb
+++ b/spec/features/category_display_spec.rb
@@ -3,28 +3,12 @@
 require "rails_helper"
 
 RSpec.describe "Categories Display", type: :feature, js: true do
-  def create_project(name, score:, downloads:, first_release:) # rubocop:disable Metrics/MethodLength
-    rubygem = Rubygem.create!(
-      name:             name,
-      current_version:  "1.0",
-      downloads:        downloads,
-      first_release_on: first_release
-    )
-    github_repo = GithubRepo.create!(
-      path:             "#{name}/#{name}",
-      stargazers_count: downloads,
-      forks_count:      downloads,
-      watchers_count:   downloads
-    )
-    Project.create! permalink: name, score: score, rubygem: rubygem, github_repo: github_repo
-  end
-
   before do
     group = CategoryGroup.create! permalink: "group1", name: "Group"
     category = Category.create! permalink: "widgets", name: "Widgets", category_group: group
-    category.projects << create_project("acme", score: 25, downloads: 25_000, first_release: 3.years.ago)
-    category.projects << create_project("widget", score: 20, downloads: 50_000, first_release: 2.years.ago)
-    category.projects << create_project("toolkit", score: 22, downloads: 10_000, first_release: 5.years.ago)
+    category.projects << Factories.project("acme", score: 25, downloads: 25_000, first_release: 3.years.ago)
+    category.projects << Factories.project("widget", score: 20, downloads: 50_000, first_release: 2.years.ago)
+    category.projects << Factories.project("toolkit", score: 22, downloads: 10_000, first_release: 5.years.ago)
   end
 
   it "can display projects of a category" do

--- a/spec/features/category_display_spec.rb
+++ b/spec/features/category_display_spec.rb
@@ -2,15 +2,70 @@
 
 require "rails_helper"
 
-RSpec.describe "Categories Display", type: :feature do
-  it "can display projects of a category" do
+RSpec.describe "Categories Display", type: :feature, js: true do
+  def create_project(name, score:, downloads:, first_release:) # rubocop:disable Metrics/MethodLength
+    rubygem = Rubygem.create!(
+      name:             name,
+      current_version:  "1.0",
+      downloads:        downloads,
+      first_release_on: first_release
+    )
+    github_repo = GithubRepo.create!(
+      path:             "#{name}/#{name}",
+      stargazers_count: downloads,
+      forks_count:      downloads,
+      watchers_count:   downloads
+    )
+    Project.create! permalink: name, score: score, rubygem: rubygem, github_repo: github_repo
+  end
+
+  before do
     group = CategoryGroup.create! permalink: "group1", name: "Group"
     category = Category.create! permalink: "widgets", name: "Widgets", category_group: group
-    category.projects << Project.create!(permalink: "rspec", score: 25)
+    category.projects << create_project("acme", score: 25, downloads: 25_000, first_release: 3.years.ago)
+    category.projects << create_project("widget", score: 20, downloads: 50_000, first_release: 2.years.ago)
+    category.projects << create_project("toolkit", score: 22, downloads: 10_000, first_release: 5.years.ago)
+  end
 
+  it "can display projects of a category" do
     visit "/categories/widgets"
     within ".projects" do
-      expect(page).to have_text "rspec"
+      expect(page).to have_text "acme"
     end
+  end
+
+  it "can apply a custom order to the list of projects" do
+    visit "/categories/widgets"
+
+    expect(listed_project_names).to be == %w[acme toolkit widget]
+
+    within ".project-order-dropdown" do
+      expect(page).to have_text "Order by Project Score"
+    end
+
+    %w[Downloads Stars Forks].each do |button_label|
+      within ".project-order-dropdown" do
+        page.find("button").hover
+        click_on button_label
+        expect(page).to have_text "Order by #{button_label}"
+      end
+      expect(listed_project_names).to be == %w[widget acme toolkit]
+    end
+
+    within ".project-order-dropdown" do
+      page.find("button").hover
+      click_on "First release"
+    end
+
+    within ".project-order-dropdown" do
+      expect(page).to have_text "Order by First release"
+    end
+    expect(listed_project_names).to be == %w[toolkit acme widget]
+  end
+
+  private
+
+  def listed_project_names
+    page.find_all(".project h3").map(&:text)
   end
 end

--- a/spec/features/mobile_navigation_spec.rb
+++ b/spec/features/mobile_navigation_spec.rb
@@ -2,10 +2,8 @@
 
 require "rails_helper"
 
-RSpec.describe "Mobile Navigation", type: :feature, js: true do
+RSpec.describe "Mobile Navigation", type: :feature, js: true, viewport: :mobile do
   it "has a toggle-able hamburger navigation on mobile" do
-    Capybara.current_session.current_window.resize_to 450, 900
-
     visit "/"
 
     within "header .navbar" do
@@ -26,7 +24,6 @@ RSpec.describe "Mobile Navigation", type: :feature, js: true do
   end
 
   it "has the sticky main nav re-appear when scrolling back up" do
-    Capybara.current_session.current_window.resize_to 450, 900
     visit "/"
 
     navbar_selector = "header.main .navbar"

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Search", type: :feature, js: true do
+  before do
+    group = CategoryGroup.create! permalink: "group1", name: "Group"
+    Category.create! permalink: "widgets", name: "Widgets", category_group: group
+
+    Factories.project("widgets", score: 25, downloads: 125_000, first_release: 3.years.ago)
+    Factories.project("more widgets",
+                      score:         25,
+                      description:   "widgets widgets",
+                      downloads:     50_000,
+                      first_release: 5.years.ago)
+    Factories.project("other", score: 22, downloads: 10_000, first_release: 5.years.ago)
+  end
+
+  it "allows users to search for projects and categories" do
+    search_for "widget"
+
+    expect(listed_project_names).to be == ["more widgets", "widgets"]
+
+    within ".category-card" do
+      expect(page).to have_text "Widgets"
+    end
+  end
+
+  it "can apply a custom project order" do
+    search_for "widget"
+
+    expect(listed_project_names).to be == ["more widgets", "widgets"]
+
+    %w[Downloads Stars Forks].each do |button_label|
+      within ".project-order-dropdown" do
+        page.find("button").hover
+        click_on button_label
+        expect(page).to have_text "Order by #{button_label}"
+      end
+      expect(listed_project_names).to be == ["widgets", "more widgets"]
+    end
+
+    within ".project-order-dropdown" do
+      page.find("button").hover
+      click_on "First release"
+    end
+
+    within ".project-order-dropdown" do
+      expect(page).to have_text "Order by First release"
+    end
+    expect(listed_project_names).to be == ["more widgets", "widgets"]
+  end
+
+  private
+
+  def search_for(query)
+    visit "/"
+    fill_in "q", with: query
+    click_button "Search"
+  end
+
+  def listed_project_names
+    page.find_all(".project h3").map(&:text)
+  end
+end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -23,13 +23,20 @@ RSpec.describe "Search", type: :feature, js: true do
 
     within ".category-card" do
       expect(page).to have_text "Widgets"
+      expect(page).not_to have_text "No matching categories were found"
     end
+
+    search_for "bicycle"
+    expect(page).to have_text "No matching categories were found"
+    expect(page).to have_text "No matching projects were found"
   end
 
   it "can apply a custom project order" do
     search_for "widget"
 
     expect(listed_project_names).to be == ["more widgets", "widgets"]
+
+    expect(page).to have_selector(".category-card", count: 1)
 
     %w[Downloads Stars Forks].each do |button_label|
       within ".project-order-dropdown" do
@@ -38,6 +45,13 @@ RSpec.describe "Search", type: :feature, js: true do
         expect(page).to have_text "Order by #{button_label}"
       end
       expect(listed_project_names).to be == ["widgets", "more widgets"]
+
+      # When using a custom order, matching categories are not shown
+      # since they are not affected by the order anyway, and if a user
+      # picks a custom project order it's reasonably safe to assume
+      # they are looking for projects, not categories
+      expect(page).not_to have_selector(".category-card")
+      expect(page).to have_text "Category results are hidden"
     end
 
     within ".project-order-dropdown" do

--- a/spec/integration/i18n_spec.rb
+++ b/spec/integration/i18n_spec.rb
@@ -13,7 +13,9 @@ RSpec.describe I18n do
     end
 
     it "only has valid metric names" do
-      expect(described_class.t(:metrics).map(&:first)).to all(satisfy { |m| Project.new.respond_to? m })
+      # The rank is special in that it only appears in searches using pg_search, but still needs to be defined
+      # because we want to display it in the search custom order dropdown
+      expect(described_class.t(:metrics).except(:rank).map(&:first)).to all(satisfy { |m| Project.new.respond_to? m })
     end
   end
 end

--- a/spec/models/project/order_spec.rb
+++ b/spec/models/project/order_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Project::Order, type: :model do
+  describe "#ordered_by" do
+    it "is 'score' when passed nil" do
+      expect(described_class.new(order: nil).ordered_by).to be == "score"
+    end
+
+    it "is 'score' when passed unallowed value" do
+      expect(described_class.new(order: "value").ordered_by).to be == "score"
+    end
+  end
+
+  described_class::DIRECTIONS.each do |order, sql|
+    describe "when given order #{order.inspect}" do
+      it "has ordered_by #{order.inspect}" do
+        expect(described_class.new(order: order).ordered_by).to be == order
+      end
+
+      it "has order_sql #{sql.inspect}" do
+        expect(described_class.new(order: order).sql).to be == sql
+      end
+
+      describe "#is?" do
+        it "is true for current order" do
+          expect(described_class.new(order: order).is?(order)).to be true
+        end
+
+        it "is false for other string" do
+          expect(described_class.new(order: order).is?(order.upcase)).to be false
+        end
+      end
+    end
+  end
+
+  describe "#available_directions" do
+    it "is a list of all valid ordered_by keys" do
+      expect(described_class.new(order: nil).available_directions).to be == described_class::DIRECTIONS.keys
+    end
+  end
+end

--- a/spec/models/project/order_spec.rb
+++ b/spec/models/project/order_spec.rb
@@ -78,4 +78,14 @@ RSpec.describe Project::Order, type: :model do
       expect(described_class.new(order: nil).available_groups.keys).to be == EXPECTED_GROUPS
     end
   end
+
+  describe "#default_direction?" do
+    it "is true when the current direction is the default" do
+      expect(described_class.new.default_direction?).to be true
+    end
+
+    it "is false when the current direction is not the default" do
+      expect(described_class.new(order: "rubygem_downloads").default_direction?).to be false
+    end
+  end
 end

--- a/spec/models/project/order_spec.rb
+++ b/spec/models/project/order_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Project::Order, type: :model do
     end
   end
 
-  DEFAULT_DIRECTION = described_class::DIRECTIONS.find { |d| d.key == "score" }
+  DEFAULT_DIRECTION = described_class::DIRECTIONS.first
 
   describe "for invalid order" do
     let(:order) { described_class.new(order: "lol") }

--- a/spec/models/project/order_spec.rb
+++ b/spec/models/project/order_spec.rb
@@ -22,10 +22,14 @@ RSpec.describe Project::Order, type: :model do
       it "uses custom direction when given" do
         expect(described_class.new(:foo, :bar, direction: :asc).sql).to be == "foos.bar ASC NULLS LAST"
       end
+
+      it "uses custom sql when given" do
+        expect(described_class.new(:foo, :bar, sql: "HELLO WORLD").sql).to be == "HELLO WORLD"
+      end
     end
   end
 
-  described_class::DIRECTIONS.each do |direction|
+  described_class::DEFAULT_DIRECTIONS.each do |direction|
     describe "for order #{direction.key}" do
       let(:order) { described_class.new(order: direction.key) }
 
@@ -52,7 +56,7 @@ RSpec.describe Project::Order, type: :model do
     end
   end
 
-  DEFAULT_DIRECTION = described_class::DIRECTIONS.first
+  DEFAULT_DIRECTION = described_class::DEFAULT_DIRECTIONS.first
 
   describe "for invalid order" do
     let(:order) { described_class.new(order: "lol") }
@@ -68,7 +72,7 @@ RSpec.describe Project::Order, type: :model do
   end
 
   describe "#available_groups" do
-    EXPECTED_GROUPS = described_class::DIRECTIONS.map(&:group).uniq
+    EXPECTED_GROUPS = described_class::DEFAULT_DIRECTIONS.map(&:group).uniq
 
     it "has expected groups: #{EXPECTED_GROUPS.to_sentence}" do
       expect(described_class.new(order: nil).available_groups.keys).to be == EXPECTED_GROUPS

--- a/spec/models/project/order_spec.rb
+++ b/spec/models/project/order_spec.rb
@@ -46,6 +46,10 @@ RSpec.describe Project::Order, type: :model do
         expect(order.is?("foobar")).to be false
       end
     end
+
+    it "has a valid SQL order clause" do
+      expect { Project.includes_associations.order(direction.sql).to_a }.not_to raise_error
+    end
   end
 
   DEFAULT_DIRECTION = described_class::DIRECTIONS.first

--- a/spec/models/project/order_spec.rb
+++ b/spec/models/project/order_spec.rb
@@ -40,4 +40,32 @@ RSpec.describe Project::Order, type: :model do
       expect(described_class.new(order: nil).available_directions).to be == described_class::DIRECTIONS.keys
     end
   end
+
+  describe "#available_groups" do
+    it "has three groups: default, rubygem and github_repo" do
+      expect(described_class.new(order: nil).available_groups.keys).to be == %w[default rubygem github_repo]
+    end
+
+    def group(name)
+      described_class.new(order: nil).available_groups[name]
+    end
+
+    RUBYGEM_DIRECTIONS = described_class::DIRECTIONS.keys.select { |key| key.start_with? "rubygem_" }
+
+    it "contains exactly #{RUBYGEM_DIRECTIONS.to_sentence} for rubygem group" do
+      expect(group("rubygem")).to be == RUBYGEM_DIRECTIONS
+    end
+
+    GITHUB_REPO_DIRECTIONS = described_class::DIRECTIONS.keys.select { |key| key.start_with? "github_repo_" }
+
+    it "contains exactly #{GITHUB_REPO_DIRECTIONS.to_sentence} for github_repo group" do
+      expect(group("github_repo")).to be == GITHUB_REPO_DIRECTIONS
+    end
+
+    DEFAULT_DIRECTIONS = %w[score].freeze
+
+    it "contains exactly #{DEFAULT_DIRECTIONS.to_sentence} for default group" do
+      expect(group("default")).to be == DEFAULT_DIRECTIONS
+    end
+  end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -25,6 +25,27 @@ RSpec.describe Project, type: :model do
       Project.create! permalink: "widgets"
       expect(Project.search("widget")).to be == [expected]
     end
+
+    describe "result order" do
+      before do
+        (1..3).each do |i|
+          rubygem = Rubygem.create! name: "widgets#{i}", downloads: 10 - i, current_version: "1.0"
+          Project.create! permalink: rubygem.name, score: 10 + i, rubygem: rubygem
+        end
+      end
+
+      it "sorts results by the search result rank by default" do
+        Project.find("widgets2").update! description: "widgets widgets!"
+        expected = %w[widgets2 widgets3 widgets1]
+        expect(Project.search("widget").pluck(:permalink)).to be == expected
+      end
+
+      it "allows to pass a custom order instance" do
+        order = Project::Order.new(order: "rubygem_downloads")
+        expected = %w[widgets1 widgets2 widgets3]
+        expect(Project.search("widget", order: order).pluck(:permalink)).to be == expected
+      end
+    end
   end
 
   describe "#github_only?" do

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -25,13 +25,13 @@ RSpec.describe Search, type: :model do
 
   describe "#projects" do
     it "searches projects for the given query" do
-      expect(Project).to receive(:search).with("my query")
+      expect(Project).to receive(:search).with("my query", order: kind_of(Project::Order))
       described_class.new("my query").projects
     end
 
     it "returns the resulting collection" do
       collection = %w[some projects]
-      allow(Project).to receive(:search).with("my query").and_return(collection)
+      allow(Project).to receive(:search).with("my query", order: kind_of(Project::Order)).and_return(collection)
       expect(described_class.new("my query").projects).to be == collection
     end
   end
@@ -46,6 +46,17 @@ RSpec.describe Search, type: :model do
       collection = %w[some projects]
       allow(Category).to receive(:search).with("my query").and_return(collection)
       expect(described_class.new("my query").categories).to be == collection
+    end
+  end
+
+  describe "#order" do
+    it "is a Project::Order with search directions by default" do
+      order = instance_double(Project::Order)
+      allow(Project::Order).to receive(:new)
+        .with(directions: Project::Order::SEARCH_DIRECTIONS)
+        .and_return(order)
+
+      expect(Search.new("q").order).to be order
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -65,6 +65,17 @@ RSpec.configure do |config|
     Rails.configuration.http_connect = example.metadata[:real_http]
   end
 
+  config.before type: :feature, js: true do
+    # Ensure we are not leaking mobile size from other specs
+    Capybara.current_session.current_window.resize_to 1280, 1024
+  end
+
+  # Use the viewport: :mobile rspec tag to force the resizing
+  # of the chrome window to a "mobile" portrait resolution
+  config.before type: :feature, js: true, viewport: :mobile do
+    Capybara.current_session.current_window.resize_to 450, 900
+  end
+
   config.around do |example|
     Sidekiq::Testing.inline! if example.metadata[:sidekiq_inline]
     example.run

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -2,7 +2,7 @@
 
 module Factories
   class << self
-    def project(name, score:, downloads:, first_release:) # rubocop:disable Metrics/MethodLength
+    def project(name, score:, downloads:, first_release:, description: nil) # rubocop:disable Metrics/MethodLength
       rubygem = Rubygem.create!(
         name:             name,
         current_version:  "1.0",
@@ -15,7 +15,11 @@ module Factories
         forks_count:      downloads,
         watchers_count:   downloads
       )
-      Project.create! permalink: name, score: score, rubygem: rubygem, github_repo: github_repo
+      Project.create! permalink:   name,
+                      score:       score,
+                      rubygem:     rubygem,
+                      github_repo: github_repo,
+                      description: description
     end
   end
 end

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Factories
+  class << self
+    def project(name, score:, downloads:, first_release:) # rubocop:disable Metrics/MethodLength
+      rubygem = Rubygem.create!(
+        name:             name,
+        current_version:  "1.0",
+        downloads:        downloads,
+        first_release_on: first_release
+      )
+      github_repo = GithubRepo.create!(
+        path:             "#{name}/#{name}",
+        stargazers_count: downloads,
+        forks_count:      downloads,
+        watchers_count:   downloads
+      )
+      Project.create! permalink: name, score: score, rubygem: rubygem, github_repo: github_repo
+    end
+  end
+end


### PR DESCRIPTION
This is another feature that [was requested a lot in the community survey](https://www.ruby-toolbox.com/blog/2018-12-04/survey-results)

This PR introduces custom sorting of project listings based on other metrics than the score, also making use of the cleanups made in #359.

![project-sorting](https://user-images.githubusercontent.com/13972/50854775-4e32ac80-1386-11e9-905b-15ed8e2c4ea9.gif)

Todos:

- [x] Incorporate into search results as well
- [x] Settle on initial list of sortable columns