### PR TITLE
Bugfix fork referencing react should also be excluded

### DIFF
--- a/app/jobs/project_update_job.rb
+++ b/app/jobs/project_update_job.rb
@@ -12,6 +12,7 @@ class ProjectUpdateJob < ApplicationJob
   # it's referenced github repo.
   REPO_LINK_BLACKLIST = %w[
     react-source
+    react-source-fb-cloned
   ].freeze
 
   def perform(permalink)


### PR DESCRIPTION
Followup to #383, I overlooked a bugfix fork (see #377) of this gem since the query I was using excluded them.