### PR TITLE
Bugfix fork detection

### DIFF
--- a/app/jobs/project_score_job.rb
+++ b/app/jobs/project_score_job.rb
@@ -1,31 +1,53 @@
 # frozen_string_literal: true
 
 class ProjectScoreJob < ApplicationJob
+  attr_accessor :project
+  private :project=
+
   def perform(permalink)
-    Project.find(permalink).tap do |project|
-      project.update! score: score_for_project(project)
-    end
+    self.project = Project.includes_associations.find permalink
+
+    project.update! score:                calculated_score,
+                    bugfix_fork_of:       bugfix_fork_of,
+                    bugfix_fork_criteria: bugfix_fork_criteria
   end
 
   private
 
-  def score_for_project(project)
-    scores = [rubygem_score(project.rubygem), github_repo_score(project.github_repo)].compact
+  def calculated_score
+    scores = [rubygem_score, github_repo_score].compact
     return if scores.empty?
 
     scores.sum / scores.count
   end
 
-  def rubygem_score(rubygem)
+  delegate :rubygem, :github_repo, to: :project
+
+  def rubygem_score
     return unless rubygem
 
     rubygem.downloads * 100.0 / rubygem.class.maximum(:downloads)
   end
 
-  def github_repo_score(github_repo)
+  def github_repo_score
     return unless github_repo
 
-    (github_repo.stargazers_count + github_repo.forks_count * 5) * 100.0 /
-      (github_repo.class.maximum(:stargazers_count) + github_repo.class.maximum(:forks_count) * 5)
+    (github_repo.stargazers_count + github_repo.forks_count * 5) * 100.0 / github_ceiling
+  end
+
+  def github_ceiling
+    github_repo.class.maximum(:stargazers_count) + github_repo.class.maximum(:forks_count) * 5
+  end
+
+  def fork_detector
+    @fork_detector ||= Project::ForkDetector.new(project)
+  end
+
+  def bugfix_fork_of
+    fork_detector.forked_from
+  end
+
+  def bugfix_fork_criteria
+    fork_detector.fork_criteria
   end
 end

--- a/app/jobs/project_score_job.rb
+++ b/app/jobs/project_score_job.rb
@@ -8,6 +8,7 @@ class ProjectScoreJob < ApplicationJob
     self.project = Project.includes_associations.find permalink
 
     project.update! score:                calculated_score,
+                    is_bugfix_fork:       bugfix_fork?,
                     bugfix_fork_of:       bugfix_fork_of,
                     bugfix_fork_criteria: bugfix_fork_criteria
   end
@@ -41,6 +42,10 @@ class ProjectScoreJob < ApplicationJob
 
   def fork_detector
     @fork_detector ||= Project::ForkDetector.new(project)
+  end
+
+  def bugfix_fork?
+    bugfix_fork_of.present?
   end
 
   def bugfix_fork_of

--- a/app/models/github_repo.rb
+++ b/app/models/github_repo.rb
@@ -64,7 +64,7 @@ class GithubRepo < ApplicationRecord
     open_pull_requests_count + merged_pull_requests_count + closed_pull_requests_count
   end
 
-  def maximum_sibling_downloads
-    rubygems.maximum(:downloads)
+  def sibling_gem_with_most_downloads
+    rubygems.order(downloads: :desc).first
   end
 end

--- a/app/models/github_repo.rb
+++ b/app/models/github_repo.rb
@@ -63,4 +63,8 @@ class GithubRepo < ApplicationRecord
 
     open_pull_requests_count + merged_pull_requests_count + closed_pull_requests_count
   end
+
+  def maximum_sibling_downloads
+    rubygems.maximum(:downloads)
+  end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -27,6 +27,9 @@ class Project < ApplicationRecord
 
   scope :includes_associations, -> { left_outer_joins(:github_repo, :rubygem, :categories) }
   scope :with_score, -> { where.not(score: nil) }
+  def self.with_bugfix_forks(include_forks)
+    include_forks ? self : where(bugfix_fork_of: nil)
+  end
 
   include PgSearch
   pg_search_scope :search_scope,

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -95,7 +95,7 @@ class Project < ApplicationRecord
            :closed_pull_requests_count,
            :pull_request_acceptance_rate,
            :average_recent_committed_at,
-           :maximum_sibling_downloads,
+           :sibling_gem_with_most_downloads,
            to:        :github_repo,
            allow_nil: true,
            prefix:    :github_repo

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -95,6 +95,7 @@ class Project < ApplicationRecord
            :closed_pull_requests_count,
            :pull_request_acceptance_rate,
            :average_recent_committed_at,
+           :maximum_sibling_downloads,
            to:        :github_repo,
            allow_nil: true,
            prefix:    :github_repo

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -28,7 +28,7 @@ class Project < ApplicationRecord
   scope :includes_associations, -> { left_outer_joins(:github_repo, :rubygem, :categories) }
   scope :with_score, -> { where.not(score: nil) }
   def self.with_bugfix_forks(include_forks)
-    include_forks ? self : where(bugfix_fork_of: nil)
+    include_forks ? self : where(is_bugfix_fork: false)
   end
 
   include PgSearch

--- a/app/models/project/fork_detector.rb
+++ b/app/models/project/fork_detector.rb
@@ -53,7 +53,7 @@ class Project::ForkDetector
   # keywords in the name and description.
   #
   RubygemSibling = Check.new("rubygem_sibling") do |project|
-    next unless project.rubygem_downloads
+    next if !project.rubygem_downloads || (project.rubygem_downloads > 50_000)
 
     sibling = Rubygem.where(description: project.rubygem_description).order(downloads: :desc).first
 

--- a/app/models/project/fork_detector.rb
+++ b/app/models/project/fork_detector.rb
@@ -1,6 +1,21 @@
 # frozen_string_literal: true
 
-# r = Project.search("authentication").limit(150).map {|p| [p.permalink, Project::ForkDetector.new(p).fork_matches]}
+#
+# This class detects "bugfix forks" of gems.
+#
+# Before bundler it was pretty tough to include a gem including
+# some additional bugfix in a project. Many people adopted the practice
+# of submitting the bugfix PR, and in the meantime published their own
+# version of the gem to rubygem with a namespace.
+#
+# Those gems quite commonly still reference the original upstream
+# github repo, leading to high project popularity scores and polluting
+# search results (they mostly have very few downloads and a single or
+# extremely few releases)
+#
+# The checks in here apply some checks derived from real world data
+# that identify those projects so they can be flagged accordingly.
+#
 class Project::ForkDetector
   class Check
     attr_accessor :name, :check
@@ -12,29 +27,46 @@ class Project::ForkDetector
     end
 
     def applies?(project)
-      !!check.call(project)
+      check.call project
     end
   end
 
+  #
+  # Quite commonly a bugfix fork keeps the original github repo
+  # reference, which means the popularity score is high due to
+  # popularity of the upstream repo
+  #
   GithubSibling = Check.new("github_sibling") do |project|
-    if project.github_repo_maximum_sibling_downloads && project.rubygem_downloads
-      sibling_max_downloads = project.github_repo_maximum_sibling_downloads
-      relative_downloads = ((project.rubygem_downloads * 100) / sibling_max_downloads.to_f).round(2)
+    next unless project.github_repo_sibling_gem_with_most_downloads && project.rubygem_downloads
 
-      relative_downloads < 1.0
-    end
+    sibling = project.github_repo_sibling_gem_with_most_downloads
+    relative_downloads = ((project.rubygem_downloads * 100) / sibling.downloads.to_f).round(2)
+    next unless relative_downloads < 1.0
+
+    sibling.name
   end
 
+  #
+  # If the github repo reference was not set on the upstream
+  # rubygem the impact on the score is not so big, yet these forks
+  # can still also produce noise in search results due to matching
+  # keywords in the name and description.
+  #
   RubygemSibling = Check.new("rubygem_sibling") do |project|
-    if project.rubygem_downloads
-      sibling_max_downloads = Rubygem.where(description: project.rubygem_description).maximum(:downloads)
-      relative_downloads = ((project.rubygem_downloads * 100) / sibling_max_downloads.to_f).round(2)
+    next unless project.rubygem_downloads
 
-      relative_downloads < 50
-    end
+    sibling = Rubygem.where(description: project.rubygem_description).order(downloads: :desc).first
+
+    next unless sibling
+
+    relative_downloads = ((project.rubygem_downloads * 100) / sibling.downloads.to_f).round(2)
+
+    next unless relative_downloads < 50
+
+    sibling.name
   end
 
-  FORK_CRITERIA = [
+  FORK_CHECKS = [
     GithubSibling,
     RubygemSibling,
   ].freeze
@@ -46,11 +78,26 @@ class Project::ForkDetector
     self.project = project
   end
 
-  def fork_matches
-    @fork_matches ||= FORK_CRITERIA.select { |check| check.applies? project }.map(&:name)
+  def fork_criteria
+    @fork_criteria ||= fork_matches.keys
+  end
+
+  def forked_from
+    @forked_from ||= fork_matches.values.compact.first
   end
 
   def fork?
     fork_matches.any?
+  end
+
+  private
+
+  def fork_matches
+    @fork_matches ||= FORK_CHECKS.each_with_object({}) do |check, matches|
+      result = check.applies? project
+      next unless result
+
+      matches[check.name] = result
+    end
   end
 end

--- a/app/models/project/fork_detector.rb
+++ b/app/models/project/fork_detector.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+# r = Project.search("authentication").limit(150).map {|p| [p.permalink, Project::ForkDetector.new(p).fork_matches]}
+class Project::ForkDetector
+  class Check
+    attr_accessor :name, :check
+    private :name=, :check=
+
+    def initialize(name, &check)
+      self.name = name.to_s
+      self.check = check
+    end
+
+    def applies?(project)
+      !!check.call(project)
+    end
+  end
+
+  GithubSibling = Check.new("github_sibling") do |project|
+    if project.github_repo_maximum_sibling_downloads && project.rubygem_downloads
+      sibling_max_downloads = project.github_repo_maximum_sibling_downloads
+      relative_downloads = ((project.rubygem_downloads * 100) / sibling_max_downloads.to_f).round(2)
+
+      relative_downloads < 1.0
+    end
+  end
+
+  RubygemSibling = Check.new("rubygem_sibling") do |project|
+    if project.rubygem_downloads
+      sibling_max_downloads = Rubygem.where(description: project.rubygem_description).maximum(:downloads)
+      relative_downloads = ((project.rubygem_downloads * 100) / sibling_max_downloads.to_f).round(2)
+
+      relative_downloads < 50
+    end
+  end
+
+  FORK_CRITERIA = [
+    GithubSibling,
+    RubygemSibling,
+  ].freeze
+
+  attr_accessor :project
+  private :project=
+
+  def initialize(project)
+    self.project = project
+  end
+
+  def fork_matches
+    @fork_matches ||= FORK_CRITERIA.select { |check| check.applies? project }.map(&:name)
+  end
+
+  def fork?
+    fork_matches.any?
+  end
+end

--- a/db/migrate/20190110202221_add_bugfix_fork_data_to_projects.rb
+++ b/db/migrate/20190110202221_add_bugfix_fork_data_to_projects.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddBugfixForkDataToProjects < ActiveRecord::Migration[5.2]
+  def change
+    change_table :projects, bulk: true do |t|
+      t.string :bugfix_fork_of, default: nil
+      t.string :bugfix_fork_criteria, array: true, default: [], nil: false
+    end
+
+    add_index :projects, :bugfix_fork_of
+  end
+end

--- a/db/migrate/20190110202221_add_bugfix_fork_data_to_projects.rb
+++ b/db/migrate/20190110202221_add_bugfix_fork_data_to_projects.rb
@@ -4,9 +4,11 @@ class AddBugfixForkDataToProjects < ActiveRecord::Migration[5.2]
   def change
     change_table :projects, bulk: true do |t|
       t.string :bugfix_fork_of, default: nil
-      t.string :bugfix_fork_criteria, array: true, default: [], nil: false
+      t.string :bugfix_fork_criteria, array: true, default: [], null: false
+      t.boolean :is_bugfix_fork, default: false, null: false
     end
 
     add_index :projects, :bugfix_fork_of
+    add_index :projects, :is_bugfix_fork
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -244,6 +244,8 @@ CREATE TABLE public.projects (
     description text,
     permalink_tsvector tsvector,
     description_tsvector tsvector,
+    bugfix_fork_of character varying,
+    bugfix_fork_criteria character varying[] DEFAULT '{}'::character varying[],
     CONSTRAINT check_project_permalink_and_rubygem_name_parity CHECK (((rubygem_name IS NULL) OR ((rubygem_name)::text = (permalink)::text)))
 );
 
@@ -386,6 +388,13 @@ CREATE UNIQUE INDEX index_github_repos_on_path ON public.github_repos USING btre
 
 
 --
+-- Name: index_projects_on_bugfix_fork_of; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_projects_on_bugfix_fork_of ON public.projects USING btree (bugfix_fork_of);
+
+
+--
 -- Name: index_projects_on_description_tsvector; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -510,6 +519,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180718195202'),
 ('20181205134522'),
 ('20181210092238'),
-('20181213102703');
+('20181213102703'),
+('20190110202221');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -245,7 +245,8 @@ CREATE TABLE public.projects (
     permalink_tsvector tsvector,
     description_tsvector tsvector,
     bugfix_fork_of character varying,
-    bugfix_fork_criteria character varying[] DEFAULT '{}'::character varying[],
+    bugfix_fork_criteria character varying[] DEFAULT '{}'::character varying[] NOT NULL,
+    is_bugfix_fork boolean DEFAULT false NOT NULL,
     CONSTRAINT check_project_permalink_and_rubygem_name_parity CHECK (((rubygem_name IS NULL) OR ((rubygem_name)::text = (permalink)::text)))
 );
 
@@ -399,6 +400,13 @@ CREATE INDEX index_projects_on_bugfix_fork_of ON public.projects USING btree (bu
 --
 
 CREATE INDEX index_projects_on_description_tsvector ON public.projects USING gin (description_tsvector);
+
+
+--
+-- Name: index_projects_on_is_bugfix_fork; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_projects_on_is_bugfix_fork ON public.projects USING btree (is_bugfix_fork);
 
 
 --

--- a/spec/jobs/project_score_job_spec.rb
+++ b/spec/jobs/project_score_job_spec.rb
@@ -44,6 +44,13 @@ RSpec.describe ProjectScoreJob, type: :job do
       expect { job.perform "rspec" }.to change { Project.find("rspec").score }.to(nil)
     end
 
+    it "sets is_bugfix_fork to false" do
+      create_gems!
+      ProjectUpdateJob.new.perform "rspec"
+
+      expect { job.perform "rspec" }.not_to change { Project.find("rspec").is_bugfix_fork }.from(false)
+    end
+
     it "sets the bugfix_fork_of to nil" do
       create_gems!
       ProjectUpdateJob.new.perform "rspec"
@@ -71,11 +78,15 @@ RSpec.describe ProjectScoreJob, type: :job do
           .and_return(detector)
       end
 
-      it "sets the bugfix_fork_of to expected value" do
+      it "sets the is_bugfix_fork to expected value" do
+        expect { job.perform "rspec" }.to change { Project.find("rspec").is_bugfix_fork }.to(true)
+      end
+
+      it "sets the bugfix_fork_of to expected gem name" do
         expect { job.perform "rspec" }.to change { Project.find("rspec").bugfix_fork_of }.to("foobar")
       end
 
-      it "sets the bugfix_fork_criteria to an empty array" do
+      it "sets the bugfix_fork_criteria to a expected matching criteria" do
         expect { job.perform "rspec" }.to change { Project.find("rspec").bugfix_fork_criteria }.to(%w[foo bar])
       end
     end

--- a/spec/jobs/project_score_job_spec.rb
+++ b/spec/jobs/project_score_job_spec.rb
@@ -43,5 +43,41 @@ RSpec.describe ProjectScoreJob, type: :job do
       Project.create! permalink: "rspec", score: 2.0
       expect { job.perform "rspec" }.to change { Project.find("rspec").score }.to(nil)
     end
+
+    it "sets the bugfix_fork_of to nil" do
+      create_gems!
+      ProjectUpdateJob.new.perform "rspec"
+
+      expect { job.perform "rspec" }.not_to change { Project.find("rspec").bugfix_fork_of }.from(nil)
+    end
+
+    it "sets the bugfix_fork_criteria to an empty array" do
+      create_gems!
+      ProjectUpdateJob.new.perform "rspec"
+
+      expect { job.perform "rspec" }.not_to change { Project.find("rspec").bugfix_fork_criteria }.from([])
+    end
+
+    describe "when bugfix fork criteria apply" do
+      let(:detector) do
+        instance_double Project::ForkDetector, forked_from: "foobar", fork_criteria: %w[foo bar]
+      end
+
+      before do
+        create_gems!
+        ProjectUpdateJob.new.perform "rspec"
+        allow(Project::ForkDetector).to receive(:new)
+          .with(Project.find("rspec"))
+          .and_return(detector)
+      end
+
+      it "sets the bugfix_fork_of to expected value" do
+        expect { job.perform "rspec" }.to change { Project.find("rspec").bugfix_fork_of }.to("foobar")
+      end
+
+      it "sets the bugfix_fork_criteria to an empty array" do
+        expect { job.perform "rspec" }.to change { Project.find("rspec").bugfix_fork_criteria }.to(%w[foo bar])
+      end
+    end
   end
 end

--- a/spec/models/github_repo_spec.rb
+++ b/spec/models/github_repo_spec.rb
@@ -157,4 +157,13 @@ RSpec.describe GithubRepo, type: :model do
       expect(repo.total_pull_requests_count).to be == 7 + 11 + 3
     end
   end
+
+  describe "#maximum_sibling_downloads" do
+    it "is the max downloads of associated rubygems" do
+      repo = described_class.new
+
+      allow(repo.rubygems).to receive(:maximum).with(:downloads).and_return(42)
+      expect(repo.maximum_sibling_downloads).to be 42
+    end
+  end
 end

--- a/spec/models/github_repo_spec.rb
+++ b/spec/models/github_repo_spec.rb
@@ -158,12 +158,13 @@ RSpec.describe GithubRepo, type: :model do
     end
   end
 
-  describe "#maximum_sibling_downloads" do
-    it "is the max downloads of associated rubygems" do
-      repo = described_class.new
+  describe "#sibling_gem_with_most_downloads" do
+    it "returns rubygem that has the most downloads and same repo" do
+      widget = Factories.project "widget", downloads: 50_000
+      other = Factories.project "other", downloads: 10_000
+      other.update! github_repo: widget.github_repo
 
-      allow(repo.rubygems).to receive(:maximum).with(:downloads).and_return(42)
-      expect(repo.maximum_sibling_downloads).to be 42
+      expect(other.github_repo.sibling_gem_with_most_downloads).to be == widget.rubygem
     end
   end
 end

--- a/spec/models/project/fork_detector_spec.rb
+++ b/spec/models/project/fork_detector_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Project::ForkDetector, type: :model do
+  describe "#fork?" do
+    it "is true for a project that references a significantly more popular repo" do
+      project = instance_double Project,
+                                github_repo_maximum_sibling_downloads: 500_000,
+                                rubygem_downloads:                     30,
+                                rubygem_description:                   "hello world"
+
+      expect(described_class.new(project)).to be_fork
+    end
+
+    it "is true for a project that has the same description as a much more popular gem" do
+      Rubygem.create! name: "demo", current_version: "1.2", description: "Hello World", downloads: 50_000
+      project = instance_double Project,
+                                github_repo_maximum_sibling_downloads: 10,
+                                rubygem_downloads:                     1000,
+                                rubygem_description:                   "Hello World"
+
+      expect(described_class.new(project)).to be_fork
+    end
+
+    it "is false for regular project" do
+      project = instance_double Project,
+                                github_repo_maximum_sibling_downloads: 1000,
+                                rubygem_downloads:                     1000,
+                                rubygem_description:                   "Hello World"
+
+      expect(described_class.new(project)).not_to be_fork
+    end
+  end
+end

--- a/spec/models/project/fork_detector_spec.rb
+++ b/spec/models/project/fork_detector_spec.rb
@@ -48,6 +48,11 @@ RSpec.describe Project::ForkDetector, type: :model do
     it "references the expected rubygem as forked_from" do
       expect(detector.forked_from).to be == "demo"
     end
+
+    it "isn't a fork when the inspected project has more than 50k downloads" do
+      allow(project).to receive(:rubygem_downloads).and_return(50_001)
+      expect(detector).not_to be_fork
+    end
   end
 
   describe "for a regular project" do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -11,6 +11,21 @@ RSpec.describe Project, type: :model do
     )
   end
 
+  describe ".with_bugfix_forks" do
+    before do
+      Factories.project "regular"
+      Factories.project("forked").tap { |p| p.update! bugfix_fork_of: "foobar" }
+    end
+
+    it "omits bugfix_forks when given false" do
+      expect(Project.with_bugfix_forks(false).pluck(:permalink)).to be == %w[regular]
+    end
+
+    it "includes bugfix_forks when given true" do
+      expect(Project.with_bugfix_forks(true).order(permalink: :asc).pluck(:permalink)).to be == %w[forked regular]
+    end
+  end
+
   describe ".search" do
     it "can find a matching project" do
       expected = Project.create! permalink: "widgets", score: 1

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Project, type: :model do
   describe ".with_bugfix_forks" do
     before do
       Factories.project "regular"
-      Factories.project("forked").tap { |p| p.update! bugfix_fork_of: "foobar" }
+      Factories.project("forked").tap { |p| p.update! is_bugfix_fork: true }
     end
 
     it "omits bugfix_forks when given false" do

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -4,7 +4,7 @@ module Factories
   # rubocop:disable Metrics/MethodLength All-in-one-place is more relevant than short methods here
   class << self
     def project(name,
-                score:,
+                score: 25,
                 downloads: 5000,
                 first_release: 1.year.ago,
                 description: nil)


### PR DESCRIPTION
This PR adds a mechanism for detecting "bugfix forks" as part of an effort to improve search result relevance over the next weeks.

There is a huge number of namespaced gems that only have one or maybe a handful of releases, long in the past. Quite frequently they still reference the upstream github repo, so their popularity score is very high for popular gems.

The reason for their existence usually is the trouble that was deploying hotfixed libraries with your app before bundler made including gems from github repos a breeze (thank you bundler, this is so helpful :). 

Since you could not simply send a PR with an urgent fix upstream and go with your github branch for a while, many people resorted to the practice of sending a PR and issuing a hotfixed, namespaced gem to github until the PR is reviewed, merged and released upstream.

The idea is to have those projects detected and excluded by default from search results in the future, with a toggle button to make them re-appear.

As it currently stands, this would change the top 50 results when searching the toolbox for `authentication` like this:

| BEFORE                              | AFTER                               |
|-------------------------------------|-------------------------------------|
| devise                              | devise                              |
| dcu-devise                          |                                     |
| drfas                               |                                     |
| loyal_devise                        |                                     |
| glennr-devise                       |                                     |
| shingara-devise                     |                                     |
| ramon-devise                        |                                     |
| cloudfoundry-devise                 |                                     |
| ivanvc-devise                       |                                     |
| devise_omniauth_fb                  |                                     |
| devise-edge                         |                                     |
| namxam-devise                       |                                     |
| upstream-devise                     |                                     |
| mongoid-devise                      |                                     |
| rmello-devise                       |                                     |
| brainsome_devise                    |                                     |
| af-devise                           |                                     |
| aihs_devise                         |                                     |
| graffititracker_devise              |                                     |
| devise-no-session                   |                                     |
| warden                              | warden                              |
| omniauth                            | omniauth                            |
| mixlib-authentication               | mixlib-authentication               |
| ruby-hmac                           | ruby-hmac                           |
| kth_omniauth                        |                                     |
| ntlm-http                           | ntlm-http                           |
| koala                               | koala                               |
| authlogic                           | authlogic                           |
| crankharder-authlogic               |                                     |
| kschrader-authlogic                 |                                     |
| cotweet-authlogic                   |                                     |
| drogus-authlogic                    |                                     |
| railsware-authlogic                 |                                     |
| expertiza-authlogic                 |                                     |
| skippy-authlogic                    |                                     |
| binarylogic-authlogic               |                                     |
| kb-authlogic                        |                                     |
| jlecour-authlogic                   |                                     |
| nulogy-authlogic                    |                                     |
| Empact-authlogic                    |                                     |
| net-http-digest_auth                | net-http-digest_auth                |
| rubyntlm                            | rubyntlm                            |
| tyler_koala                         |                                     |
| cotweet_koala                       |                                     |
| technoweenie/restful-authentication | technoweenie/restful-authentication |
| clearance                           | clearance                           |
| thoughtbot-clearance                | thoughtbot-clearance                |
| gravis-clearance                    |                                     |
| activerain-clearance                |                                     |
| jeffrafter-clearance                |                                     |
|                                     | nifty-generators                    |
|                                     | simple_token_authentication         |
|                                     | httpauth                            |
|                                     | devise-two-factor                   |
|                                     | knock                               |
|                                     | devise_ldap_authenticatable         |
|                                     | spree_auth_devise                   |
|                                     | omniauth-auth0                      |
|                                     | authentication-needed-san           |
|                                     | authentication-rails                |
|                                     | authentication-service              |
|                                     | sorcery                             |
|                                     | rubycas-client                      |
|                                     | sinatra-authorize                   |
|                                     | textkey_rest                        |
|                                     | rubycas-server                      |
|                                     | signature                           |
|                                     | two_factor_authentication           |
|                                     | pyu-ruby-sasl                       |
|                                     | sinatra-authentication              |
|                                     | pusher-signature                    |
|                                     | securecompare                       |
|                                     | devise-token_authenticatable        |
|                                     | u2f                                 |
|                                     | google_places                       |
|                                     | fluent-plugin-secure-forward        |
|                                     | rodauth                             |
|                                     | warden-hmac-authentication          |
|                                     | omniauth-authentiq                  |
|                                     | rails_warden                        |
|                                     | omniauth-identity                   |
|                                     | tripletex_api                       |
|                                     | fresh-auth                          |
|                                     | refinerycms-authentication          |
|                                     | devise_cas_authenticatable          |
|                                     | rails-auth                          |
|                                     | bitbucket_rest_api                  |