### PR TITLE
Project Comparisons

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,6 +14,7 @@
 //= require turbolinks
 //= require chart.js/dist/Chart.bundle.js
 //= require headroom.js/dist/headroom
+//= require javascript-autocomplete/auto-complete.js
 //= require_tree .
 
 document.addEventListener("turbolinks:load", function () {

--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -41,6 +41,14 @@ $navbar-item-hover-background-color: transparent
 $navbar-item-active-background-color: transparent
 $navbar-tab-hover-background-color: transparent
 $navbar-tab-active-background-color: transparent
+// Need to set these variables despite them being bulma defaults
+// so we can customize the navbar breakpoint to the
+// default bulma widescreen breakpoint before importing bulma itself
+$gap: 64px
+$widescreen: 1152px + (2 * $gap)
+// Navbar burger toggles on desktop <-> widescreen (default: tablet <-> desktop)
+// since we have too many menu items
+$navbar-breakpoint: $widescreen
 
 @import "bulma/bulma"
 @import "components/**/*"
@@ -76,8 +84,10 @@ header.main
         .wrap
           border-color: $primary
 
-    // Do not show red active border on mobile nav
     .navbar-menu.is-active
+      // Do not show box shadow, it looks funny on desktop
+      box-shadow: none
+      // Do not show red active border on mobile nav
       .navbar-item.is-active
         .wrap
           border-color: transparent
@@ -98,7 +108,7 @@ header.main
     // navbar burger and ensure it's nicely aligned
     .mobile-search
       margin-left: auto
-      @extend .is-hidden-desktop
+      @extend .is-hidden-widescreen
       height: $navbar-height
       width: $navbar-height
       .icon

--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -11,6 +11,7 @@
  * It is generally better to create a new file per style scope.
  *
  *= require_self
+ *= require javascript-autocomplete/auto-complete.css
  */
 
 @import "font-awesome"
@@ -186,3 +187,15 @@ article.blog-post
   height: 350px
   &.small
     height: 180px
+
+.autocomplete-suggestions
+  .autocomplete-suggestion
+    padding: 10px 8px
+    &.selected
+      background: $primary
+      color: white
+      b
+        color: white
+    b
+      color: black
+      font-weight: bold

--- a/app/controllers/comparisons_controller.rb
+++ b/app/controllers/comparisons_controller.rb
@@ -15,7 +15,7 @@ class ComparisonsController < ApplicationController
 
   def enforce_canonical_query
     @expected_ids = @projects.map(&:permalink).sort.join(",")
-    query_string = Rack::Utils.parse_nested_query(request.query_string).except("add").to_query
+    query_string = Rack::Utils.parse_nested_query(request.query_string).slice("display", "order").to_query
     destination = if query_string.present?
                     comparison_path(@expected_ids) + "?#{query_string}"
                   else

--- a/app/controllers/comparisons_controller.rb
+++ b/app/controllers/comparisons_controller.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class ComparisonsController < ApplicationController
+  def show
+    @projects = Project.where(permalink: requested_project_permalinks)
+                       .for_display(forks: true)
+                       .includes_associations
+                       .order(current_order.sql)
+                       .limit(50)
+    @display_mode = display_mode
+    enforce_canonical_query
+  end
+
+  private
+
+  def enforce_canonical_query
+    @expected_ids = @projects.map(&:permalink).sort.join(",")
+    redirect_to comparison_path(@expected_ids) if selection_is_unordered?
+  end
+
+  def selection_is_unordered?
+    params[:add].present? || (requested_project_permalinks.try(:join, ",").presence != @expected_ids.presence)
+  end
+
+  def requested_project_permalinks
+    (params[:id].presence || "").split(",") + [params[:add]].map { |id| id.try(:strip).presence }.compact
+  end
+
+  def display_mode
+    DisplayMode.new params[:display], default: "table"
+  end
+
+  def current_order
+    @current_order ||= Project::Order.new order: params[:order]
+  end
+  helper_method :current_order
+end

--- a/app/controllers/comparisons_controller.rb
+++ b/app/controllers/comparisons_controller.rb
@@ -15,7 +15,14 @@ class ComparisonsController < ApplicationController
 
   def enforce_canonical_query
     @expected_ids = @projects.map(&:permalink).sort.join(",")
-    redirect_to comparison_path(@expected_ids) if selection_is_unordered?
+    query_string = Rack::Utils.parse_nested_query(request.query_string).except("add").to_query
+    destination = if query_string.present?
+                    comparison_path(@expected_ids) + "?#{query_string}"
+                  else
+                    comparison_path(@expected_ids)
+                  end
+
+    redirect_to destination if selection_is_unordered?
   end
 
   def selection_is_unordered?

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -10,6 +10,10 @@ class SearchesController < ApplicationController
     redirect_to_search_with_forks_included if should_redirect_to_included_forks?
   end
 
+  def by_name
+    render json: Project.suggest(params[:q])
+  end
+
   private
 
   def perform_search

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -79,13 +79,17 @@ module ApplicationHelper
   # object might make sense...
   #
   def link_with_preserved_display_settings(**args)
-    addressable = Addressable::URI.new.tap do |uri|
-      uri.query_values = default_display_settings.merge(args).compact
-    end
-    "#{request.path}?#{addressable.query}"
+    "#{request.path}?#{current_display_settings_query_string(**args)}"
   end
 
-  def default_display_settings
+  def current_display_settings_query_string(**args)
+    addressable = Addressable::URI.new.tap do |uri|
+      uri.query_values = current_display_settings.merge(args).compact
+    end
+    addressable.query
+  end
+
+  def current_display_settings
     {
       order:      try(:current_order)&.ordered_by,
       q:          @search&.query,

--- a/app/helpers/component_helpers.rb
+++ b/app/helpers/component_helpers.rb
@@ -59,6 +59,10 @@ module ComponentHelpers
     render "components/small_health_indicator", project: project
   end
 
+  def project_details_buttons(project)
+    render "components/project/details_buttons", project: project
+  end
+
   def project_order_dropdown(order)
     render "components/project_order_dropdown", order: order
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -42,6 +42,16 @@ class Project < ApplicationRecord
       .with_score
   end
 
+  def self.suggest(name)
+    return [] if name.blank?
+
+    Project
+      .where("permalink ILIKE ?", "#{name}%")
+      .order("score DESC NULLS LAST")
+      .limit(25)
+      .pluck(:permalink)
+  end
+
   include PgSearch
   pg_search_scope :search_scope,
                   # This is unfortunately not used when using explicit tsvector columns,

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -46,7 +46,7 @@ class Project < ApplicationRecord
     return [] if name.blank?
 
     Project
-      .where("permalink ILIKE ?", "#{name}%")
+      .where("permalink ILIKE ?", "#{sanitize_sql_like(name)}%")
       .order("score DESC NULLS LAST")
       .limit(25)
       .pluck(:permalink)

--- a/app/views/comparisons/show.html.slim
+++ b/app/views/comparisons/show.html.slim
@@ -1,0 +1,38 @@
+- content_for :title, "Compare Projects"
+
+.hero
+  section.section: .container
+    h2
+      a href=comparison_path("")
+        span Compare projects
+
+    .columns: .column
+      .tags
+        - @expected_ids.split(",").each do |permalink|
+          span.tag.is-primary.is-medium
+            span= permalink
+            a.delete.is-small href=comparison_path((@expected_ids.split(",") - [permalink]).join(","))
+
+      = form_tag link_with_preserved_display_settings, method: :get, autocomplete: "off" do
+        .field.has-addons.has-addons-centered
+          .control.is-expanded
+            input.input placeholder="Type a gem name to add it to the comparison" type="text" name="add" value=""
+          .control
+            button.button type="submit"
+              span.icon: i.fa.fa-plus
+              span Add to comparison
+
+
+- if @projects.any?
+  section.section: .container
+    .level
+      .level-left
+      .level-right
+        .level-item= project_display_picker @display_mode
+        .level-item= project_order_dropdown current_order
+
+    = render "projects/listing", projects: @projects, show_categories: false, display_mode: @display_mode
+
+- else
+  article.blog-post
+    h3 About project comparisons

--- a/app/views/comparisons/show.html.slim
+++ b/app/views/comparisons/show.html.slim
@@ -31,22 +31,30 @@
               span.icon: i.fa.fa-plus
               span Add to comparison
 
+        / Our autocomplete library interferes with the enter key on the input field -
+        / it should be possible to just type a name and hit enter without interacting
+        / with the autocompletion in any way.
         javascript:
-          new autoComplete({
-            minChars: 1,
-            selector: "input.autocomplete-comparison",
-            source: function(term, callback) {
-              fetch("/search/by_name?q=" + term)
-                .then(function(response) {
-                  response.json().then(function(data) {
-                    callback(data);
+          (function() {
+            var submitComparisonForm = function() { document.querySelector("form.autocomplete-form").submit() }
+            document.querySelector("input.autocomplete-comparison").addEventListener("keydown", function(event) {
+              if (event.key === "Enter") { submitComparisonForm(); }
+            });
+
+            new autoComplete({
+              minChars: 1,
+              selector: "input.autocomplete-comparison",
+              source: function(term, callback) {
+                fetch("/search/by_name?q=" + term)
+                  .then(function(response) {
+                    response.json().then(function(data) {
+                      callback(data);
+                    });
                   });
-                });
-            },
-            onSelect: function() {
-              document.querySelector("form.autocomplete-form").submit()
-            }
-          });
+              },
+              onSelect: submitComparisonForm
+            });
+          })();
 
 
 - if @projects.any?

--- a/app/views/comparisons/show.html.slim
+++ b/app/views/comparisons/show.html.slim
@@ -5,6 +5,10 @@
     h2
       a href=comparison_path("")
         span Compare projects
+    - if @projects.empty?
+      .description
+        markdown:
+          Project comparisons enable you to view any selection of projects side by side just like they're shown on regular categories or in search results. **[You can try out an example](/compare/hanami,merb,rails,sinatra)** or start yourself by adding a library to the comparison via the input below.
 
     .columns: .column
       .tags
@@ -13,14 +17,31 @@
             span= permalink
             a.delete.is-small href=comparison_path((@expected_ids.split(",") - [permalink]).join(","))
 
-      = form_tag link_with_preserved_display_settings, method: :get, autocomplete: "off" do
+      = form_tag link_with_preserved_display_settings, method: :get, autocomplete: "off", class: "autocomplete-form" do
         .field.has-addons.has-addons-centered
           .control.is-expanded
-            input.input placeholder="Type a gem name to add it to the comparison" type="text" name="add" value=""
+            input.input.autocomplete-comparison autofocus="autofocus" placeholder="Type a project name to add it to the comparison" type="text" name="add" value=""
           .control
             button.button type="submit"
               span.icon: i.fa.fa-plus
               span Add to comparison
+
+        javascript:
+          new autoComplete({
+            minChars: 1,
+            selector: "input.autocomplete-comparison",
+            source: function(term, callback) {
+              fetch("/search/by_name?q=" + term)
+                .then(function(response) {
+                  response.json().then(function(data) {
+                    callback(data);
+                  });
+                });
+            },
+            onSelect: function() {
+              document.querySelector("form.autocomplete-form").submit()
+            }
+          });
 
 
 - if @projects.any?
@@ -32,7 +53,3 @@
         .level-item= project_order_dropdown current_order
 
     = render "projects/listing", projects: @projects, show_categories: false, display_mode: @display_mode
-
-- else
-  article.blog-post
-    h3 About project comparisons

--- a/app/views/comparisons/show.html.slim
+++ b/app/views/comparisons/show.html.slim
@@ -2,23 +2,28 @@
 
 .hero
   section.section: .container
-    h2
-      a href=comparison_path("")
-        span Compare projects
-    - if @projects.empty?
-      .description
-        markdown:
-          Project comparisons enable you to view any selection of projects side by side just like they're shown on regular categories or in search results. **[You can try out an example](/compare/hanami,merb,rails,sinatra)** or start yourself by adding a library to the comparison via the input below.
+    .columns: .column
+      h2
+        a href=comparison_path("")
+          span Compare projects
+      - if @projects.size < 2
+        .description
+          markdown:
+            Project comparisons enable you to view any selection of projects side by side just like they're shown on regular categories or in search results. **[You can try out an example](/compare/hanami,merb,rails,sinatra)** or start yourself by adding a library to the comparison via the input below.
 
     .columns: .column
       .tags
         - @expected_ids.split(",").each do |permalink|
           span.tag.is-primary.is-medium
             span= permalink
-            a.delete.is-small href=comparison_path((@expected_ids.split(",") - [permalink]).join(","))
+            a.delete.is-small href=(comparison_path((@expected_ids.split(",") - [permalink]).join(",")) + "?#{current_display_settings_query_string}")
 
-      = form_tag link_with_preserved_display_settings, method: :get, autocomplete: "off", class: "autocomplete-form" do
+      = form_tag request.path, method: :get, autocomplete: "off", class: "autocomplete-form" do
         .field.has-addons.has-addons-centered
+          // Persist display settings across submissions
+          - current_display_settings.compact.each do |name, value|
+            input type="hidden" name=name value=value
+
           .control.is-expanded
             input.input.autocomplete-comparison autofocus="autofocus" placeholder="Type a project name to add it to the comparison" type="text" name="add" value=""
           .control

--- a/app/views/comparisons/show.html.slim
+++ b/app/views/comparisons/show.html.slim
@@ -9,7 +9,7 @@
       - if @projects.size < 2
         .description
           markdown:
-            Project comparisons enable you to view any selection of projects side by side just like they're shown on regular categories or in search results. **[You can try out an example](/compare/hanami,merb,rails,sinatra)** or start yourself by adding a library to the comparison via the input below.
+            Project comparisons allow you to view any selection of projects side by side just like they're shown on regular categories or in search results. **[You can try out an example](/compare/hanami,merb,rails,sinatra)** or start yourself by adding a library to the comparison via the input below.
 
     .columns: .column
       .tags

--- a/app/views/components/_project.html.slim
+++ b/app/views/components/_project.html.slim
@@ -38,10 +38,7 @@
   - if local_assigns[:compact]
     .metrics.compact= metrics_row project, :rubygem_downloads, :github_repo_stargazers_count, :rubygem_current_version, :rubygem_releases_count, :rubygem_first_release_on, :rubygem_latest_release_on
 
-    .columns: .column.has-text-right
-      a.button.is-outlined href="/projects/#{project.permalink}"
-        span.icon: i.fa.fa-plus
-        span Show more project details
+    = project_details_buttons project
 
   - else
     = project_metrics project, compact: compact

--- a/app/views/components/project/_details_buttons.html.slim
+++ b/app/views/components/project/_details_buttons.html.slim
@@ -1,0 +1,8 @@
+.columns: .column
+  .buttons.is-right
+    a.button.is-outlined href="/projects/#{project.permalink}"
+      span.icon: i.fa.fa-plus
+      span Show more project details
+    a.button.is-outlined href=comparison_path(project.permalink)
+      span.icon: i.fa.fa-arrows-h
+      span Compare

--- a/app/views/components/project/_metrics.html.slim
+++ b/app/views/components/project/_metrics.html.slim
@@ -51,7 +51,4 @@
     .column: .metrics
       = metrics_row project, :github_repo_issue_closure_rate, :github_repo_pull_request_acceptance_rate, :github_repo_average_recent_committed_at, :rubygem_reverse_dependencies_count
 
-  .columns: .column.has-text-right
-    a.button.is-outlined href="/projects/#{project.permalink}"
-      span.icon: i.fa.fa-plus
-      span Show more project details
+  = project_details_buttons project

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -58,7 +58,7 @@ html.has-navbar-fixed-top lang="en"
 
         .navbar-menu#mainMenu
           .navbar-end
-            a.navbar-item href="/" class=active_when(controller: :welcome)
+            a.navbar-item.is-hidden-widescreen-only href="/" class=active_when(controller: :welcome)
               .wrap
                 span.icon: i.fa.fa-home
                 span Home

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -68,6 +68,11 @@ html.has-navbar-fixed-top lang="en"
                 span.icon: i.fa.fa-bars
                 span Categories
 
+            a.navbar-item href=comparison_path class=active_when(controller: :comparisons)
+              .wrap
+                span.icon: i.fa.fa-arrows-h
+                span Compare
+
             a.navbar-item href=page_path("docs/index") class=active_when(controller: :pages)
               .wrap
                 span.icon: i.fa.fa-life-ring

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,11 @@ Rails.application.routes.draw do
   end
   get "compare(/:id)", to: "comparisons#show", constraints: { id: /.*/ }, as: :comparison
 
-  resource  :search, only: %i[show]
+  resource :search, only: %i[show] do
+    collection do
+      get :by_name
+    end
+  end
   resources :blog, only: %i[index show], constraints: { id: /[^\.]+/ }
 
   namespace :webhooks do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,10 @@ require "sidekiq/web"
 # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 Rails.application.routes.draw do
   resources :categories, only: %i[index show]
-  resources :projects, only: %i[show], constraints: { id: Patterns::ROUTE_PATTERN }
+  resources :projects, only: %i[show], constraints: { id: Patterns::ROUTE_PATTERN } do
+  end
+  get "compare(/:id)", to: "comparisons#show", constraints: { id: /.*/ }, as: :comparison
+
   resource  :search, only: %i[show]
   resources :blog, only: %i[index show], constraints: { id: /[^\.]+/ }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "dependencies": {
     "bulma": "^0.7.0",
     "chart.js": "^2.7.3",
-    "headroom.js": "^0.9.4"
+    "headroom.js": "^0.9.4",
+    "javascript-autocomplete": "^1.0.3"
   },
   "version": "1.0.0",
   "main": "index.js",

--- a/spec/controllers/comparisons_controller_spec.rb
+++ b/spec/controllers/comparisons_controller_spec.rb
@@ -34,6 +34,11 @@ RSpec.describe ComparisonsController, type: :controller do
         expect(response).to redirect_to("/compare/a,b,c")
       end
 
+      it "keeps display parameters around when given" do
+        get :show, params: { id: "b,c,a", display: "compact", order: "downloads", foo: "bar" }
+        expect(response).to redirect_to("/compare/a,b,c?display=compact&order=downloads")
+      end
+
       it "redirects to distinct ids when querying duplicates" do
         get :show, params: { id: "b,c,a,c,b" }
         expect(response).to redirect_to("/compare/a,b,c")

--- a/spec/controllers/comparisons_controller_spec.rb
+++ b/spec/controllers/comparisons_controller_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ComparisonsController, type: :controller do
+  before do
+    Factories.project "a", score: 30, downloads: 5000
+    Factories.project "b", score: 25, downloads: 40_000
+    Factories.project "c", score: 20, downloads: 3000
+  end
+
+  describe "GET show" do
+    shared_examples_for "a successful request" do
+      it "responds with success" do
+        do_request
+        expect(response).to have_http_status(:success)
+      end
+
+      it "renders show template" do
+        do_request
+        expect(response).to render_template(:show)
+      end
+    end
+
+    describe "without params" do
+      let(:do_request) { get :show }
+
+      it_behaves_like "a successful request"
+    end
+
+    describe "with valid ids" do
+      it "redirects to sorted ids when querying invalid order" do
+        get :show, params: { id: "b,c,a" }
+        expect(response).to redirect_to("/compare/a,b,c")
+      end
+
+      it "redirects to distinct ids when querying duplicates" do
+        get :show, params: { id: "b,c,a,c,b" }
+        expect(response).to redirect_to("/compare/a,b,c")
+      end
+
+      it "redirects to valid ids when querying with invalid projects" do
+        get :show, params: { id: "b,c,a,404" }
+        expect(response).to redirect_to("/compare/a,b,c")
+      end
+
+      describe "when requesting in correct order" do
+        let(:do_request) { get :show, params: { id: "a,b,c" } }
+
+        it_behaves_like "a successful request"
+      end
+    end
+
+    #
+    # The add param is used to append projects to the comparison
+    #
+    describe "adding a project to comparison via param" do
+      describe "when comparison list is empty" do
+        it "redirects to comparison page with given project" do
+          get :show, params: { add: "a" }
+          expect(response).to redirect_to("/compare/a")
+        end
+
+        it "redirects to plain compare path when added project is invalid" do
+          get :show, params: { add: "404" }
+          expect(response).to redirect_to("/compare")
+        end
+      end
+
+      describe "when comparison list already has projects" do
+        it "redirects to comparison page with given project" do
+          get :show, params: { add: "a", id: "c,b" }
+          expect(response).to redirect_to("/compare/a,b,c")
+        end
+
+        it "redirects to compare path with valid projects when added project is invalid" do
+          get :show, params: { add: "404", id: "c,b" }
+          expect(response).to redirect_to("/compare/b,c")
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/searches_controller_spec.rb
+++ b/spec/controllers/searches_controller_spec.rb
@@ -69,4 +69,17 @@ RSpec.describe SearchesController, type: :controller do
       expect(response).to have_http_status(:success)
     end
   end
+
+  describe "GET by_name" do
+    it "requests list of matching project names to Project.suggest" do
+      expect(Project).to receive(:suggest).with("foobar").and_return([])
+      get :by_name, params: { q: "foobar" }
+    end
+
+    it "returns list of matching project names as json" do
+      allow(Project).to receive(:suggest).with("foobar").and_return(%w[a b c])
+      get :by_name, params: { q: "foobar" }
+      expect(Oj.load(response.body)).to be == %w[a b c]
+    end
+  end
 end

--- a/spec/features/comparisons_spec.rb
+++ b/spec/features/comparisons_spec.rb
@@ -18,12 +18,13 @@ RSpec.describe "Project Comparisons", type: :feature, js: true do
 
     fill_in :add, with: "acme"
     click_button "Add to comparison"
-    expect(page).not_to have_text("view any selection of projects")
+    expect(page).to have_text("view any selection of projects")
     expect(listed_project_names).to be == %w[acme]
     expect(comparison_project_tags.map(&:text)).to be == %w[acme]
 
     fill_in :add, with: "widget"
     click_button "Add to comparison"
+    expect(page).not_to have_text("view any selection of projects")
     expect(listed_project_names).to be == %w[acme widget]
     expect(comparison_project_tags.map(&:text)).to be == %w[acme widget]
 
@@ -45,6 +46,19 @@ RSpec.describe "Project Comparisons", type: :feature, js: true do
     expect(listed_project_names).to be == %w[widget acme toolkit]
     change_display_mode "Compact"
     expect(listed_project_names).to be == %w[widget acme toolkit]
+
+    # It should keep current display settings on add
+    fill_in :add, with: "irrelevant"
+    click_button "Add to comparison"
+    expect_display_mode "Compact"
+    expect(listed_project_names).to be == %w[widget acme toolkit]
+
+    # It should keep current display settings on remove
+    comparison_project_tags.first.find(".delete").click
+    wait_for do
+      expect(listed_project_names).to be == %w[widget toolkit]
+    end
+    expect_display_mode "Compact"
   end
 
   it "has working autocompletion for project addition form" do

--- a/spec/features/comparisons_spec.rb
+++ b/spec/features/comparisons_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Project Comparisons", type: :feature, js: true do
+  before do
+    Factories.project("acme", score: 25, downloads: 25_000, first_release: 3.years.ago)
+    Factories.project("widget", score: 20, downloads: 50_000, first_release: 2.years.ago)
+    Factories.project("toolkit", score: 22, downloads: 10_000, first_release: 5.years.ago)
+  end
+
+  it "allows to compare arbitrary projects" do
+    visit "/"
+    within ".navbar" do
+      click_on "Compare"
+    end
+    expect(page).to have_selector("article.blog-post")
+
+    fill_in :add, with: "acme"
+    click_button "Add to comparison"
+    expect(page).not_to have_selector("article.blog-post")
+    expect(listed_project_names).to be == %w[acme]
+    expect(comparison_project_tags.map(&:text)).to be == %w[acme]
+
+    fill_in :add, with: "widget"
+    click_button "Add to comparison"
+    expect(listed_project_names).to be == %w[acme widget]
+    expect(comparison_project_tags.map(&:text)).to be == %w[acme widget]
+
+    comparison_project_tags.first.find(".delete").click
+    wait_for do
+      expect(listed_project_names).to be == %w[widget]
+    end
+  end
+
+  private
+
+  def listed_project_names
+    page.find_all(".project-comparison tbody th").map(&:text)
+  end
+
+  def comparison_project_tags
+    page.find_all(".hero .tags .tag")
+  end
+end

--- a/spec/features/comparisons_spec.rb
+++ b/spec/features/comparisons_spec.rb
@@ -73,6 +73,14 @@ RSpec.describe "Project Comparisons", type: :feature, js: true do
     wait_for do
       expect(listed_project_names).to be == %w[toolkit widget]
     end
+
+    # Our autocomplete library interferes with the enter key on the input field -
+    # it should be possible to just type a name and hit enter without interacting
+    # with the autocompletion in any way.
+    page.find("input.autocomplete-comparison").send_keys "acme", :enter
+    wait_for do
+      expect(listed_project_names).to be == %w[acme toolkit widget]
+    end
   end
 
   private

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -57,6 +57,16 @@ RSpec.describe Project, type: :model do
       Factories.project "foofoo", score: nil
       expect(described_class.suggest("fo")).to be == %w[foobar foo foofoo]
     end
+
+    it "is case-insensitive" do
+      Factories.project "DeMo"
+      expect(described_class.suggest("dem")).to be == %w[DeMo]
+    end
+
+    it "sanitizes user-provided special chars" do
+      Factories.project "foof"
+      expect(described_class.suggest("%oof")).to be == %w[]
+    end
   end
 
   describe ".search" do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -41,6 +41,24 @@ RSpec.describe Project, type: :model do
     end
   end
 
+  describe ".suggest" do
+    it "does not make any database query for empty param" do
+      expect { described_class.suggest(" ") }.not_to make_database_queries
+    end
+
+    it "returns empty array for empty param" do
+      expect(described_class.suggest(" ")).to be == []
+    end
+
+    it "fetches projects from database that match given name ordered by score" do
+      Factories.project "demofoo"
+      Factories.project "foobar", score: 10
+      Factories.project "foo", score: 5
+      Factories.project "foofoo", score: nil
+      expect(described_class.suggest("fo")).to be == %w[foobar foo foofoo]
+    end
+  end
+
   describe ".search" do
     it "can find a matching project" do
       expected = Project.create! permalink: "widgets", score: 1

--- a/spec/support/helpers/feature_spec_helpers.rb
+++ b/spec/support/helpers/feature_spec_helpers.rb
@@ -2,7 +2,11 @@
 
 module FeatureSpecHelpers
   def listed_project_names
-    page.find_all(".project h3").map(&:text)
+    if current_display_mode == "Table"
+      page.find_all(".project-comparison tbody th").map(&:text)
+    else
+      page.find_all(".project h3").map(&:text)
+    end
   end
 
   #
@@ -31,10 +35,15 @@ module FeatureSpecHelpers
     end
   end
 
+  def current_display_mode
+    page.find(".project-display-picker .is-active").text
+  end
+
   def expect_display_mode(label) # rubocop:disable Metrics/AbcSize It's good enough :)
     within(".project-display-picker .is-active") do
       expect(page).to have_text(label)
     end
+
     case label.downcase.to_sym
     when :table
       expect(page).to have_selector(".project-comparison", count: 1)

--- a/yarn.lock
+++ b/yarn.lock
@@ -45,6 +45,11 @@ headroom.js@^0.9.4:
   resolved "https://registry.yarnpkg.com/headroom.js/-/headroom.js-0.9.4.tgz#0c4e6b4563bb69df55aecdefaba3227566f2df5a"
   integrity sha1-DE5rRWO7ad9Vrs3vq6MidWby31o=
 
+javascript-autocomplete@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/javascript-autocomplete/-/javascript-autocomplete-1.0.3.tgz#67f151c7c5cdac4e36f4a2f0aaad1308f468d8dc"
+  integrity sha1-Z/FRx8XNrE429KLwqq0TCPRo2Nw=
+
 moment@^2.10.2:
   version "2.23.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.23.0.tgz#759ea491ac97d54bac5ad776996e2a58cc1bc225"


### PR DESCRIPTION
Following shortly to the new alternate display modes via #398 this PR adds a new feature that allows users to compare arbitrary projects using the usual project sorting / display modes, with the comparison pages being deep-linkable too.

The ability to compare arbitrary projects side by side came in in 3rd place in the [recent community survey](https://www.ruby-toolbox.com/blog/2018-12-04/survey-results) feature vote.

Since the top navigation became too crowded to fit all the content in the desktop breakpoint (~1024-1280px) I had to also tweak the responsiveness of the navigation a bit.

I'm not fully happy yet with how the display settings and consistent URL generation works at the moment, but I'll save that for a followup refactoring PR, it's tested and works, it just feels a bit brittle and similar logic is sprinkled across 3 different controllers, the view helpers and some view templates now, there must be a better way to do this :)

![project-comparisons-cut](https://user-images.githubusercontent.com/13972/52794499-38449580-3070-11e9-876c-a0f2309b4e85.gif)


