### PR TITLE
Bring back category bar chart

### DIFF
--- a/app/helpers/component_helpers.rb
+++ b/app/helpers/component_helpers.rb
@@ -70,10 +70,11 @@ module ComponentHelpers
            scale:  scale
   end
 
-  def bar_chart(data)
+  def bar_chart(data, small: false)
     render "components/bar_chart",
            keys:   data.keys,
-           values: data.values
+           values: data.values,
+           small:  small
   end
 
   def landing_hero(title:, image:, &block)

--- a/app/views/categories/show.html.slim
+++ b/app/views/categories/show.html.slim
@@ -16,6 +16,8 @@
       - else
         em This category does not have a description yet. You can <strong><a href="#{@category.catalog_edit_url}">add one on github</a></strong>!
 
+    = bar_chart @category.projects.first(10).map {|p| [p.permalink, p.score]}.to_h, small: true
+
 section.section: .container
   .level.is-mobile
     .level-left

--- a/app/views/categories/show.html.slim
+++ b/app/views/categories/show.html.slim
@@ -16,7 +16,8 @@
       - else
         em This category does not have a description yet. You can <strong><a href="#{@category.catalog_edit_url}">add one on github</a></strong>!
 
-    = bar_chart @category.projects.first(10).map {|p| [p.permalink, p.score]}.to_h, small: true
+    - if current_order.default_direction?
+      = bar_chart @category.projects.first(10).map {|p| [p.permalink, p.score]}.to_h, small: true
 
 section.section: .container
   .level.is-mobile

--- a/app/views/components/_bar_chart.html.slim
+++ b/app/views/components/_bar_chart.html.slim
@@ -1,5 +1,5 @@
 - element = "bar-chart-#{SecureRandom.hex(8)}"
-canvas class=element width="400" height="150"
+canvas class=element width="400" height=(small ? 60 : 150)
 
 javascript:
   barChart(

--- a/app/views/components/_bar_chart.html.slim
+++ b/app/views/components/_bar_chart.html.slim
@@ -1,5 +1,5 @@
 - element = "bar-chart-#{SecureRandom.hex(8)}"
-canvas class=element width="400" height=(small ? 60 : 150)
+canvas.bar-chart class=element width="400" height=(small ? 60 : 150)
 
 javascript:
   barChart(

--- a/app/views/pages/components/bar_chart.html.slim
+++ b/app/views/pages/components/bar_chart.html.slim
@@ -6,3 +6,6 @@
 
 = component_example "A Bar Chart" do
   .chart= bar_chart 2014 => 2123, 2015 => 3501, 2016 => 2012
+
+= component_example "A small bar Chart" do
+  .chart= bar_chart({ 2014 => 2123, 2015 => 3501, 2016 => 2012 }, small: true)

--- a/spec/features/category_display_spec.rb
+++ b/spec/features/category_display_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe "Categories Display", type: :feature, js: true do
     visit "/categories/widgets"
 
     expect(listed_project_names).to be == %w[acme toolkit widget]
+    expect(page).to have_selector(".hero canvas.bar-chart")
 
     within ".project-order-dropdown" do
       expect(page).to have_text "Order by Project Score"
@@ -34,6 +35,7 @@ RSpec.describe "Categories Display", type: :feature, js: true do
         expect(page).to have_text "Order by #{button_label}"
       end
       expect(listed_project_names).to be == %w[widget acme toolkit]
+      expect(page).not_to have_selector(".hero canvas.bar-chart")
     end
 
     within ".project-order-dropdown" do


### PR DESCRIPTION
Thanks to the charts utilities introduced in #388 this was now very simple. Fixes #126. I chose to only include the 10 top-scoring projects because especially on mobile for bigger categories the graph otherwise is too constrained. When using a custom project order (via #360) the chart is hidden.

![screenshot from 2019-01-28 11-22-43](https://user-images.githubusercontent.com/13972/51830245-b45c8080-22ef-11e9-8c6c-75418f857b6a.png)



