### PR TITLE
Search UI tweaks

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -43,4 +43,12 @@ document.addEventListener("turbolinks:load", function () {
       });
     });
   }
+
+  document.querySelectorAll("form.search-form").forEach(function(form) {
+    form.addEventListener("submit", function() {
+      document.querySelectorAll("form.search-form button[type=submit]").forEach(function(button) {
+        button.classList.add("is-loading");
+      });
+    })
+  });
 });

--- a/app/views/searches/show.html.slim
+++ b/app/views/searches/show.html.slim
@@ -6,12 +6,10 @@
 .hero.search
   section.section: .container
     .columns: .column
-      .is-hidden-mobile
-        h2
-          a href=search_path(q: @query)
-            = content_for(:title)
-      .is-hidden-tablet
-        = render partial: "search_form"
+      = render partial: "search_form"
+      - unless @search
+        javascript:
+          document.querySelector(".hero.search input[type=text]").focus();
 
 - if @search
   section.section.search-results: .container

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -105,10 +105,28 @@ RSpec.describe "Search", type: :feature, js: true do
     expect(active_element.tag_name).to be == "body"
   end
 
+  it "puts search submit buttons into loading state" do
+    search_for "foo", halt: true
+    expect(page).to have_selector(".search-form .button.is-loading", count: 2)
+  end
+
   private
 
-  def search_for(query, container: ".navbar")
+  #
+  # To test onSubmit loading state change we need to prevent the form from actually
+  # submitting itself
+  #
+  HALT_FORM_SUBMISSION_JS = <<~JS
+    document.querySelectorAll(".search-form").forEach(function(form) {
+      form.addEventListener("submit", function(e) { e.preventDefault(); })
+    });
+  JS
+
+  def search_for(query, container: ".navbar", halt: false)
     visit "/"
+
+    page.evaluate_script HALT_FORM_SUBMISSION_JS if halt
+
     within container do
       fill_in "q", with: query
       click_button "Search"

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -97,6 +97,14 @@ RSpec.describe "Search", type: :feature, js: true do
     expect(listed_project_names).to be == (5..7).map { |i| "widgets #{i}" }
   end
 
+  it "automatically focuses the search input when accessed without query" do
+    search_for ""
+    expect(active_element).to(satisfy { |e| e.tag_name == "input" && e["name"] == "q" })
+
+    search_for "foo"
+    expect(active_element.tag_name).to be == "body"
+  end
+
   private
 
   def search_for(query, container: ".navbar")

--- a/spec/support/helpers/feature_spec_helpers.rb
+++ b/spec/support/helpers/feature_spec_helpers.rb
@@ -18,4 +18,8 @@ module FeatureSpecHelpers
     end
   end
   # rubocop:enable Performance/RedundantBlockCall
+
+  def active_element
+    page.evaluate_script "document.activeElement"
+  end
 end


### PR DESCRIPTION
Some minor search UI tweaks remaining from #109 to allow closing that one:

* Improved "blank search" page - also show the search input at full width on desktop now
* Auto-focus the search input on the search page
* Put the submit button into loading state on submit to give visual feedback