### PR TITLE
Comparison table health indicators

### DIFF
--- a/app/assets/stylesheets/components/hoverable_health_indicator.sass
+++ b/app/assets/stylesheets/components/hoverable_health_indicator.sass
@@ -1,0 +1,6 @@
+.hoverable-health-indicator
+  @extend .dropdown, .is-hoverable
+
+  .dropdown-menu
+    // The longer health tags break out of the container :'-(
+    width: 330px

--- a/app/helpers/component_helpers.rb
+++ b/app/helpers/component_helpers.rb
@@ -55,6 +55,10 @@ module ComponentHelpers
     render "components/project_health_tag", status: health_status
   end
 
+  def hoverable_health_indicator(project)
+    render "components/hoverable_health_indicator", project: project
+  end
+
   def project_order_dropdown(order)
     render "components/project_order_dropdown", order: order
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -150,5 +150,9 @@ class Project < ApplicationRecord
   def bug_tracker_url
     rubygem_bug_tracker_url || github_repo_issues_url
   end
+
+  def health
+    @health ||= Project::Health.new(self)
+  end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/models/project/health.rb
+++ b/app/models/project/health.rb
@@ -45,4 +45,11 @@ class Project::Health
   def status
     @status ||= checks.select { |check| check.applies? project }.presence || [HEALTHY_STATUS]
   end
+
+  def overall_level
+    return :red if status.any? { |status| status.level == :red }
+    return :yellow if status.any? { |status| status.level == :yellow }
+
+    :green
+  end
 end

--- a/app/views/components/_hoverable_health_indicator.html.slim
+++ b/app/views/components/_hoverable_health_indicator.html.slim
@@ -1,0 +1,14 @@
+- dropdown_id = "health-dropdown" + SecureRandom.hex(8)
+
+.hoverable-health-indicator
+  .dropdown-trigger
+    .project-health-tag class="level-#{project.health.overall_level}" aria-haspopup="true" aria-controls=dropdown_id
+      a href="/projects/#{project.permalink}"
+        .tags.has-addons
+          span.tag
+            span.icon: i.fa class="fa-heartbeat"
+
+  .dropdown-menu role="menu" id=dropdown_id
+    .dropdown-content
+      .dropdown-item
+        = project_health_tags project

--- a/app/views/components/_project_comparison.html.slim
+++ b/app/views/components/_project_comparison.html.slim
@@ -2,9 +2,8 @@
   - metrics = %i[score rubygem_downloads github_repo_stargazers_count github_repo_forks_count rubygem_first_release_on rubygem_latest_release_on rubygem_reverse_dependencies_count]
   table.table.is-striped.is-hoverable.is-fullwidth
     thead
-      th
-      th
-      th
+      - 4.times do
+        th
       - metrics.each do |key|
         th: .heading
           - docs_page = File.join("docs", "metrics", key.to_s)
@@ -29,6 +28,9 @@
             - if project.github_repo_url
               a href=project.github_repo_url
                 span.icon: i.fa.fa-github
+
+          td
+            = hoverable_health_indicator project
 
           // This should be less messy...
           - metrics.each do |key|

--- a/app/views/components/_project_health_tags.html.slim
+++ b/app/views/components/_project_health_tags.html.slim
@@ -7,5 +7,5 @@
       a.tag.is-primary href=project_path(project.bugfix_fork_of)
         = project.bugfix_fork_of
 
-  - Project::Health.new(project).status.each do |status|
+  - project.health.status.each do |status|
     = project_health_tag status

--- a/app/views/pages/components/project_health_tag.html.slim
+++ b/app/views/pages/components/project_health_tag.html.slim
@@ -24,3 +24,16 @@
       suspected originating gem.
 
   = project_health_tags Project.new(bugfix_fork_of: "rails")
+
+= component_example "Tiny tag list with hover dropdown"
+  .content
+    markdown:
+      When available space is very limited, the "worst" status health indicator can be shown, featuring
+      a dropdown that shows the detailed health stats on hover.
+
+
+  - Project.for_display.order(score: :desc).limit(10).each do |project|
+    = hoverable_health_indicator project
+
+  - Project.for_display.where("rubygems.latest_release_on < ?", 5.years.ago).order(score: :desc).limit(10).each do |project|
+    = hoverable_health_indicator project

--- a/spec/models/project/health_spec.rb
+++ b/spec/models/project/health_spec.rb
@@ -68,4 +68,33 @@ RSpec.describe Project::Health, type: :model do
       expect(health.status).to be == [described_class::HEALTHY_STATUS]
     end
   end
+
+  describe "overall_level" do
+    before do
+      health.checks.each { |check| allow(check).to receive(:applies?) }
+    end
+
+    it "returns the red if a matching check is red" do
+      health.checks.each { |check| allow(check).to receive(:applies?).and_return(true) }
+      expect(health.overall_level).to be == :red
+    end
+
+    it "returns yellow if worst matching check is yellow" do
+      health.checks.each do |check|
+        next unless %i[yellow green].include? check.level
+
+        allow(check).to receive(:applies?).and_return(true)
+      end
+      expect(health.overall_level).to be == :yellow
+    end
+
+    it "returns green if worst matching check is green" do
+      health.checks.each do |check|
+        next unless check.level == :green
+
+        allow(check).to receive(:applies?).and_return(true)
+      end
+      expect(health.overall_level).to be == :green
+    end
+  end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -204,4 +204,23 @@ RSpec.describe Project, type: :model do
       expect(Project.new(permalink: "FoOBaR").permalink).to be == "FoOBaR"
     end
   end
+
+  describe "#health" do
+    let(:project) { described_class.new }
+
+    it "passes itself to Project Health" do
+      expect(Project::Health).to receive(:new).with(project)
+      project.health
+    end
+
+    it "returns a project health instance" do
+      health = instance_double Project::Health
+      allow(Project::Health).to receive(:new).and_return(health)
+      expect(project.health).to be == health
+    end
+
+    it "memoizes the instance" do
+      expect(project.health.object_id).to be == project.health.object_id
+    end
+  end
 end


### PR DESCRIPTION
This introduces project health indicators (see #355) to the new project comparison table view (via #398), since they can be very helpful to get an overview and were missing from the table. 

Since there's limited space on the table there is a new tiny badge that shows the color of the "worst" status. On hover it shows a popup that displays the actual health tags for that project.

![screenshot from 2019-02-13 11-50-01](https://user-images.githubusercontent.com/13972/52706481-cc85fe00-2f85-11e9-9e0b-98306347e506.png)
