### PR TITLE
Fix eager load for included assocations

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -25,7 +25,10 @@ class Project < ApplicationRecord
              optional:    true,
              inverse_of:  :projects
 
-  scope :includes_associations, -> { left_outer_joins(:github_repo, :rubygem, :categories) }
+  scope :includes_associations, lambda {
+    includes(:github_repo, :rubygem, :categories)
+      .left_outer_joins(:github_repo, :rubygem, :categories)
+  }
   scope :with_score, -> { where.not(score: nil) }
   def self.with_bugfix_forks(include_forks)
     include_forks ? self : where(is_bugfix_fork: false)

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -11,6 +11,21 @@ RSpec.describe Project, type: :model do
     )
   end
 
+  describe ".includes_associations" do
+    before do
+      rand(3..14).times { |i| Factories.project "project #{i}" }
+    end
+
+    it "only makes expected amount of queries" do
+      nested_accessor = ->(p) { [p.categories.map(&:name), p.rubygem_downloads, p.github_repo_stargazers_count] }
+
+      # Sometimes activerecord sprinkles in a `SELECT a.attname, format_type(a.atttypid, a.atttypmod),`
+      # here for good measure. Actually it's supposed to be 4 queries.
+      expect { Project.includes_associations.map(&nested_accessor) }
+        .to make_database_queries(count: 4..5)
+    end
+  end
+
   describe ".with_bugfix_forks" do
     before do
       Factories.project "regular"


### PR DESCRIPTION
I accidentally messed this up in up in ac9393bf56 (#360). The replacement of includes with left_outer_join did fix my search query sql problem, but now the nested associations are actually not eager loaded anymore, leading to performance hits on the search endpoint. The combination of includes and left outer join fixes that problem here.