### PR TITLE
Project display modes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,8 @@ gem "webpacker", require: false
 
 gem "font-awesome-rails", "~> 4.7"
 
+gem "addressable"
+
 # Use ActiveStorage variant
 # gem 'mini_magick', '~> 4.8'
 

--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,8 @@ gem "forgery"
 gem "rack-canonical-host"
 gem "rack-ssl-enforcer"
 
+gem "browser"
+
 gem "github_webhook"
 
 gem "high_voltage"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -404,6 +404,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  addressable
   appsignal
   bootsnap (>= 1.1.0)
   browser

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,7 @@ GEM
     bindex (0.5.0)
     bootsnap (1.3.2)
       msgpack (~> 1.0)
+    browser (2.5.3)
     builder (3.2.3)
     byebug (10.0.2)
     capybara (3.13.2)
@@ -405,6 +406,7 @@ PLATFORMS
 DEPENDENCIES
   appsignal
   bootsnap (>= 1.1.0)
+  browser
   byebug
   capybara (>= 2.15, < 4.0)
   chromedriver-helper

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -76,6 +76,13 @@ document.addEventListener("turbolinks:load", function () {
     });
   });
 
+  document.querySelectorAll(".project-display-picker .button").forEach(function(button) {
+    button.classList.remove("is-loading");
+    button.addEventListener("click", function() {
+      button.classList.add("is-loading");
+    });
+  });
+
   // See above, just for the custom project order dropdown
   document.querySelectorAll(".project-order-dropdown .dropdown-content a").forEach(function(button) {
     document.querySelectorAll(".project-order-dropdown button").forEach(function(dropdown) {

--- a/app/assets/stylesheets/components/category_card.sass
+++ b/app/assets/stylesheets/components/category_card.sass
@@ -22,6 +22,10 @@
     width: auto
     display: inline-block
     margin: 10px
+    &:first-child
+      margin-left: 0
+    &:last-child
+      margin-right: 0
   .card-content
     flex: 1
   footer

--- a/app/assets/stylesheets/components/project.sass
+++ b/app/assets/stylesheets/components/project.sass
@@ -43,3 +43,11 @@
 
     &:hover
       color: $primary
+
+
+.project-compact-cards
+  @extend .columns, .is-multiline
+  .item
+    @extend .column, .is-full, .is-half-tablet, .is-flex
+    .project
+      width: 100%

--- a/app/assets/stylesheets/components/project.sass
+++ b/app/assets/stylesheets/components/project.sass
@@ -18,9 +18,6 @@
     align-self: flex-end
     margin-bottom: 0
 
-  &.compact
-    .metric
-      width: 33%
 
   .metric
     @extend .column, .is-3-tablet, .is-6-mobile
@@ -36,6 +33,10 @@
       font-weight: bold
       a
         color: $grey-darker
+
+  &.compact
+    .metric
+      @extend .is-half, .is-one-third-desktop
 
 .project-links
   a.button

--- a/app/assets/stylesheets/components/project.sass
+++ b/app/assets/stylesheets/components/project.sass
@@ -48,6 +48,18 @@
 .project-compact-cards
   @extend .columns, .is-multiline
   .item
-    @extend .column, .is-full, .is-half-tablet, .is-flex
+    @extend .column, .is-full, .is-half-tablet
+    // When displayed next to each other, the wrapping box should
+    // stretch to equal height to its row sibling
+    display: flex
     .project
       width: 100%
+      // When displayed in a row next to each other the description
+      // row should stretch to the full height so metrics in equal-
+      // height siblings are bottom-aligned
+      display: flex
+      flex-direction: column
+      align-items: stretch
+      align-content: stretch
+      .stretch
+        flex: 1

--- a/app/assets/stylesheets/components/project.sass
+++ b/app/assets/stylesheets/components/project.sass
@@ -18,6 +18,10 @@
     align-self: flex-end
     margin-bottom: 0
 
+  &.compact
+    .metric
+      width: 33%
+
   .metric
     @extend .column, .is-3-tablet, .is-6-mobile
     // Align content to bottom

--- a/app/assets/stylesheets/components/project.sass
+++ b/app/assets/stylesheets/components/project.sass
@@ -29,6 +29,7 @@
         color: $black-ter
 
     .heading
+      font-weight: bold
       a
         color: $grey-darker
 

--- a/app/assets/stylesheets/components/project_comparison.sass
+++ b/app/assets/stylesheets/components/project_comparison.sass
@@ -1,5 +1,7 @@
 .project-comparison
   overflow: auto
+  table
+    @extend .table, .is-fullwidth
   .heading
     @extend .is-size-7
     white-space: nowrap
@@ -11,9 +13,28 @@
   tbody
     td
       @extend .has-text-right
-
-    td
       font-weight: bold
+
+    th.sticky
+      position: sticky
+      left: 0
+      // Black magic... https://stackoverflow.com/a/45042852
+      &:after
+        content: ""
+        position: absolute
+        right: 0
+        top: 0
+        bottom: 0
+        border-right: 1px solid #dbdbdb
+
+    // Bulma sets the striped background on the tr by default,
+    // which conflicts with the sticky project cells column on the left
+    tr
+      td, th
+        background: white
+    tr:nth-child(even)
+      td, th
+        background: #fafafa
 
   tbody td, thead th
     a

--- a/app/assets/stylesheets/components/project_comparison.sass
+++ b/app/assets/stylesheets/components/project_comparison.sass
@@ -14,6 +14,7 @@
     td
       @extend .has-text-right
       font-weight: bold
+      white-space: nowrap
 
     th.sticky
       position: sticky

--- a/app/assets/stylesheets/components/project_comparison.sass
+++ b/app/assets/stylesheets/components/project_comparison.sass
@@ -1,0 +1,20 @@
+.project-comparison
+  overflow: auto
+  .heading
+    @extend .is-size-7
+    white-space: nowrap
+
+  thead
+    th
+      @extend .has-text-right
+
+  tbody
+    td
+      @extend .has-text-right
+
+    td
+      font-weight: bold
+
+  tbody td, thead th
+    a
+      color: $dark

--- a/app/assets/stylesheets/components/project_display_picker.sass
+++ b/app/assets/stylesheets/components/project_display_picker.sass
@@ -1,0 +1,4 @@
+.project-display-picker
+  @extend .field, .has-addons
+  a
+    @extend .button

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -7,16 +7,16 @@ class CategoriesController < ApplicationController
 
   def show
     @category = Category.find_for_show! params[:id], order: current_order
-    @display_mode = DisplayMode.new params[:display]
+    @display_mode = display_mode
     redirect_to @category if @category.permalink != params[:id]
   end
 
   private
 
   def display_mode
-    @display_mode ||= DisplayMode.new params[:display]
+    default = browser.device.mobile? ? "compact" : "full"
+    DisplayMode.new params[:display], default: default
   end
-  helper_method :display_mode
 
   def current_order
     @current_order ||= Project::Order.new order: params[:order]

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -7,10 +7,16 @@ class CategoriesController < ApplicationController
 
   def show
     @category = Category.find_for_show! params[:id], order: current_order
+    @display_mode = DisplayMode.new params[:display]
     redirect_to @category if @category.permalink != params[:id]
   end
 
   private
+
+  def display_mode
+    @display_mode ||= DisplayMode.new params[:display]
+  end
+  helper_method :display_mode
 
   def current_order
     @current_order ||= Project::Order.new order: params[:order]

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -5,13 +5,18 @@ class SearchesController < ApplicationController
     @query = params[:q].presence
     return unless @query
 
-    @search = Search.new(@query, order: current_order, show_forks: show_forks?)
-    @projects = @search.projects.page(params[:page])
+    perform_search
 
     redirect_to_search_with_forks_included if should_redirect_to_included_forks?
   end
 
   private
+
+  def perform_search
+    @search = Search.new @query, order: current_order, show_forks: show_forks?
+    @projects = @search.projects.page params[:page]
+    @display_mode = DisplayMode.new params[:display], default: "compact"
+  end
 
   # If a user searches for some query but that search does not
   # yield any project results we automatically redirect to the

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -70,6 +70,30 @@ module ApplicationHelper
     ).render(text).html_safe # rubocop:disable Rails/OutputSafety
   end
 
+  #
+  # Creates a link to the current page respecting all display mode & search query
+  # url arguments available in project listings (mode, order, search query, bugfix forks)
+  #
+  # This logic depends on too much implicit state by gathering bits & pieces
+  # from various assumed assigned variables, maybe extraction to some wrapping
+  # object might make sense...
+  #
+  def link_with_preserved_display_settings(**args)
+    addressable = Addressable::URI.new.tap do |uri|
+      uri.query_values = default_display_settings.merge(args).compact
+    end
+    "#{request.path}?#{addressable.query}"
+  end
+
+  def default_display_settings
+    {
+      order:      try(:current_order)&.ordered_by,
+      q:          @search&.query,
+      show_forks: @search&.show_forks,
+      display:    @display_mode&.current,
+    }
+  end
+
   # why
   # https://rails.lighthouseapp.com/projects/8994/tickets/4334-to_param-and-resource_path-escapes-forward-slashes
   # https://github.com/rails/rails/issues/16058

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,21 +13,21 @@ module ApplicationHelper
   end
 
   # This should be refactored...
-  # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   def pretty_metric_value(value)
     if value.is_a?(Float) || value.is_a?(BigDecimal)
       number_with_delimiter(value.floor) + "%"
     elsif value.is_a? Integer
       number_with_delimiter value
     elsif value.is_a?(Date) || value.is_a?(Time)
-      content_tag "time", "#{time_ago_in_words(value)} ago", datetime: value.iso8601, title: l(value)
+      l value.to_date
     elsif value.is_a? Array
       value.to_sentence
     else
       value
     end
   end
-  # rubocop:enable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  # rubocop:enable Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
   #
   # A little utility method for displaying project rankings like most downloaded gems

--- a/app/helpers/component_helpers.rb
+++ b/app/helpers/component_helpers.rb
@@ -59,6 +59,10 @@ module ComponentHelpers
     render "components/project_order_dropdown", order: order
   end
 
+  def project_comparison(projects)
+    render "components/project_comparison", projects: projects
+  end
+
   def section_heading(title, description: nil, &block)
     render "components/section_heading", title: title, description: description, &block
   end

--- a/app/helpers/component_helpers.rb
+++ b/app/helpers/component_helpers.rb
@@ -14,16 +14,16 @@ module ComponentHelpers
     render "components/category_card", locals
   end
 
-  def render_project(project, show_categories: false)
-    render "components/project", project: project, show_categories: show_categories
+  def render_project(project, show_categories: false, compact: false)
+    render "components/project", project: project, show_categories: show_categories, compact: compact
   end
 
-  def project_links(project)
-    render "components/project/links", project: project
+  def project_links(project, compact: false)
+    render "components/project/links", project: project, compact: compact
   end
 
-  def project_metrics(project, expanded_view: false)
-    render "components/project/metrics", project: project, expanded_view: expanded_view
+  def project_metrics(project, expanded_view: false, compact: false)
+    render "components/project/metrics", project: project, expanded_view: expanded_view, compact: compact
   end
 
   def metrics_row(project, *metrics)

--- a/app/helpers/component_helpers.rb
+++ b/app/helpers/component_helpers.rb
@@ -67,6 +67,10 @@ module ComponentHelpers
     render "components/section_heading", title: title, description: description, &block
   end
 
+  def project_display_picker
+    render "components/project_display_picker"
+  end
+
   def line_chart(data, scale: "logarithmic")
     render "components/line_chart",
            keys:   data.keys,

--- a/app/helpers/component_helpers.rb
+++ b/app/helpers/component_helpers.rb
@@ -67,8 +67,8 @@ module ComponentHelpers
     render "components/section_heading", title: title, description: description, &block
   end
 
-  def project_display_picker
-    render "components/project_display_picker"
+  def project_display_picker(display_mode)
+    render "components/project_display_picker", display_mode: display_mode
   end
 
   def line_chart(data, scale: "logarithmic")

--- a/app/models/display_mode.rb
+++ b/app/models/display_mode.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+#
+# A little utility class for picking a display mode based on given param,
+# falling back to a customizible default
+#
+class DisplayMode
+  attr_accessor :requested, :default, :available
+  private :requested=, :default=, :available=
+
+  def initialize(requested = nil, default: "full")
+    self.requested = requested.to_s
+    self.default = default.to_s
+    self.available = %w[full compact table]
+  end
+
+  def current
+    return requested if available.include? requested
+
+    available.find { |mode| mode == default } || available.first
+  end
+end

--- a/app/views/application/_search_form.html.slim
+++ b/app/views/application/_search_form.html.slim
@@ -1,4 +1,7 @@
 = form_tag search_path, method: :get, class: "search-form" do
+  - if @display_mode
+    input type="hidden" name="display" value=@display_mode.current
+
   .field.has-addons.has-addons-centered
     .control.is-expanded
       input.input placeholder="Search for libraries" type="text" name="q" value=@query

--- a/app/views/categories/show.html.slim
+++ b/app/views/categories/show.html.slim
@@ -20,14 +20,14 @@
       = bar_chart @category.projects.first(10).map {|p| [p.permalink, p.score]}.to_h, small: true
 
 section.section: .container
-  .level.is-mobile
+  .level
     .level-left
     .level-right
-      .level-item= project_display_picker display_mode
+      .level-item= project_display_picker @display_mode
       .level-item= project_order_dropdown current_order
 
   .columns: .column.projects
-    - if display_mode.current == "table"
+    - if @display_mode.current == "table"
       = project_comparison @category.projects
     - else
       - @category.projects.each do |project|

--- a/app/views/categories/show.html.slim
+++ b/app/views/categories/show.html.slim
@@ -26,9 +26,4 @@ section.section: .container
       .level-item= project_display_picker @display_mode
       .level-item= project_order_dropdown current_order
 
-  .columns: .column.projects
-    - if @display_mode.current == "table"
-      = project_comparison @category.projects
-    - else
-      - @category.projects.each do |project|
-        = render_project project
+  = render "projects/listing", projects: @category.projects, show_categories: false, display_mode: @display_mode

--- a/app/views/categories/show.html.slim
+++ b/app/views/categories/show.html.slim
@@ -22,8 +22,13 @@
 section.section: .container
   .level.is-mobile
     .level-left
-    .level-right: .level-item= project_order_dropdown current_order
+    .level-right
+      .level-item= project_display_picker display_mode
+      .level-item= project_order_dropdown current_order
 
   .columns: .column.projects
-    - @category.projects.each do |project|
-      = render_project project
+    - if display_mode.current == "table"
+      = project_comparison @category.projects
+    - else
+      - @category.projects.each do |project|
+        = render_project project

--- a/app/views/components/_project.html.slim
+++ b/app/views/components/_project.html.slim
@@ -28,7 +28,7 @@
   .columns: .links.column
     = project_links project, compact: compact
 
-  .columns: .description.column
+  .columns.stretch: .description.column
     - if local_assigns[:compact]
       = truncate project.description, length: 300
     - else

--- a/app/views/components/_project.html.slim
+++ b/app/views/components/_project.html.slim
@@ -36,8 +36,7 @@
 
 
   - if local_assigns[:compact]
-    .metrics.compact= metrics_row project, :rubygem_downloads, :github_repo_stargazers_count, :rubygem_current_version
-    .metrics.compact= metrics_row project, :rubygem_releases_count, :rubygem_first_release_on, :rubygem_latest_release_on
+    .metrics.compact= metrics_row project, :rubygem_downloads, :github_repo_stargazers_count, :rubygem_current_version, :rubygem_releases_count, :rubygem_first_release_on, :rubygem_latest_release_on
 
     .columns: .column.has-text-right
       a.button.is-outlined href="/projects/#{project.permalink}"

--- a/app/views/components/_project.html.slim
+++ b/app/views/components/_project.html.slim
@@ -25,8 +25,23 @@
         = category_card category, compact: true, inline: true
 
   .columns: .links.column
-    = project_links project
+    = project_links project, compact: compact
 
-  .columns: .description.column= project.description
+  .columns: .description.column
+    - if local_assigns[:compact]
+      = truncate project.description, length: 300
+    - else
+      = project.description
 
-  = project_metrics project
+
+  - if local_assigns[:compact]
+    .metrics.compact= metrics_row project, :rubygem_downloads, :github_repo_stargazers_count, :rubygem_current_version
+    .metrics.compact= metrics_row project, :rubygem_releases_count, :rubygem_first_release_on, :rubygem_latest_release_on
+
+    .columns: .column.has-text-right
+      a.button.is-outlined href="/projects/#{project.permalink}"
+        span.icon: i.fa.fa-plus
+        span Show more project details
+
+  - else
+    = project_metrics project, compact: compact

--- a/app/views/components/_project.html.slim
+++ b/app/views/components/_project.html.slim
@@ -8,7 +8,7 @@
             = project.permalink
 
     .level-right
-      - if local_assigns[:show_categories] and project.categories.any?
+      - if show_categories and project.categories.any? and not compact
         .level-item.categories.is-hidden-touch
           - project.categories.each do |category|
             = category_card category, compact: true, inline: true
@@ -17,12 +17,13 @@
           i.fa class=metric_icon(:score)
         span= project.score
 
-  .columns: .column= project_health_tags project
+  - if show_categories and project.categories.any?
+    .columns class=(compact ? "" : "is-hidden-desktop")
+      .column
+        - project.categories.each do |category|
+          = category_card category, compact: true, inline: true
 
-  - if local_assigns[:show_categories] and project.categories.any?
-    .columns.is-hidden-desktop: .column
-      - project.categories.each do |category|
-        = category_card category, compact: true, inline: true
+  .columns: .column= project_health_tags project
 
   .columns: .links.column
     = project_links project, compact: compact

--- a/app/views/components/_project_comparison.html.slim
+++ b/app/views/components/_project_comparison.html.slim
@@ -30,13 +30,18 @@
               a href=project.github_repo_url
                 span.icon: i.fa.fa-github
 
+          // This should be less messy...
           - metrics.each do |key|
             - docs_page = File.join("docs", "metrics", key.to_s)
+            - value = project.public_send key
+            - better = (key == :rubygem_first_released_on ? :min : :max)
             td
+              - if value == projects.map {|p| p.public_send(key) }.compact.public_send(better)
+                span.icon: i.fa.fa-star
               = link_to_docs_if_exists docs_page do
                 // The helper prints decimals as percentages by default,
                 // this is the ugly workaround...
                 - if key == :score
-                  = "%.2f" % project.score
+                  = "%.2f" % value
                 - else
-                  = pretty_metric_value project.public_send(key)
+                  = pretty_metric_value value

--- a/app/views/components/_project_comparison.html.slim
+++ b/app/views/components/_project_comparison.html.slim
@@ -1,0 +1,25 @@
+.project-comparison
+  - metrics = %i[score rubygem_downloads github_repo_stargazers_count github_repo_forks_count rubygem_first_release_on rubygem_latest_release_on rubygem_reverse_dependencies_count]
+  table.table.is-striped.is-hoverable.is-fullwidth
+    thead
+      th
+      - metrics.each do |key|
+        th: .heading
+          - docs_page = File.join("docs", "metrics", key.to_s)
+
+          = link_to_docs_if_exists docs_page do
+            span.icon
+              i.fa class=metric_icon(key)
+            span= metric_label key
+
+    tbody
+      - projects.each do |project|
+        tr
+          th
+            a href="/projects/#{project.permalink}"= project.permalink
+
+          - metrics.each do |key|
+            - docs_page = File.join("docs", "metrics", key.to_s)
+            td
+              = link_to_docs_if_exists docs_page do
+                = pretty_metric_value project.public_send(key)

--- a/app/views/components/_project_comparison.html.slim
+++ b/app/views/components/_project_comparison.html.slim
@@ -41,7 +41,7 @@
               = link_to_docs_if_exists docs_page do
                 // The helper prints decimals as percentages by default,
                 // this is the ugly workaround...
-                - if key == :score
+                - if key == :score and value.present?
                   = "%.2f" % value
                 - else
                   = pretty_metric_value value

--- a/app/views/components/_project_comparison.html.slim
+++ b/app/views/components/_project_comparison.html.slim
@@ -3,6 +3,8 @@
   table.table.is-striped.is-hoverable.is-fullwidth
     thead
       th
+      th
+      th
       - metrics.each do |key|
         th: .heading
           - docs_page = File.join("docs", "metrics", key.to_s)
@@ -15,11 +17,26 @@
     tbody
       - projects.each do |project|
         tr
-          th
+          th.sticky
             a href="/projects/#{project.permalink}"= project.permalink
+
+          td
+            - if project.rubygem_url
+              a href=project.rubygem_url
+                span.icon: i.fa.fa-diamond
+
+          td
+            - if project.github_repo_url
+              a href=project.github_repo_url
+                span.icon: i.fa.fa-github
 
           - metrics.each do |key|
             - docs_page = File.join("docs", "metrics", key.to_s)
             td
               = link_to_docs_if_exists docs_page do
-                = pretty_metric_value project.public_send(key)
+                // The helper prints decimals as percentages by default,
+                // this is the ugly workaround...
+                - if key == :score
+                  = "%.2f" % project.score
+                - else
+                  = pretty_metric_value project.public_send(key)

--- a/app/views/components/_project_display_picker.html.slim
+++ b/app/views/components/_project_display_picker.html.slim
@@ -1,7 +1,7 @@
 .project-display-picker
   - display_mode.available.each do |mode|
     p.control
-      a.button class=(display_mode.current == mode ? "is-active" : "") href="#{request.path}?display=#{mode}"
+      a.button class=(display_mode.current == mode ? "is-active" : "") href=link_with_preserved_display_settings(display: mode)
         span.icon.is-small
           - if mode == "table"
             i.fa.fa-table

--- a/app/views/components/_project_display_picker.html.slim
+++ b/app/views/components/_project_display_picker.html.slim
@@ -1,0 +1,16 @@
+.project-display-picker
+  p.control
+    a.button.is-active
+      span.icon.is-small
+        i.fa.fa-square
+      span Detailed
+  p.control
+    a.button
+      span.icon.is-small
+        i.fa.fa-th-large
+      span Compact
+  p.control
+    a.button
+      span.icon.is-small
+        i.fa.fa-table
+      span Table

--- a/app/views/components/_project_display_picker.html.slim
+++ b/app/views/components/_project_display_picker.html.slim
@@ -1,7 +1,7 @@
 .project-display-picker
   - display_mode.available.each do |mode|
     p.control
-      a.button class=(display_mode.current == mode ? "is-active" : "")
+      a.button class=(display_mode.current == mode ? "is-active" : "") href="#{request.path}?display=#{mode}"
         span.icon.is-small
           - if mode == "table"
             i.fa.fa-table

--- a/app/views/components/_project_display_picker.html.slim
+++ b/app/views/components/_project_display_picker.html.slim
@@ -1,16 +1,12 @@
 .project-display-picker
-  p.control
-    a.button.is-active
-      span.icon.is-small
-        i.fa.fa-square
-      span Detailed
-  p.control
-    a.button
-      span.icon.is-small
-        i.fa.fa-th-large
-      span Compact
-  p.control
-    a.button
-      span.icon.is-small
-        i.fa.fa-table
-      span Table
+  - display_mode.available.each do |mode|
+    p.control
+      a.button class=(display_mode.current == mode ? "is-active" : "")
+        span.icon.is-small
+          - if mode == "table"
+            i.fa.fa-table
+          - elsif mode == "compact"
+            i.fa.fa-th-large
+          - else
+            i.fa.fa-square
+        span= mode.humanize

--- a/app/views/components/_project_order_dropdown.html.slim
+++ b/app/views/components/_project_order_dropdown.html.slim
@@ -21,6 +21,6 @@
               strong= t(:label, scope: "labels.#{group}")
 
         - directions.map(&:key).each do |direction|
-          a href="#{request.path}?order=#{direction}&q=#{@search&.query}&show_forks=#{@search&.show_forks}" class=(order.is?(direction) ? "is-active" : "")
+          a href="#{request.path}?order=#{direction}&q=#{@search&.query}&show_forks=#{@search&.show_forks}&display={display_mode.current}" class=(order.is?(direction) ? "is-active" : "")
             span.icon: i.fa class=metric_icon(direction)
             = metric_label direction

--- a/app/views/components/_project_order_dropdown.html.slim
+++ b/app/views/components/_project_order_dropdown.html.slim
@@ -21,6 +21,6 @@
               strong= t(:label, scope: "labels.#{group}")
 
         - directions.map(&:key).each do |direction|
-          a href="#{request.path}?order=#{direction}&q=#{@search&.query}&show_forks=#{@search&.show_forks}&display={display_mode.current}" class=(order.is?(direction) ? "is-active" : "")
+          a href=link_with_preserved_display_settings(order: direction) class=(order.is?(direction) ? "is-active" : "")
             span.icon: i.fa class=metric_icon(direction)
             = metric_label direction

--- a/app/views/components/project/_links.html.slim
+++ b/app/views/components/project/_links.html.slim
@@ -2,9 +2,11 @@
   = project_link project.rubygem_name, project.rubygem_url, icon: :diamond
   = project_link project.github_repo_path, project.github_repo_url, icon: :github
   = project_link "Homepage", project.homepage_url, icon: :home
-  = project_link "Documentation", project.documentation_url, icon: :book
-  = project_link "Source Code", project.source_code_url, icon: "code-fork"
-  = project_link "Bug Tracker", project.bug_tracker_url, icon: :bug
-  = project_link "Changelog", project.changelog_url, icon: "file-text-o"
-  = project_link "Mailing List", project.mailing_list_url, icon: :envelope
-  = project_link "Wiki", project.wiki_url, icon: "pencil-square"
+
+  - unless local_assigns[:compact]
+    = project_link "Documentation", project.documentation_url, icon: :book
+    = project_link "Source Code", project.source_code_url, icon: "code-fork"
+    = project_link "Bug Tracker", project.bug_tracker_url, icon: :bug
+    = project_link "Changelog", project.changelog_url, icon: "file-text-o"
+    = project_link "Mailing List", project.mailing_list_url, icon: :envelope
+    = project_link "Wiki", project.wiki_url, icon: "pencil-square"

--- a/app/views/components/project/_metrics.html.slim
+++ b/app/views/components/project/_metrics.html.slim
@@ -54,4 +54,4 @@
   .columns: .column.has-text-right
     a.button.is-outlined href="/projects/#{project.permalink}"
       span.icon: i.fa.fa-plus
-      | &nbsp;Show more project details
+      span Show more project details

--- a/app/views/pages/components/project.html.slim
+++ b/app/views/pages/components/project.html.slim
@@ -46,6 +46,6 @@
 
 
 = component_example "Compact card" do
-  .columns.is-multiline.is-flex
+  .project-compact-cards
     - 4.times do
-      .column.is-half= render_project full.sample, compact: true
+      .column= render_project full.sample, compact: true

--- a/app/views/pages/components/project.html.slim
+++ b/app/views/pages/components/project.html.slim
@@ -43,3 +43,9 @@
       markdown:
         Hides unavailable metrics automatically
     = project_metrics github
+
+
+= component_example "Compact card" do
+  .columns.is-multiline.is-flex
+    - 4.times do
+      .column.is-half= render_project full.sample, compact: true

--- a/app/views/pages/components/project_comparison.html.slim
+++ b/app/views/pages/components/project_comparison.html.slim
@@ -1,0 +1,9 @@
+.hero
+  section.section: .container
+    p.heading= link_to "Ruby Toolbox UI Components Styleguide", "/pages/components"
+    h2= current_page.split("/").last.humanize
+
+- projects = Project.for_display.order(score: :desc).limit(100).sample(15)
+
+= component_example "Project Comparison" do
+  = project_comparison projects

--- a/app/views/pages/components/project_display_picker.html.slim
+++ b/app/views/pages/components/project_display_picker.html.slim
@@ -4,4 +4,6 @@
     h2= current_page.split("/").last.humanize
 
 = component_example "Project Display Picker" do
-  = project_display_picker
+  = project_display_picker DisplayMode.new
+  = project_display_picker DisplayMode.new(:compact)
+  = project_display_picker DisplayMode.new(default: "table")

--- a/app/views/pages/components/project_display_picker.html.slim
+++ b/app/views/pages/components/project_display_picker.html.slim
@@ -1,0 +1,7 @@
+.hero
+  section.section: .container
+    p.heading= link_to "Ruby Toolbox UI Components Styleguide", "/pages/components"
+    h2= current_page.split("/").last.humanize
+
+= component_example "Project Display Picker" do
+  = project_display_picker

--- a/app/views/projects/_listing.html.slim
+++ b/app/views/projects/_listing.html.slim
@@ -1,10 +1,11 @@
 .columns: .column.projects
   - if display_mode.current == "table"
     = project_comparison projects
+
   - elsif display_mode.current == "compact"
-    .columns.is-multiline.is-flex
+    .columns.is-multiline
       - projects.each do |project|
-        .column.is-half= render_project project, show_categories: show_categories, compact: true
+        .column.is-full.is-half-tablet= render_project project, show_categories: show_categories, compact: true
   - else
     - projects.each do |project|
       = render_project project, show_categories: show_categories

--- a/app/views/projects/_listing.html.slim
+++ b/app/views/projects/_listing.html.slim
@@ -2,8 +2,9 @@
   - if display_mode.current == "table"
     = project_comparison projects
   - elsif display_mode.current == "compact"
-    - projects.each do |project|
-      = render_project project, show_categories: show_categories
+    .columns.is-multiline.is-flex
+      - projects.each do |project|
+        .column.is-half= render_project project, show_categories: show_categories, compact: true
   - else
     - projects.each do |project|
       = render_project project, show_categories: show_categories

--- a/app/views/projects/_listing.html.slim
+++ b/app/views/projects/_listing.html.slim
@@ -3,9 +3,9 @@
     = project_comparison projects
 
   - elsif display_mode.current == "compact"
-    .columns.is-multiline
+    .project-compact-cards
       - projects.each do |project|
-        .column.is-full.is-half-tablet= render_project project, show_categories: show_categories, compact: true
+        .item= render_project project, show_categories: show_categories, compact: true
   - else
     - projects.each do |project|
       = render_project project, show_categories: show_categories

--- a/app/views/projects/_listing.html.slim
+++ b/app/views/projects/_listing.html.slim
@@ -1,0 +1,9 @@
+.columns: .column.projects
+  - if display_mode.current == "table"
+    = project_comparison projects
+  - elsif display_mode.current == "compact"
+    - projects.each do |project|
+      = render_project project, show_categories: show_categories
+  - else
+    - projects.each do |project|
+      = render_project project, show_categories: show_categories

--- a/app/views/searches/show.html.slim
+++ b/app/views/searches/show.html.slim
@@ -37,6 +37,7 @@
         .level-left: .level-item
           h2.subtitle.is-4 Projects
         .level-right
+          .level-item= project_display_picker @display_mode
           .level-item
             .field.has-addons
               .control
@@ -60,8 +61,7 @@
       - if @projects.any?
         .columns: .column= paginate @projects
 
-        - @projects.each do |project|
-          = render_project project, show_categories: true
+        = render "projects/listing", projects: @projects, show_categories: true, display_mode: @display_mode
 
         .columns: .column= paginate @projects
 

--- a/app/views/searches/show.html.slim
+++ b/app/views/searches/show.html.slim
@@ -42,12 +42,12 @@
             .field.has-addons
               .control
                 - if @search.show_forks
-                  a.button.bugfix-forks-toggle href=search_path(q: @search.query, order: current_order.ordered_by, show_forks: false)
+                  a.button.bugfix-forks-toggle href=link_with_preserved_display_settings(show_forks: "false")
                     span.icon: i.fa.fa-check-square
                     span Bugfix forks are <strong>shown</strong>
 
                 - else
-                  a.button.bugfix-forks-toggle href=search_path(q: @search.query, order: current_order.ordered_by, show_forks: true)
+                  a.button.bugfix-forks-toggle href=link_with_preserved_display_settings(show_forks: "true")
                     span.icon: i.fa.fa-square-o
                     span Bugfix forks are <strong>hidden</strong>
 

--- a/spec/controllers/categories_controller_spec.rb
+++ b/spec/controllers/categories_controller_spec.rb
@@ -31,7 +31,9 @@ RSpec.describe CategoriesController, type: :controller do
     end
 
     describe "for known category" do
-      let(:do_request) { get :show, params: { id: category.permalink } }
+      def do_request(display: nil)
+        get :show, params: { id: category.permalink, display: display }
+      end
 
       let(:category) do
         Category.create! permalink:      "category",
@@ -69,25 +71,7 @@ RSpec.describe CategoriesController, type: :controller do
         end
       end
 
-      describe "display_mode" do
-        it "assigns 'full' by default" do
-          do_request
-          expect(assigns(:display_mode).current).to be == "full"
-        end
-
-        it "assigns 'compact' for mobile device" do
-          request.headers["User-Agent"] = "Android mobile"
-          do_request
-          expect(assigns(:display_mode).current).to be == "compact"
-        end
-
-        DisplayMode.new.available.each do |mode|
-          it "assigns #{mode.inspect} when requested explicitly" do
-            get :show, params: { id: category.id, display: mode }
-            expect(assigns(:display_mode).current).to be == mode
-          end
-        end
-      end
+      it_behaves_like "pickable project display listing", default: "full"
     end
   end
 end

--- a/spec/controllers/categories_controller_spec.rb
+++ b/spec/controllers/categories_controller_spec.rb
@@ -68,6 +68,26 @@ RSpec.describe CategoriesController, type: :controller do
           end
         end
       end
+
+      describe "display_mode" do
+        it "assigns 'full' by default" do
+          do_request
+          expect(assigns(:display_mode).current).to be == "full"
+        end
+
+        it "assigns 'compact' for mobile device" do
+          request.headers["User-Agent"] = "Android mobile"
+          do_request
+          expect(assigns(:display_mode).current).to be == "compact"
+        end
+
+        DisplayMode.new.available.each do |mode|
+          it "assigns #{mode.inspect} when requested explicitly" do
+            get :show, params: { id: category.id, display: mode }
+            expect(assigns(:display_mode).current).to be == mode
+          end
+        end
+      end
     end
   end
 end

--- a/spec/controllers/searches_controller_spec.rb
+++ b/spec/controllers/searches_controller_spec.rb
@@ -4,9 +4,11 @@ require "rails_helper"
 
 RSpec.describe SearchesController, type: :controller do
   describe "GET #show" do
-    def do_request(query: nil, order: nil, show_forks: nil)
-      get :show, params: { q: query, order: order, show_forks: show_forks }
+    def do_request(query: "foobar", order: nil, show_forks: nil, display: nil)
+      get :show, params: { q: query, order: order, show_forks: show_forks, display: display }
     end
+
+    it_behaves_like "pickable project display listing", default: "compact"
 
     it "returns http success" do
       Factories.project "foobar"

--- a/spec/features/category_display_spec.rb
+++ b/spec/features/category_display_spec.rb
@@ -22,6 +22,11 @@ RSpec.describe "Categories Display", type: :feature, js: true do
       click_on "Table"
     end
     expect(page).to have_selector(".project-comparison", count: 1)
+
+    within ".project-display-picker" do
+      click_on "Compact"
+    end
+    expect(page).to have_selector(".project-compact-cards", count: 1)
   end
 
   it "can apply a custom order to the list of projects" do

--- a/spec/features/category_display_spec.rb
+++ b/spec/features/category_display_spec.rb
@@ -16,17 +16,11 @@ RSpec.describe "Categories Display", type: :feature, js: true do
     within ".projects" do
       expect(page).to have_text "acme"
     end
+
     expect(page).to have_selector(".project", count: 3)
-
-    within ".project-display-picker" do
-      click_on "Table"
-    end
-    expect(page).to have_selector(".project-comparison", count: 1)
-
-    within ".project-display-picker" do
-      click_on "Compact"
-    end
-    expect(page).to have_selector(".project-compact-cards", count: 1)
+    expect_display_mode "Full"
+    change_display_mode "Table"
+    change_display_mode "Compact"
   end
 
   it "can apply a custom order to the list of projects" do
@@ -40,23 +34,12 @@ RSpec.describe "Categories Display", type: :feature, js: true do
     end
 
     %w[Downloads Stars Forks].each do |button_label|
-      within ".project-order-dropdown" do
-        page.find("button").hover
-        click_on button_label
-        expect(page).to have_text "Order by #{button_label}"
-      end
+      order_by button_label
       expect(listed_project_names).to be == %w[widget acme toolkit]
       expect(page).not_to have_selector(".hero canvas.bar-chart")
     end
 
-    within ".project-order-dropdown" do
-      page.find("button").hover
-      click_on "First release"
-    end
-
-    within ".project-order-dropdown" do
-      expect(page).to have_text "Order by First release"
-    end
+    order_by "First release"
     expect(listed_project_names).to be == %w[toolkit acme widget]
   end
 

--- a/spec/features/category_display_spec.rb
+++ b/spec/features/category_display_spec.rb
@@ -16,6 +16,12 @@ RSpec.describe "Categories Display", type: :feature, js: true do
     within ".projects" do
       expect(page).to have_text "acme"
     end
+    expect(page).to have_selector(".project", count: 3)
+
+    within ".project-display-picker" do
+      click_on "Table"
+    end
+    expect(page).to have_selector(".project-comparison", count: 1)
   end
 
   it "can apply a custom order to the list of projects" do

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -21,6 +21,15 @@ RSpec.describe "Search", type: :feature, js: true do
 
     expect(listed_project_names).to be == ["more widgets", "widgets"]
 
+    within(".project-display-picker .is-active") do
+      expect(page).to have_text("Compact")
+    end
+
+    within ".project-display-picker" do
+      click_on "Table"
+    end
+    expect(page).to have_selector(".project-comparison", count: 1)
+
     within ".category-card" do
       expect(page).to have_text "Widgets"
       expect(page).not_to have_text "No matching categories were found"

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -21,14 +21,9 @@ RSpec.describe "Search", type: :feature, js: true do
 
     expect(listed_project_names).to be == ["more widgets", "widgets"]
 
-    within(".project-display-picker .is-active") do
-      expect(page).to have_text("Compact")
-    end
-
-    within ".project-display-picker" do
-      click_on "Table"
-    end
-    expect(page).to have_selector(".project-comparison", count: 1)
+    expect_display_mode "Compact"
+    change_display_mode "Table"
+    change_display_mode "Full"
 
     within ".category-card" do
       expect(page).to have_text "Widgets"
@@ -186,14 +181,6 @@ RSpec.describe "Search", type: :feature, js: true do
     within container do
       fill_in "q", with: query
       click_button "Search"
-    end
-  end
-
-  def order_by(button_label, expect_navigation: true)
-    within ".project-order-dropdown" do
-      page.find("button").hover
-      click_on button_label
-      expect(page).to have_text "Order by #{button_label}" if expect_navigation
     end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -24,19 +24,14 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(metrics_row).to include("1,297%")
     end
 
-    it "renders dates pretty-printed" do
+    it "renders dates regularly" do
       allow(project).to receive(:rubygem_downloads).and_return(Date.new(2014, 7, 4))
-      Timecop.travel Date.new(2015, 7, 4) do
-        expect(metrics_row).to include("<time datetime=\"2014-07-04\" title=\"2014-07-04\">about 1 year ago</time>")
-      end
+      expect(metrics_row).to include("2014-07-04")
     end
 
-    it "renders times pretty-printed" do
+    it "renders times as dates" do
       allow(project).to receive(:rubygem_downloads).and_return(Time.utc(2014, 7, 4, 13, 13, 0))
-      Timecop.travel Date.new(2015, 7, 4) do
-        expected = '<time datetime="2014-07-04T13:13:00Z" title="Fri, 04 Jul 2014 13:13:00 +0000">12 months ago</time>'
-        expect(metrics_row).to include(expected)
-      end
+      expect(metrics_row).to include("2014-07-04")
     end
 
     it "renders strings as-is" do

--- a/spec/models/display_mode_spec.rb
+++ b/spec/models/display_mode_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DisplayMode, type: :model do
+  describe "#current" do
+    it "is the default when none requested" do
+      expect(DisplayMode.new.current).to be == "full"
+    end
+
+    it "is the default when nil requested" do
+      expect(DisplayMode.new(nil).current).to be == "full"
+    end
+
+    it "is the default when invalid requested" do
+      expect(DisplayMode.new("123").current).to be == "full"
+    end
+
+    it "is the requested when valid" do
+      requested = DisplayMode.new.available.sample
+      expect(DisplayMode.new(requested.to_sym).current).to be == requested
+    end
+
+    it "is the first when default is invalid" do
+      expect(DisplayMode.new(default: "lol").current).to be == DisplayMode.new.available.first
+    end
+  end
+end

--- a/spec/support/helpers/feature_spec_helpers.rb
+++ b/spec/support/helpers/feature_spec_helpers.rb
@@ -22,4 +22,31 @@ module FeatureSpecHelpers
   def active_element
     page.evaluate_script "document.activeElement"
   end
+
+  def order_by(button_label, expect_navigation: true)
+    within ".project-order-dropdown" do
+      page.find("button").hover
+      click_on button_label
+      expect(page).to have_text "Order by #{button_label}" if expect_navigation
+    end
+  end
+
+  def expect_display_mode(label) # rubocop:disable Metrics/AbcSize It's good enough :)
+    within(".project-display-picker .is-active") do
+      expect(page).to have_text(label)
+    end
+    case label.downcase.to_sym
+    when :table
+      expect(page).to have_selector(".project-comparison", count: 1)
+    when :compact
+      expect(page).to have_selector(".project-compact-cards", count: 1)
+    end
+  end
+
+  def change_display_mode(label)
+    within ".project-display-picker" do
+      click_on label
+    end
+    expect_display_mode label
+  end
 end

--- a/spec/support/shared_examples/controllers/pickable_project_display_listing_examples.rb
+++ b/spec/support/shared_examples/controllers/pickable_project_display_listing_examples.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples_for "pickable project display listing" do |default:|
+  describe "display_mode" do
+    it "assigns '#{default}' by default" do
+      do_request
+      expect(assigns(:display_mode).current).to be == default
+    end
+
+    it "assigns 'compact' for mobile device" do
+      request.headers["User-Agent"] = "Android mobile"
+      do_request
+      expect(assigns(:display_mode).current).to be == "compact"
+    end
+
+    DisplayMode.new.available.each do |mode|
+      it "assigns #{mode.inspect} when requested explicitly" do
+        do_request display: mode
+        expect(assigns(:display_mode).current).to be == mode
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds alternate display modes for project listings in categories#show and search actions:

* Full (the current, well-known one)
* Compact, similar to the current but with smaller cards. This will become the default on mobile devices for category display and for all devices in the search to allow a quicker overview
* Table (side-by-side comparison, this was an often requested feature in the community survey last november)

![alternate-views-cropped](https://user-images.githubusercontent.com/13972/52047779-0993ce80-254a-11e9-986d-b600d8c439e8.gif)


