### PR TITLE
Allow blacklisting for linking github repos from gems

### DIFF
--- a/spec/jobs/project_update_job_spec.rb
+++ b/spec/jobs/project_update_job_spec.rb
@@ -41,6 +41,12 @@ RSpec.describe ProjectUpdateJob, type: :job do
         expect { do_perform }.to change { project.reload.github_repo_path }.from(nil).to("rspec/rspec")
       end
 
+      it "assigns nil github_repo_path when gem name is blacklisted" do
+        project.update! github_repo_path: "foo/bar"
+        stub_const "#{described_class}::REPO_LINK_BLACKLIST", [project.permalink]
+        expect { do_perform }.to change { project.reload.github_repo_path }.to(nil)
+      end
+
       it "enqueues a GithubRepoUpdateJob if the github repo is missing" do
         expect(GithubRepoUpdateJob).to receive(:perform_async).with("rspec/rspec")
         do_perform


### PR DESCRIPTION
Normally the project updating mechanism tries to detect the github repo from a gems link references.

The react-source gem references the upstream JS react  repo, which has an extremely large audience on github.  However it doesn't seem to have any affiliation with react itself. Since react's github popularity metrics (stars, forks) are much higher than the most popular ruby repo (at the time of  writing ;) this skews popularity scores, since the max stars and forks are considered for the overall popularity scoring. Hence, this gem is being prevented from linking against it referenced github repo.

To allow similar future tweaks this makes the actual blacklist a configurable array.