### PR TITLE
Filter bugfix forks from search results by default & allow to toggle display

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -51,4 +51,28 @@ document.addEventListener("turbolinks:load", function () {
       });
     })
   });
+
+  // When the bugfix forks toggle is clicked on the search the HTTP response takes
+  // a tad too long to process without visual feedback to the user that something has happened,
+  // therefore we put it into the loading state (and when going back in history ensure to revert
+  // that state)
+  document.querySelectorAll("a.bugfix-forks-toggle").forEach(function(button) {
+    button.classList.remove("is-loading");
+    button.addEventListener("click", function() {
+      button.classList.add("is-loading");
+    });
+  });
+
+  // See above, just for the custom project order dropdown
+  document.querySelectorAll(".project-order-dropdown .dropdown-content a").forEach(function(button) {
+    document.querySelectorAll(".project-order-dropdown button").forEach(function(dropdown) {
+      dropdown.classList.remove("is-loading");
+    });
+    button.addEventListener("click", function() {
+      document.querySelectorAll(".project-order-dropdown button").forEach(function(dropdown) {
+        dropdown.classList.add("is-loading");
+      });
+    });
+  });
 });
+

--- a/app/assets/stylesheets/components/project_health_tag.sass
+++ b/app/assets/stylesheets/components/project_health_tag.sass
@@ -12,3 +12,6 @@
   &.level-red
     .tag
       @extend .is-danger
+
+  a.tag:hover
+    text-decoration: none

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -5,11 +5,15 @@ class SearchesController < ApplicationController
     @query = params[:q].presence
     return unless @query
 
-    @search = Search.new(@query, order: current_order)
+    @search = Search.new(@query, order: current_order, show_forks: show_forks?)
     @projects = @search.projects.page(params[:page])
   end
 
   private
+
+  def show_forks?
+    params[:show_forks].present?
+  end
 
   def current_order
     @current_order ||= Project::Order.new order: params[:order], directions: Project::Order::SEARCH_DIRECTIONS

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -7,9 +7,18 @@ class SearchesController < ApplicationController
 
     @search = Search.new(@query, order: current_order, show_forks: show_forks?)
     @projects = @search.projects.page(params[:page])
+
+    redirect_to_search_with_forks_included if !@search.show_forks && @projects.empty?
   end
 
   private
+
+  def redirect_to_search_with_forks_included
+    redirect_to action:     :show,
+                q:          @search.query,
+                order:      current_order.ordered_by,
+                show_forks: true
+  end
 
   def show_forks?
     params[:show_forks].present?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -93,6 +93,10 @@ module ApplicationHelper
     render partial: "components/category_card", locals: locals
   end
 
+  def project_health_tags(project)
+    render "components/project_health_tags", project: project
+  end
+
   def project_health_tag(health_status)
     render "components/project_health_tag", status: health_status
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -45,8 +45,9 @@ class Project < ApplicationRecord
                   },
                   ranked_by: ":tsearch * (#{table_name}.score + 1) * (#{table_name}.score + 1)"
 
-  def self.search(query, order: Project::Order.new(directions: Project::Order::SEARCH_DIRECTIONS))
+  def self.search(query, order: Project::Order.new(directions: Project::Order::SEARCH_DIRECTIONS), show_forks: false)
     with_score
+      .with_bugfix_forks(show_forks)
       .search_scope(query)
       .reorder("")
       .includes_associations

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 class Search
-  attr_accessor :query, :order
-  private :query=, :order=
+  attr_accessor :query, :order, :show_forks
+  private :query=, :order=, :show_forks=
 
-  def initialize(query, order: Project::Order.new(directions: Project::Order::SEARCH_DIRECTIONS))
+  def initialize(query, order: Project::Order.new(directions: Project::Order::SEARCH_DIRECTIONS), show_forks: false)
     self.query = query.presence&.strip
     self.order = order
+    self.show_forks = !!show_forks
   end
 
   def query?
@@ -14,7 +15,7 @@ class Search
   end
 
   def projects
-    @projects ||= Project.search(query, order: order)
+    @projects ||= Project.search(query, order: order, show_forks: show_forks)
   end
 
   def categories

--- a/app/views/components/_project_health_tags.html.slim
+++ b/app/views/components/_project_health_tags.html.slim
@@ -1,0 +1,11 @@
+.project-health-tags
+  - if project.bugfix_fork_of
+    .project-health-tag.tags.has-addons
+      a.tag.is-dark href=page_path("docs/features/bugfix_forks")
+        span.icon: i.fa.fa-code-fork
+        span Bugfix fork of
+      a.tag.is-primary href=project_path(project.bugfix_fork_of)
+        = project.bugfix_fork_of
+
+  - Project::Health.new(project).status.each do |status|
+    = project_health_tag status

--- a/app/views/components/_project_order_dropdown.html.slim
+++ b/app/views/components/_project_order_dropdown.html.slim
@@ -21,6 +21,6 @@
               strong= t(:label, scope: "labels.#{group}")
 
         - directions.map(&:key).each do |direction|
-          a href="#{request.path}?order=#{direction}&q=#{@search&.query}" class=(order.is?(direction) ? "is-active" : "")
+          a href="#{request.path}?order=#{direction}&q=#{@search&.query}&show_forks=#{@search&.show_forks}" class=(order.is?(direction) ? "is-active" : "")
             span.icon: i.fa class=metric_icon(direction)
             = metric_label direction

--- a/app/views/pages/components/project_health_tag.html.slim
+++ b/app/views/pages/components/project_health_tag.html.slim
@@ -8,3 +8,19 @@
     = project_health_tag Project::Health::HEALTHY_STATUS
     - Project::Health::Checks::ALL.each do |status|
       = project_health_tag status
+
+= component_example "Tag list shortcut helper" do
+  .content
+    markdown:
+      Use `project_health_tags(project)` to render the full list of health tags without iterating over individual items
+
+  = project_health_tags Project.new
+
+= component_example "Reference to bugfix forks" do
+  .content
+    markdown:
+      Projects that are a [bugfix fork](/pages/docs/features/bugfix_forks)
+      get an additional badge linking the documentation and the
+      suspected originating gem.
+
+  = project_health_tags Project.new(bugfix_fork_of: "rails")

--- a/app/views/pages/docs/features/bugfix_forks.html.slim
+++ b/app/views/pages/docs/features/bugfix_forks.html.slim
@@ -1,0 +1,39 @@
+.hero
+  section.section: .container.has-text-centered
+    h2 Bugfix Forks
+
+
+section.section: .container: .columns
+  article.blog-post
+    markdown:
+      Nowadays it's easy to **include a patched gem version from a git repository**
+      by adding `gem "xyz", git: "some git source"` to your application's `Gemfile`, but **before
+      [bundler] existed** this was a very **cumbersome task**.
+
+      If you **ran into an issue with a gem** you were using and you or somebody else
+      created a bugfix for the problem **you had to wait for the library maintainers to publish
+      a new release** to Rubygems **before you could patch your application**.
+
+      To **get around this issue** many developers adopted a pattern of **publishing a namespaced fork
+      including a bugfix** to Rubygems **until the fix was merged and released upstream**.
+
+      Unfortunately the widespread adoption of this practice led to a **huge number of orphaned gems**
+      that usually have only a single or at most a handful of releases. Additionally these **forked gems
+      often retained** their upstream **github source code url**, so on the Ruby Toolbox **these forks
+      receive a high popularity ranking**.
+
+      Because of this, the Ruby Toolbox tries to identify these projects based on common patterns.
+
+      If a **project is flagged as a bugfix fork** by default it **does not show up in search results**.
+      However, you can **re-enable inclusion of bugfix forks** from within the **search navigation** if
+      you are missing a library.
+
+      If you spot a **library that is flagged as a bugfix fork wrongly** please
+      [report this as an issue on the Ruby Toolbox issue tracker](https://github.com/rubytoolbox/rubytoolbox/issues).
+
+      #### See also:
+
+      * [rubytoolbox#377](https://github.com/rubytoolbox/rubytoolbox/pull/377)
+      * [rubytoolbox#380](https://github.com/rubytoolbox/rubytoolbox/pull/380)
+
+      [bundler]: /projects/bundler

--- a/app/views/pages/docs/features/bugfix_forks.html.slim
+++ b/app/views/pages/docs/features/bugfix_forks.html.slim
@@ -12,7 +12,7 @@ section.section: .container: .columns
 
       If you **ran into an issue with a gem** you were using and you or somebody else
       created a bugfix for the problem **you had to wait for the library maintainers to publish
-      a new release** to Rubygems **before you could patch your application**.
+      a new release** to Rubygems **before you could patch your application** (or use [Github's discontinued Rubygems server][github-gems], which also had namespacing).
 
       To **get around this issue** many developers adopted a pattern of **publishing a namespaced fork
       including a bugfix** to Rubygems **until the fix was merged and released upstream**.
@@ -37,3 +37,4 @@ section.section: .container: .columns
       * [rubytoolbox#380](https://github.com/rubytoolbox/rubytoolbox/pull/380)
 
       [bundler]: /projects/bundler
+      [github-gems]: https://blog.github.com/2008-04-25-github-s-rubygem-server/

--- a/app/views/projects/_project.html.slim
+++ b/app/views/projects/_project.html.slim
@@ -17,10 +17,7 @@
           i.fa class=metric_icon(:score)
         span= project.score
 
-  .columns: .column
-    .project-health-tags
-      - Project::Health.new(project).status.each do |status|
-        = project_health_tag status
+  .columns: .column= project_health_tags project
 
   - if local_assigns[:show_categories] and project.categories.any?
     .columns.is-hidden-desktop: .column

--- a/app/views/projects/show.html.slim
+++ b/app/views/projects/show.html.slim
@@ -19,10 +19,8 @@
         - @project.categories.each do |category|
           = category_card category, compact: true, inline: true
 
-  .columns: .column
-    .project-health-tags
-      - Project::Health.new(@project).status.each do |status|
-        = project_health_tag status
+  .columns: .column= project_health_tags @project
+
 
   .columns: .links.column
     = render partial: "projects/links", locals: { project: @project }

--- a/app/views/searches/show.html.slim
+++ b/app/views/searches/show.html.slim
@@ -38,15 +38,21 @@
           h2.subtitle.is-4 Projects
         .level-right
           .level-item
-            - if @search.show_forks
-              a.button.is-white href=search_path(q: @search.query, order: current_order.ordered_by)
-                span.icon: i.fa.fa-check-square
-                span Bugfix forks are <strong>shown</strong>
+            .field.has-addons.bugfix-forks
+              .control
+                - if @search.show_forks
+                  a.button href=search_path(q: @search.query, order: current_order.ordered_by)
+                    span.icon: i.fa.fa-check-square
+                    span Bugfix forks are <strong>shown</strong>
 
-            - else
-              a.button.is-white href=search_path(q: @search.query, order: current_order.ordered_by, show_forks: true)
-                span.icon: i.fa.fa-square-o
-                span Bugfix forks are <strong>hidden</strong>
+                - else
+                  a.button href=search_path(q: @search.query, order: current_order.ordered_by, show_forks: true)
+                    span.icon: i.fa.fa-square-o
+                    span Bugfix forks are <strong>hidden</strong>
+
+              .control
+                a.button.help href=page_path("docs/features/bugfix_forks")
+                  span.icon: i.fa.fa-question-circle
 
           .level-item
             = project_order_dropdown current_order

--- a/app/views/searches/show.html.slim
+++ b/app/views/searches/show.html.slim
@@ -38,7 +38,7 @@
           h2.subtitle.is-4 Projects
         .level-right
           .level-item
-            .field.has-addons.bugfix-forks
+            .field.has-addons
               .control
                 - if @search.show_forks
                   a.button href=search_path(q: @search.query, order: current_order.ordered_by)
@@ -51,7 +51,7 @@
                     span Bugfix forks are <strong>hidden</strong>
 
               .control
-                a.button.help href=page_path("docs/features/bugfix_forks")
+                a.button.bugfix-forks-help href=page_path("docs/features/bugfix_forks")
                   span.icon: i.fa.fa-question-circle
 
           .level-item

--- a/app/views/searches/show.html.slim
+++ b/app/views/searches/show.html.slim
@@ -33,11 +33,23 @@
             span Category results are hidden when using a custom project result order
 
     .columns: .column.projects
-      .level
+      .level.project-search-nav
         .level-left: .level-item
           h2.subtitle.is-4 Projects
-        .level-right: .level-item
-          = project_order_dropdown current_order
+        .level-right
+          .level-item
+            - if @search.show_forks
+              a.button.is-white href=search_path(q: @search.query, order: current_order.ordered_by)
+                span.icon: i.fa.fa-check-square
+                span Bugfix forks are <strong>shown</strong>
+
+            - else
+              a.button.is-white href=search_path(q: @search.query, order: current_order.ordered_by, show_forks: true)
+                span.icon: i.fa.fa-square-o
+                span Bugfix forks are <strong>hidden</strong>
+
+          .level-item
+            = project_order_dropdown current_order
 
       - if @projects.any?
         .columns: .column= paginate @projects

--- a/app/views/searches/show.html.slim
+++ b/app/views/searches/show.html.slim
@@ -41,12 +41,12 @@
             .field.has-addons
               .control
                 - if @search.show_forks
-                  a.button href=search_path(q: @search.query, order: current_order.ordered_by, show_forks: false)
+                  a.button.bugfix-forks-toggle href=search_path(q: @search.query, order: current_order.ordered_by, show_forks: false)
                     span.icon: i.fa.fa-check-square
                     span Bugfix forks are <strong>shown</strong>
 
                 - else
-                  a.button href=search_path(q: @search.query, order: current_order.ordered_by, show_forks: true)
+                  a.button.bugfix-forks-toggle href=search_path(q: @search.query, order: current_order.ordered_by, show_forks: true)
                     span.icon: i.fa.fa-square-o
                     span Bugfix forks are <strong>hidden</strong>
 

--- a/app/views/searches/show.html.slim
+++ b/app/views/searches/show.html.slim
@@ -41,7 +41,7 @@
             .field.has-addons
               .control
                 - if @search.show_forks
-                  a.button href=search_path(q: @search.query, order: current_order.ordered_by)
+                  a.button href=search_path(q: @search.query, order: current_order.ordered_by, show_forks: false)
                     span.icon: i.fa.fa-check-square
                     span Bugfix forks are <strong>shown</strong>
 

--- a/spec/controllers/searches_controller_spec.rb
+++ b/spec/controllers/searches_controller_spec.rb
@@ -9,8 +9,15 @@ RSpec.describe SearchesController, type: :controller do
     end
 
     it "returns http success" do
-      do_request
-      expect(response).to be_successful
+      Factories.project "foobar"
+      do_request query: "foobar"
+      expect(response).to have_http_status(:success)
+    end
+
+    it "renders show template" do
+      Factories.project "foobar"
+      do_request query: "foobar"
+      expect(response).to render_template(:show)
     end
 
     it "assigns nothing to search when there is no query" do
@@ -48,6 +55,11 @@ RSpec.describe SearchesController, type: :controller do
         )
         .and_call_original
       do_request query: "hello world", order: "rubygem_downloads", show_forks: true
+    end
+
+    it "redirects to results including forks when project search has no results" do
+      do_request query: "my query"
+      expect(response).to redirect_to(search_path(q: "my query", order: "rank", show_forks: true))
     end
   end
 end

--- a/spec/controllers/searches_controller_spec.rb
+++ b/spec/controllers/searches_controller_spec.rb
@@ -4,8 +4,8 @@ require "rails_helper"
 
 RSpec.describe SearchesController, type: :controller do
   describe "GET #show" do
-    def do_request(query: nil, order: nil)
-      get :show, params: { q: query, order: order }
+    def do_request(query: nil, order: nil, show_forks: nil)
+      get :show, params: { q: query, order: order, show_forks: show_forks }
     end
 
     it "returns http success" do
@@ -30,13 +30,24 @@ RSpec.describe SearchesController, type: :controller do
         .and respond_to(:total_pages)
     end
 
-    it "passes query and a project order instance to Search.new" do
+    it "passes query, a project order instance and show_forks status to Search.new" do
       order = Project::Order.new(order: "rubygem_downloads")
       allow(Project::Order).to receive(:new)
         .with(order: "rubygem_downloads", directions: Project::Order::SEARCH_DIRECTIONS)
         .and_return(order)
-      expect(Search).to receive(:new).with("hello world", order: order).and_call_original
+      expect(Search).to receive(:new).with("hello world", order: order, show_forks: false).and_call_original
       do_request query: "hello world", order: "rubygem_downloads"
+    end
+
+    it "passes show_forks true to search when set in params" do
+      expect(Search).to receive(:new)
+        .with(
+          kind_of(String),
+          order:      kind_of(Project::Order),
+          show_forks: true
+        )
+        .and_call_original
+      do_request query: "hello world", order: "rubygem_downloads", show_forks: true
     end
   end
 end

--- a/spec/controllers/searches_controller_spec.rb
+++ b/spec/controllers/searches_controller_spec.rb
@@ -58,8 +58,13 @@ RSpec.describe SearchesController, type: :controller do
     end
 
     it "redirects to results including forks when project search has no results" do
-      do_request query: "my query"
+      get :show, params: { q: "my query" }
       expect(response).to redirect_to(search_path(q: "my query", order: "rank", show_forks: true))
+    end
+
+    it "does not redirect when project search has no results but explicit show forks is given" do
+      get :show, params: { q: "my query", show_forks: true }
+      expect(response).to have_http_status(:success)
     end
   end
 end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -43,11 +43,7 @@ RSpec.describe "Search", type: :feature, js: true do
     expect(page).to have_selector(".category-card", count: 1)
 
     %w[Downloads Stars Forks].each do |button_label|
-      within ".project-order-dropdown" do
-        page.find("button").hover
-        click_on button_label
-        expect(page).to have_text "Order by #{button_label}"
-      end
+      order_by button_label
       expect(listed_project_names).to be == ["widgets", "more widgets"]
 
       # When using a custom order, matching categories are not shown
@@ -58,14 +54,7 @@ RSpec.describe "Search", type: :feature, js: true do
       expect(page).to have_text "Category results are hidden"
     end
 
-    within ".project-order-dropdown" do
-      page.find("button").hover
-      click_on "First release"
-    end
-
-    within ".project-order-dropdown" do
-      expect(page).to have_text "Order by First release"
-    end
+    order_by "First release"
     expect(listed_project_names).to be == ["more widgets", "widgets"]
   end
 
@@ -108,8 +97,13 @@ RSpec.describe "Search", type: :feature, js: true do
     end
 
     wait_for { listed_project_names.include? "more widgets" }
-
     expect(listed_project_names).to be == ["more widgets", "widgets"]
+    expect(page).to have_text "Bugfix forks are shown"
+
+    # Re-ordering should retain show_forks status
+    order_by "Downloads"
+    expect(listed_project_names).to be == ["widgets", "more widgets"]
+    expect(page).to have_text "Bugfix forks are shown"
 
     within ".project-search-nav" do
       click_on "Bugfix forks are shown"
@@ -163,6 +157,14 @@ RSpec.describe "Search", type: :feature, js: true do
     within container do
       fill_in "q", with: query
       click_button "Search"
+    end
+  end
+
+  def order_by(button_label)
+    within ".project-order-dropdown" do
+      page.find("button").hover
+      click_on button_label
+      expect(page).to have_text "Order by #{button_label}"
     end
   end
 end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -118,8 +118,13 @@ RSpec.describe "Search", type: :feature, js: true do
     wait_for { !listed_project_names.include? "more widgets" }
     expect(listed_project_names).to be == ["widgets"]
 
-    page.find(".project-search-nav .bugfix-forks a.help").click
+    # When there are no results from projects search without
+    # forks we redirect to the page with included forks automatically
+    search_for "more widgets"
+    expect(listed_project_names).to be == ["more widgets"]
 
+    # Ensure help page is accessible
+    page.find(".project-search-nav a.bugfix-forks-help").click
     within ".hero" do
       expect(page).to have_text("Bugfix Forks")
     end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -117,6 +117,12 @@ RSpec.describe "Search", type: :feature, js: true do
 
     wait_for { !listed_project_names.include? "more widgets" }
     expect(listed_project_names).to be == ["widgets"]
+
+    page.find(".project-search-nav .bugfix-forks a.help").click
+
+    within ".hero" do
+      expect(page).to have_text("Bugfix Forks")
+    end
   end
 
   it "automatically focuses the search input when accessed without query" do

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -56,6 +56,16 @@ RSpec.describe "Search", type: :feature, js: true do
 
     order_by "First release"
     expect(listed_project_names).to be == ["more widgets", "widgets"]
+
+    # Ensure the button is correctly put into loading state on click
+    halt_js = <<~JS
+      document.querySelectorAll(".project-order-dropdown a").forEach(function(button) {
+        button.addEventListener("click", function(e) { e.preventDefault(); })
+      });
+    JS
+    page.evaluate_script halt_js
+    order_by "Downloads", expect_navigation: false
+    expect(page).to have_selector(".project-order-dropdown button.is-loading")
   end
 
   it "paginates large project collections" do
@@ -117,6 +127,16 @@ RSpec.describe "Search", type: :feature, js: true do
     search_for "more widgets"
     expect(listed_project_names).to be == ["more widgets"]
 
+    # Ensure the button is correctly put into loading state on click
+    halt_js = <<~JS
+      document.querySelectorAll("a.bugfix-forks-toggle").forEach(function(button) {
+        button.addEventListener("click", function(e) { e.preventDefault(); })
+      });
+    JS
+    page.evaluate_script halt_js
+    click_on "Bugfix forks are shown"
+    expect(page).to have_selector("a.bugfix-forks-toggle.is-loading")
+
     # Ensure help page is accessible
     page.find(".project-search-nav a.bugfix-forks-help").click
     within ".hero" do
@@ -160,11 +180,11 @@ RSpec.describe "Search", type: :feature, js: true do
     end
   end
 
-  def order_by(button_label)
+  def order_by(button_label, expect_navigation: true)
     within ".project-order-dropdown" do
       page.find("button").hover
       click_on button_label
-      expect(page).to have_text "Order by #{button_label}"
+      expect(page).to have_text "Order by #{button_label}" if expect_navigation
     end
   end
 end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -97,6 +97,28 @@ RSpec.describe "Search", type: :feature, js: true do
     expect(listed_project_names).to be == (5..7).map { |i| "widgets #{i}" }
   end
 
+  it "hides bugfix forks from results by default, but allows to toggle their display" do
+    Project.find("more widgets").update! is_bugfix_fork: true
+
+    search_for "widget"
+
+    expect(listed_project_names).to be == ["widgets"]
+    within ".project-search-nav" do
+      click_on "Bugfix forks are hidden"
+    end
+
+    wait_for { listed_project_names.include? "more widgets" }
+
+    expect(listed_project_names).to be == ["more widgets", "widgets"]
+
+    within ".project-search-nav" do
+      click_on "Bugfix forks are shown"
+    end
+
+    wait_for { !listed_project_names.include? "more widgets" }
+    expect(listed_project_names).to be == ["widgets"]
+  end
+
   it "automatically focuses the search input when accessed without query" do
     search_for ""
     expect(active_element).to(satisfy { |e| e.tag_name == "input" && e["name"] == "q" })

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -41,6 +41,24 @@ RSpec.describe Project, type: :model do
       expect(Project.search("widget")).to be == [expected]
     end
 
+    describe "for projects flagged as bugfix forks" do
+      let(:expected) do
+        Project.create! permalink: "somethingelse", score: 10, description: "Provides amazing widgets"
+      end
+
+      before do
+        Project.create! permalink: "widgets", is_bugfix_fork: true, score: 1
+      end
+
+      it "does not include them by default" do
+        expect(Project.search("widget")).to be == [expected]
+      end
+
+      it "includes them when called with show_forks true" do
+        expect(Project.search("widget", show_forks: true)).to be == [expected, Project.find("widgets")]
+      end
+    end
+
     describe "result order" do
       before do
         (1..3).each do |i|

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -25,13 +25,24 @@ RSpec.describe Search, type: :model do
 
   describe "#projects" do
     it "searches projects for the given query" do
-      expect(Project).to receive(:search).with("my query", order: kind_of(Project::Order))
+      expect(Project).to receive(:search).with("my query", order: kind_of(Project::Order), show_forks: false)
       described_class.new("my query").projects
+    end
+
+    it "passes given show_forks value to search query" do
+      expect(Project).to receive(:search)
+        .with(
+          kind_of(String),
+          order:      kind_of(Project::Order),
+          show_forks: true
+        )
+      described_class.new("my query", show_forks: "yes").projects
     end
 
     it "returns the resulting collection" do
       collection = %w[some projects]
-      allow(Project).to receive(:search).with("my query", order: kind_of(Project::Order)).and_return(collection)
+      allow(Project).to receive(:search).with("my query", order: kind_of(Project::Order), show_forks: false)
+                                        .and_return(collection)
       expect(described_class.new("my query").projects).to be == collection
     end
   end


### PR DESCRIPTION
Following the addition of the backing logic for this via #377 this PR adds filtering of bugfix forks from search results by default, with the option to re-enable display via a button.

It also introduces a documentation page explaining the feature. Over the next weeks I want to add more of these, including a proper navigation item and sidebar navigation for the docs themselves.

This change highly increases top search result relevancy as explained in https://github.com/rubytoolbox/rubytoolbox/pull/377

When searching with the default of hidden bugfix forks yields no project results the controller redirects to the variant with forks enabled.

This PR also puts the new bugfix fork toggle as well as the previous custom project sorting dropdown (#360) into loading state to give some visual hint that something is happening, the search is a tad too slow to get by without any additional cues imho :snail: 

![bugfix-fork-filtering](https://user-images.githubusercontent.com/13972/51126093-92103080-1822-11e9-8971-c7d32fb1c327.gif)
