### PR TITLE
Improve mobile display of category bar chart

### DIFF
--- a/app/assets/javascripts/charts/bar_chart.js
+++ b/app/assets/javascripts/charts/bar_chart.js
@@ -19,6 +19,8 @@ var barChart = function(selector, labels, values) {
       legend: {
         display: false
       },
+      responsive: true,
+      maintainAspectRatio: false,
       tooltips: {
         mode: "index",
         intersect: false,

--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -172,3 +172,11 @@ article.blog-post
   .search-form
     .button, .input
       @extend .is-medium
+
+// See https://www.chartjs.org/docs/latest/general/responsive.html#configuration-options
+// and https://github.com/chartjs/Chart.js/issues/2958#issuecomment-261949718
+.chart-container
+  position: relative
+  height: 350px
+  &.small
+    height: 180px

--- a/app/views/components/_bar_chart.html.slim
+++ b/app/views/components/_bar_chart.html.slim
@@ -1,5 +1,6 @@
 - element = "bar-chart-#{SecureRandom.hex(8)}"
-canvas.bar-chart class=element width="400" height=(small ? 60 : 150)
+.chart-container class=(small ? "small" : "")
+  canvas.bar-chart class=element
 
 javascript:
   barChart(


### PR DESCRIPTION
The category bar chart from #401 was too low on mobile, this makes the height flexible aspect ratio and an enclosing relative container as per chart.js docs