### PR TITLE
Search results pagination

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,8 @@ gem "hairtrigger"
 gem "pg", "~> 0.18"
 gem "pg_search"
 
+gem "kaminari"
+
 # Use Puma as the app server
 gem "puma", "~> 3.11"
 # Use SCSS for stylesheets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,6 +156,18 @@ GEM
     io-like (0.3.0)
     jaro_winkler (1.5.1)
     json (2.1.0)
+    kaminari (1.1.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.1.1)
+      kaminari-activerecord (= 1.1.1)
+      kaminari-core (= 1.1.1)
+    kaminari-actionview (1.1.1)
+      actionview
+      kaminari-core (= 1.1.1)
+    kaminari-activerecord (1.1.1)
+      activerecord
+      kaminari-core (= 1.1.1)
+    kaminari-core (1.1.1)
     launchy (2.4.3)
       addressable (~> 2.3)
     listen (3.1.5)
@@ -404,6 +416,7 @@ DEPENDENCIES
   hairtrigger
   high_voltage
   http
+  kaminari
   launchy
   listen (>= 3.0.5, < 3.2)
   lograge

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -3,7 +3,10 @@
 class SearchesController < ApplicationController
   def show
     @query = params[:q].presence
-    @search = Search.new(@query, order: current_order) if @query
+    return unless @query
+
+    @search = Search.new(@query, order: current_order)
+    @projects = @search.projects.page(params[:page])
   end
 
   private

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -48,7 +48,6 @@ class Project < ApplicationRecord
       .reorder("")
       .includes_associations
       .order(order.sql)
-      .limit(25)
   end
 
   delegate :current_version,

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,17 @@
+<%
+=begin
+
+Link to the "First" page
+- available local variables
+  url          : url to the first page
+  current_page : a page object for the currently displayed page
+  total_pages  : total number of pages
+  per_page     : number of items to fetch per page
+  remote       : data-remote
+
+=end
+%>
+
+<li>
+  <%= link_to_unless current_page.first?, "1", url, remote: remote, class: "pagination-link#{' is-current' if current_page.first?}" %>
+</li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,17 @@
+<%
+=begin
+
+Non-link tag that stands for skipped pages...
+- available local variables
+  current_page : a page object for the currently displayed page
+  total_pages  : total number of pages
+  per_page     : number of items to fetch per page
+  remote       : data-remote
+
+=end
+%>
+<li>
+  <span class="pagination-ellipsis">
+    <%= t('views.pagination.truncate').html_safe %>
+  </span>
+</li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,17 @@
+<%
+=begin
+
+Link to the "Last" page
+- available local variables
+  url          : url to the last page
+  current_page : a page object for the currently displayed page
+  total_pages  : total number of pages
+  per_page     : number of items to fetch per page
+  remote       : data-remote
+
+=end
+%>
+
+<li>
+  <%= link_to_unless current_page.last?, total_pages, url, remote: remote, class: "pagination-link#{' is-current' if current_page.last?}" %>
+</li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,20 @@
+<%
+=begin
+
+Link to the "Next" page
+- available local variables
+  url          : url to the next page
+  current_page : a page object for the currently displayed page
+  total_pages  : total number of pages
+  per_page     : number of items to fetch per page
+  remote       : data-remote
+
+=end
+%>
+
+<% unless current_page.last? %>
+  <%= link_to url, rel: 'next', remote: remote, class: 'pagination-next' do %>
+    <span><%= t('views.pagination.next').html_safe %></span>
+    <span class="icon"><i class="fa fa-angle-right"></i></span>
+  <% end %>
+<% end %>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,18 @@
+<%
+=begin
+
+Link showing page number
+- available local variables
+  page         : a page object for "this" page
+  url          : url to this page
+  current_page : a page object for the currently displayed page
+  total_pages  : total number of pages
+  per_page     : number of items to fetch per page
+  remote       : data-remote
+
+=end
+%>
+
+<li>
+  <%= link_to page, url, {remote: remote, rel: page.rel, class: "pagination-link#{' is-current' if page.current?}"} %>
+</li>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,31 @@
+<%
+=begin
+
+The container tag
+- available local variables
+  current_page : a page object for the currently displayed page
+  total_pages  : total number of pages
+  per_page     : number of items to fetch per page
+  remote       : data-remote
+  paginator    : the paginator that renders the pagination tags inside
+
+=end
+%>
+
+<%= paginator.render do %>
+  <nav class="pagination is-right">
+    <%= prev_page_tag unless current_page.first? %>
+    <%= next_page_tag unless current_page.last? %>
+    <ul class="pagination-list">
+      <%= first_page_tag if current_page.number > 4   %>
+      <% each_page do |page| %>
+        <% if page.display_tag? %>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? %>
+          <%= gap_tag %>
+        <% end %>
+      <% end %>
+      <%= last_page_tag if current_page.number < total_pages - 3 %>
+    </ul>
+  </nav>
+<% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,21 @@
+<%
+=begin
+
+Link to the "Previous" page
+- available local variables
+  url          : url to the previous page
+  current_page : a page object for the currently displayed page
+  total_pages  : total number of pages
+  per_page     : number of items to fetch per page
+  remote       : data-remote
+
+=end
+%>
+
+
+<% unless current_page.first? %>
+  <%= link_to url, rel: 'prev', remote: remote, class: 'pagination-previous' do %>
+    <span class="icon"><i class="fa fa-angle-left"></i></span>
+    <span><%= t('views.pagination.previous').html_safe %></span>
+  <% end %>
+<% end %>

--- a/app/views/searches/show.html.slim
+++ b/app/views/searches/show.html.slim
@@ -16,7 +16,9 @@
 - if @search
   section.section.search-results: .container
     .columns: .column
-      h2.subtitle.is-4 Categories
+      .level
+        .level-left: .level-item: h2.subtitle.is-4 Categories
+
       - if current_order.default_direction?
         - if @search.categories.any?
           .columns.is-multiline
@@ -32,15 +34,19 @@
           span Category results are hidden when using a custom project result order
 
     .columns: .column.projects
-      .level.is-mobile
+      .level
         .level-left: .level-item
           h2.subtitle.is-4 Projects
         .level-right: .level-item
           = project_order_dropdown current_order
 
-      - if @search.projects.any?
-        - @search.projects.each do |project|
+      - if @projects.any?
+        .columns: .column= paginate @projects
+
+        - @projects.each do |project|
           = render project, show_categories: true
+
+        .columns: .column= paginate @projects
 
       - else
         .notification.is-default

--- a/app/views/searches/show.html.slim
+++ b/app/views/searches/show.html.slim
@@ -15,23 +15,24 @@
 
 - if @search
   section.section.search-results: .container
-    .columns: .column
-      .level
-        .level-left: .level-item: h2.subtitle.is-4 Categories
+    - if @projects.current_page == 1
+      .columns: .column
+        .level
+          .level-left: .level-item: h2.subtitle.is-4 Categories
 
-      - if current_order.default_direction?
-        - if @search.categories.any?
-          .columns.is-multiline
-            - @search.categories.each do |category|
-              .category-cards.four= category_card category
+        - if current_order.default_direction?
+          - if @search.categories.any?
+            .columns.is-multiline
+              - @search.categories.each do |category|
+                .category-cards.four= category_card category
+          - else
+            .notification.is-default
+              span.icon: i.fa.fa-info-circle
+              span No matching categories were found
         - else
           .notification.is-default
             span.icon: i.fa.fa-info-circle
-            span No matching categories were found
-      - else
-        .notification.is-default
-          span.icon: i.fa.fa-info-circle
-          span Category results are hidden when using a custom project result order
+            span Category results are hidden when using a custom project result order
 
     .columns: .column.projects
       .level

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  # in the test environment the limit is lower to avoid having to create
+  # huge amounts of db records for simple test cases
+  config.default_per_page = Rails.env.test? ? 3 : 20
+
+  # config.max_per_page = nil
+  config.window = 2
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.params_on_first_page = false
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,6 +32,11 @@ en:
   name: The Ruby Toolbox
   tagline: Know your options!
   description: Explore and compare open source Ruby libraries
+  views:
+    pagination:
+      previous: Previous page
+      next: Next page
+
   project_health:
     github_repo_archived: Repository is archived
     github_repo_gone: Repository is gone

--- a/spec/controllers/searches_controller_spec.rb
+++ b/spec/controllers/searches_controller_spec.rb
@@ -23,6 +23,13 @@ RSpec.describe SearchesController, type: :controller do
       expect(assigns(:search)).to be_a Search
     end
 
+    it "assigns paginated projects scope when there is a query" do
+      do_request query: "foo"
+      expect(assigns(:projects)).to be_a(ActiveRecord::Relation)
+        .and respond_to(:current_page)
+        .and respond_to(:total_pages)
+    end
+
     it "passes query and a project order instance to Search.new" do
       order = Project::Order.new(order: "rubygem_downloads")
       allow(Project::Order).to receive(:new)

--- a/spec/features/mobile_navigation_spec.rb
+++ b/spec/features/mobile_navigation_spec.rb
@@ -46,20 +46,6 @@ RSpec.describe "Mobile Navigation", type: :feature, js: true, viewport: :mobile 
 
   private
 
-  #
-  # Since we're using custom js stuff here capybaras default synchronization
-  # does not help us. In order to have the fastest-possible turnaround time,
-  # this will retry at a high frequency until the maximum amount of tries is reached,
-  # causing an exception to be raised.
-  #
-  # rubocop:disable Performance/RedundantBlockCall
-  def wait_for(&block)
-    Retriable.retriable tries: 15, base_interval: 0.05 do
-      raise "Exceeded max retries while waiting for block to pass" unless block.call
-    end
-  end
-  # rubocop:enable Performance/RedundantBlockCall
-
   def scroll_by(y) # rubocop:disable Naming/UncommunicativeMethodParamName
     # Perform the actual scroll
     page.execute_script "window.scrollBy(0, #{y})"

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -77,6 +77,7 @@ RSpec.describe "Search", type: :feature, js: true do
     search_for "widgets"
 
     expect(listed_project_names).to be == ["more widgets", "widgets", "widgets 1"]
+    within(".search-results") { expect(page).to have_text "Categories" }
 
     within ".pagination", match: :first do
       click_on "Next page"
@@ -84,6 +85,9 @@ RSpec.describe "Search", type: :feature, js: true do
 
     wait_for { listed_project_names.include? "widgets 2" }
     expect(listed_project_names).to be == (2..4).map { |i| "widgets #{i}" }
+    # Only project results are paginated, hence we hide the categories section entirely
+    # when browsing project results
+    within(".search-results") { expect(page).not_to have_text "Categories" }
 
     within ".pagination", match: :first do
       click_on "3"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -76,6 +76,8 @@ RSpec.configure do |config|
     Capybara.current_session.current_window.resize_to 450, 900
   end
 
+  config.include FeatureSpecHelpers, type: :feature
+
   config.around do |example|
     Sidekiq::Testing.inline! if example.metadata[:sidekiq_inline]
     example.run

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -1,8 +1,13 @@
 # frozen_string_literal: true
 
 module Factories
+  # rubocop:disable Metrics/MethodLength All-in-one-place is more relevant than short methods here
   class << self
-    def project(name, score:, downloads:, first_release:, description: nil) # rubocop:disable Metrics/MethodLength
+    def project(name,
+                score:,
+                downloads: 5000,
+                first_release: 1.year.ago,
+                description: nil)
       rubygem = Rubygem.create!(
         name:             name,
         current_version:  "1.0",
@@ -22,4 +27,5 @@ module Factories
                       description: description
     end
   end
+  # rubocop:enable Metrics/MethodLength
 end

--- a/spec/support/helpers/feature_spec_helpers.rb
+++ b/spec/support/helpers/feature_spec_helpers.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module FeatureSpecHelpers
+  def listed_project_names
+    page.find_all(".project h3").map(&:text)
+  end
+
+  #
+  # Since we're using custom js stuff here capybaras default synchronization
+  # does not help us. In order to have the fastest-possible turnaround time,
+  # this will retry at a high frequency until the maximum amount of tries is reached,
+  # causing an exception to be raised.
+  #
+  # rubocop:disable Performance/RedundantBlockCall
+  def wait_for(&block)
+    Retriable.retriable tries: 15, base_interval: 0.05 do
+      raise "Exceeded max retries while waiting for block to pass" unless block.call
+    end
+  end
+  # rubocop:enable Performance/RedundantBlockCall
+end


### PR DESCRIPTION
This PR finally introduces pagination of project search results. So far, the total result list was hard-limited to 25 projects (see also #109). With this change it becomes possible to browse the entire result set.

![screenshot from 2019-01-10 12-44-28](https://user-images.githubusercontent.com/13972/50966593-aa581680-14d5-11e9-8dad-2f710ce47299.png)
