### PR TITLE
Introduce weekly persistence of gem download stats

### DIFF
--- a/app/jobs/rubygem_downloads_persistence_job.rb
+++ b/app/jobs/rubygem_downloads_persistence_job.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+#
+# This job performs an upsert to store whatever downloads count is currently stored
+# on each rubygem into the historical stats table rubygem_download_stats.
+#
+# * This job is scheduled hourly
+# * It only actually runs on sundays, because we only currently need weekly stats anyway
+# * If it already ran on a given day we don't care, we'll keep upserting until the day ends.
+#   This is to ensure within reason that the job actually runs on every sunday without having
+#   to put in place some complex persistent logic that actually keeps track of that.
+#
+class RubygemDownloadsPersistenceJob < ApplicationJob
+  def perform # rubocop:disable Metrics/MethodLength It's a simple method, the SQL code is just lengthy
+    return unless should_run?
+
+    upsert_sql = <<~SQL
+      INSERT INTO
+        rubygem_download_stats (rubygem_name, total_downloads, date, created_at, updated_at)
+        SELECT
+          name AS rubygem_name,
+          downloads AS total_downloads,
+          DATE '#{date}' as date,
+          current_timestamp as created_at,
+          current_timestamp as updated_at
+        FROM   rubygems
+
+      ON CONFLICT (rubygem_name, date) DO UPDATE
+      SET
+        total_downloads = excluded.total_downloads
+    SQL
+
+    result = ActiveRecord::Base.connection.execute upsert_sql
+    Rails.logger.info "Processed #{result.cmd_tuples} gem stats records"
+    result.cmd_tuples == Rubygem.count
+  end
+
+  #
+  # We only want to persist weekly stats, with the set date on sundays. Weekly stats
+  # are sufficient for the current purposes and reduce the required storage and backup sizes
+  # significantly.
+  #
+  # Since background jobs might be queued on a sunday yet, due to a queue backlog, might get
+  # executed at a later time, we need to check this at actual job execution time
+  #
+  def should_run?
+    date.sunday?
+  end
+
+  private
+
+  def date
+    @date ||= Time.current.utc.to_date
+  end
+end

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -9,6 +9,13 @@ class Rubygem < ApplicationRecord
           inverse_of:  :rubygem,
           dependent:   :destroy
 
+  has_many :download_stats, -> { order(date: :asc) },
+           class_name:  "RubygemDownloadStat",
+           primary_key: :name,
+           foreign_key: :rubygem_name,
+           inverse_of:  :rubygem,
+           dependent:   :destroy
+
   def self.update_batch
     where("updated_at < ? ", 24.hours.ago.utc)
       .order(updated_at: :asc)

--- a/app/models/rubygem_download_stat.rb
+++ b/app/models/rubygem_download_stat.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RubygemDownloadStat < ApplicationRecord
+  belongs_to :rubygem,
+             primary_key: :name,
+             foreign_key: :rubygem_name,
+             inverse_of:  :download_stats
+end

--- a/app/services/cron.rb
+++ b/app/services/cron.rb
@@ -6,12 +6,13 @@
 # hour, i.e. using the Heroku hourly scheduler and `rake cron`
 #
 class Cron
-  def run(time: Time.current.utc)
+  def run(time: Time.current.utc) # rubocop:disable Metrics/MethodLength It's easier to have it in one place
     case time.hour
     when 0
       RubygemsSyncJob.perform_async
     end
 
+    RubygemDownloadsPersistenceJob.perform_async
     RemoteUpdateSchedulerJob.perform_async
     CatalogImportJob.perform_async
     GithubIgnore.expire!

--- a/db/migrate/20190204132920_create_rubygem_download_stats.rb
+++ b/db/migrate/20190204132920_create_rubygem_download_stats.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateRubygemDownloadStats < ActiveRecord::Migration[5.2]
+  def change
+    create_table :rubygem_download_stats do |t|
+      t.string :rubygem_name, null: false
+      t.date :date, null: false
+      t.integer :total_downloads, null: false
+      t.timestamps
+    end
+
+    add_index :rubygem_download_stats, %i[rubygem_name date], unique: true
+    add_foreign_key :rubygem_download_stats, :rubygems, column: :rubygem_name, primary_key: :name
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -256,6 +256,39 @@ CREATE TABLE public.projects (
 
 
 --
+-- Name: rubygem_download_stats; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.rubygem_download_stats (
+    id bigint NOT NULL,
+    rubygem_name character varying NOT NULL,
+    date date NOT NULL,
+    total_downloads integer NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: rubygem_download_stats_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.rubygem_download_stats_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: rubygem_download_stats_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.rubygem_download_stats_id_seq OWNED BY public.rubygem_download_stats.id;
+
+
+--
 -- Name: rubygems; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -299,6 +332,13 @@ ALTER TABLE ONLY public.categorizations ALTER COLUMN id SET DEFAULT nextval('pub
 
 
 --
+-- Name: rubygem_download_stats id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.rubygem_download_stats ALTER COLUMN id SET DEFAULT nextval('public.rubygem_download_stats_id_seq'::regclass);
+
+
+--
 -- Name: ar_internal_metadata ar_internal_metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -312,6 +352,14 @@ ALTER TABLE ONLY public.ar_internal_metadata
 
 ALTER TABLE ONLY public.categorizations
     ADD CONSTRAINT categorizations_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: rubygem_download_stats rubygem_download_stats_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.rubygem_download_stats
+    ADD CONSTRAINT rubygem_download_stats_pkey PRIMARY KEY (id);
 
 
 --
@@ -435,6 +483,13 @@ CREATE UNIQUE INDEX index_projects_on_rubygem_name ON public.projects USING btre
 
 
 --
+-- Name: index_rubygem_download_stats_on_rubygem_name_and_date; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_rubygem_download_stats_on_rubygem_name_and_date ON public.rubygem_download_stats USING btree (rubygem_name, date);
+
+
+--
 -- Name: index_rubygems_on_name; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -494,6 +549,14 @@ ALTER TABLE ONLY public.categories
 
 
 --
+-- Name: rubygem_download_stats fk_rails_c4eb80d594; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.rubygem_download_stats
+    ADD CONSTRAINT fk_rails_c4eb80d594 FOREIGN KEY (rubygem_name) REFERENCES public.rubygems(name);
+
+
+--
 -- Name: projects fk_rails_ddb4eb0108; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -535,6 +598,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190110202221'),
 ('20190117100816'),
 ('20190117101723'),
-('20190121165354');
+('20190121165354'),
+('20190204132920');
 
 

--- a/spec/jobs/rubygem_downloads_persistence_job_spec.rb
+++ b/spec/jobs/rubygem_downloads_persistence_job_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RubygemDownloadsPersistenceJob, type: :job do
+  let(:job) { described_class.new }
+  let(:do_perform) { job.perform }
+
+  before do
+    RubygemDownloadStat.delete_all
+
+    Factories.rubygem "a", downloads: 100
+    Factories.rubygem "b", downloads: 200
+    Factories.rubygem "c", downloads: 300
+  end
+
+  def stats
+    RubygemDownloadStat.order(rubygem_name: :asc, date: :asc).map do |stat|
+      stat.attributes.symbolize_keys.slice(:rubygem_name, :date, :total_downloads)
+    end
+  end
+
+  describe "#should_run?" do
+    it "is true on sundays" do
+      Timecop.freeze Time.zone.today.end_of_week(:monday) do
+        expect(job.should_run?).to be true
+      end
+    end
+
+    it "is false on other days of the week" do
+      # Any weekday other than sunday this week
+      date = (Time.zone.today.beginning_of_week(:monday)..Time.zone.today.end_of_week(:sunday)).to_a.sample
+      Timecop.freeze date do
+        expect(job.should_run?).to be false
+      end
+    end
+  end
+
+  it "does not do anything if RubygemDownloadsPersistenceJob.should_run? is false" do
+    allow(job).to receive(:should_run?)
+    expect { do_perform }.not_to change(RubygemDownloadStat, :count).from(0)
+  end
+
+  describe "when no previous download stats exist" do
+    before do
+      allow(job).to receive(:should_run?).and_return(true)
+    end
+
+    it "creates the three expected download stat records" do
+      expect { do_perform }.to change { stats }
+        .from([])
+        .to([
+              { date: Time.zone.today, rubygem_name: "a", total_downloads: 100 },
+              { date: Time.zone.today, rubygem_name: "b", total_downloads: 200 },
+              { date: Time.zone.today, rubygem_name: "c", total_downloads: 300 },
+            ])
+    end
+  end
+
+  describe "when previous stats do exist" do
+    before do
+      # Should not be changed
+      Rubygem.find("a").download_stats.create! date: "2019-02-03", total_downloads: 50
+
+      # Should get updated
+      Rubygem.find("b").download_stats.create! date: Time.zone.today, total_downloads: 100
+
+      allow(job).to receive(:should_run?).and_return(true)
+    end
+
+    it "performs expected upsert operation on records" do
+      expect { do_perform }.to change { stats }
+        .to([
+              { date: Date.new(2019, 2, 3), rubygem_name: "a", total_downloads: 50 },
+              { date: Time.zone.today, rubygem_name: "a", total_downloads: 100 },
+              { date: Time.zone.today, rubygem_name: "b", total_downloads: 200 },
+              { date: Time.zone.today, rubygem_name: "c", total_downloads: 300 },
+            ])
+    end
+  end
+end

--- a/spec/models/rubygem_download_stat_spec.rb
+++ b/spec/models/rubygem_download_stat_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RubygemDownloadStat, type: :model do
+  it "has a unique index on rubygem name and date" do
+    rubygem = Factories.rubygem "example"
+    do_create = lambda {
+      rubygem.download_stats.create! total_downloads: 2000, date: Time.zone.today
+    }
+
+    do_create.call
+
+    expect(&do_create).to raise_error(ActiveRecord::RecordNotUnique)
+  end
+end

--- a/spec/services/cron_spec.rb
+++ b/spec/services/cron_spec.rb
@@ -19,6 +19,11 @@ RSpec.describe Cron, type: :service do
     cron.run time: time_at(rand(24))
   end
 
+  it "queues RubygemDownloadsPersistenceJob every hour" do
+    expect(RubygemDownloadsPersistenceJob).to receive(:perform_async)
+    cron.run time: time_at(rand(24))
+  end
+
   it "invokes GithubIgnore.expire every hour" do
     expect(GithubIgnore).to receive(:expire!)
     cron.run time: time_at(rand(24))

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -8,12 +8,9 @@ module Factories
                 downloads: 5000,
                 first_release: 1.year.ago,
                 description: nil)
-      rubygem = Rubygem.create!(
-        name:             name,
-        current_version:  "1.0",
-        downloads:        downloads,
-        first_release_on: first_release
-      )
+
+      rubygem = self.rubygem name, downloads: downloads, first_release: first_release
+
       github_repo = GithubRepo.create!(
         path:             "#{name}/#{name}",
         stargazers_count: downloads,
@@ -25,6 +22,15 @@ module Factories
                       rubygem:     rubygem,
                       github_repo: github_repo,
                       description: description
+    end
+
+    def rubygem(name, downloads: 5000, first_release: 1.year.ago)
+      Rubygem.create!(
+        name:             name,
+        current_version:  "1.0",
+        downloads:        downloads,
+        first_release_on: first_release
+      )
     end
   end
   # rubocop:enable Metrics/MethodLength


### PR DESCRIPTION
This PR introduces a new table to persist weekly rubygem download stats in preparation of displaying historical download stats and detection of trending repos.

The persistence happens every week on sundays using an amazingly efficient single query postgres upsert query. Postgres, you're awesome :heart: 