### PR TITLE
Fix minor UI glitch in display mode selection

### DIFF
--- a/app/views/application/_search_form.html.slim
+++ b/app/views/application/_search_form.html.slim
@@ -1,5 +1,6 @@
 = form_tag search_path, method: :get, class: "search-form" do
-  - if @display_mode
+  // Keep chosen display mode across searches, regardless of search form location within page
+  - if @display_mode and controller_name == "searches"
     input type="hidden" name="display" value=@display_mode.current
 
   .field.has-addons.has-addons-centered

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -161,6 +161,18 @@ RSpec.describe "Search", type: :feature, js: true do
     expect(page).to have_selector(".search-form .button.is-loading", count: 2)
   end
 
+  it "keeps the chosen search display mode across searches" do
+    search_for "widget"
+    change_display_mode "Table"
+    search_for "widget", visit_home_first: false
+    expect_display_mode "Table"
+
+    visit "/categories/widgets"
+    change_display_mode "Table"
+    search_for "widget", visit_home_first: false
+    expect_display_mode "Compact"
+  end
+
   private
 
   #
@@ -173,8 +185,8 @@ RSpec.describe "Search", type: :feature, js: true do
     });
   JS
 
-  def search_for(query, container: ".navbar", halt: false)
-    visit "/"
+  def search_for(query, container: ".navbar", halt: false, visit_home_first: true)
+    visit "/" if visit_home_first
 
     page.evaluate_script HALT_FORM_SUBMISSION_JS if halt
 


### PR DESCRIPTION
Followup to #398. Across searches, the chosen display mode should remain persistent, but due to the way it's implemented if you pick a different display mode in the category display, then search from the top nav it would also use that display mode. While that might also have some merit it would break the new default of using the compact display mode in search by default (by enforcing full view), and I prefer consistent and expectable behaviour here. Also adds a missing feature spec that ensures this actuall works :)