### PR TITLE
Gem download stats calculations

### DIFF
--- a/app/models/rubygem_download_stat.rb
+++ b/app/models/rubygem_download_stat.rb
@@ -1,5 +1,34 @@
 # frozen_string_literal: true
 
+#
+# This class represents historical rubygem download data for a given date and gem.
+#
+# We only store weekly stats, on sundays, to make calculations between timeframes
+# more consistent and easy to reason about, as well as saving on database storage
+# massively. For the Ruby Toolbox's purposes, weekly stats are just fine(tm).
+#
+# The weekly persistence of stats happens via the `RubygemDownloadsPersistenceJob`,
+# which takes a snapshot of whatever current downloads are stored on the `rubygems`
+# table (if gem data updating is broken this might be outdated, but again on the
+# average week the assumption is that this is good enough for our purposes).
+#
+# A number of additional stats is calculated using postgres trigger functions, based
+# on the presence of previous data:
+#
+# `absolute_change_(week|month|year)`:
+#   The total number of downloads just in that timeframe (if previous record is there)
+#
+# `relative_change_(week|month|year)`:
+#   The percentage of all-time total downloads the timeframe's absolute downloads constitute
+#
+# `growth_change_(week|month|year)`:
+#   The difference between current relative change and the previous one in the timeframe
+#
+# The trigger functions are not "clever" in triggering related updates if a historical record
+# changes (since the assumption is they won't change anyway, it's historical data after all).
+# If you change historical numbers, be sure to trigger a re-calculation of all related stats by
+# issuing `UPDATE rubygem_download_stats SET id = id (WHERE rubygem_name = 'foo')".
+#
 class RubygemDownloadStat < ApplicationRecord
   belongs_to :rubygem,
              primary_key: :name,

--- a/db/migrate/20190207133425_create_gem_trends_columns_and_calculation_trigger.rb
+++ b/db/migrate/20190207133425_create_gem_trends_columns_and_calculation_trigger.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: false
+
+#
+# This migration creates stats columns
+#
+class CreateGemTrendsColumnsAndCalculationTrigger < ActiveRecord::Migration[5.2]
+  def up
+    change_table :rubygem_download_stats, bulk: true do |t|
+      t.integer :absolute_change_week, default: nil
+      t.decimal :relative_change_week, default: nil
+
+      t.integer :absolute_change_month, default: nil
+      t.decimal :relative_change_month, default: nil
+
+      t.integer :absolute_change_year, default: nil
+      t.decimal :relative_change_year, default: nil
+    end
+
+    create_stats_trigger :week, 7
+    create_stats_trigger :month, 28
+    create_stats_trigger :year, 364
+  end
+
+  def down
+    change_table :rubygem_download_stats, bulk: true do |t|
+      t.remove :absolute_change_week,
+               :relative_change_week,
+               :absolute_change_month,
+               :relative_change_month,
+               :absolute_change_year,
+               :relative_change_year
+    end
+
+    drop_trigger :rubygem_stats_calculation_week, :rubygem_download_stats
+    drop_trigger :rubygem_stats_calculation_month, :rubygem_download_stats
+    drop_trigger :rubygem_stats_calculation_year, :rubygem_download_stats
+  end
+
+  private
+
+  def create_stats_trigger(name, distance_in_days)
+    create_trigger("rubygem_stats_calculation_#{name}", compatibility: 1)
+      .on(:rubygem_download_stats)
+      .declare("previous_downloads int;")
+      .before(:insert,
+              :update,
+              &difference_to_previous_trigger_sql(name, distance_in_days))
+  end
+
+  def difference_to_previous_trigger_sql(name, distance_in_days)
+    lambda do
+      <<~SQL
+        SELECT total_downloads INTO previous_downloads
+          FROM rubygem_download_stats
+          WHERE
+            rubygem_name = NEW.rubygem_name AND date = NEW.date - #{distance_in_days};
+
+        IF previous_downloads IS NOT NULL THEN
+          NEW.absolute_change_#{name} := NEW.total_downloads - previous_downloads;
+          IF previous_downloads > 0 THEN
+            NEW.relative_change_#{name} := ROUND((NEW.absolute_change_#{name} * 100.0) / previous_downloads, 2);
+          END IF;
+        END IF;
+      SQL
+    end
+  end
+end

--- a/db/migrate/20190207133425_create_gem_trends_columns_and_calculation_trigger.rb
+++ b/db/migrate/20190207133425_create_gem_trends_columns_and_calculation_trigger.rb
@@ -8,12 +8,15 @@ class CreateGemTrendsColumnsAndCalculationTrigger < ActiveRecord::Migration[5.2]
     change_table :rubygem_download_stats, bulk: true do |t|
       t.integer :absolute_change_week, default: nil
       t.decimal :relative_change_week, default: nil
+      t.decimal :growth_change_week, default: nil
 
       t.integer :absolute_change_month, default: nil
       t.decimal :relative_change_month, default: nil
+      t.decimal :growth_change_month, default: nil
 
       t.integer :absolute_change_year, default: nil
       t.decimal :relative_change_year, default: nil
+      t.decimal :growth_change_year, default: nil
     end
 
     create_stats_trigger :week, 7
@@ -25,10 +28,13 @@ class CreateGemTrendsColumnsAndCalculationTrigger < ActiveRecord::Migration[5.2]
     change_table :rubygem_download_stats, bulk: true do |t|
       t.remove :absolute_change_week,
                :relative_change_week,
+               :growth_change_week,
                :absolute_change_month,
                :relative_change_month,
+               :growth_change_month,
                :absolute_change_year,
-               :relative_change_year
+               :relative_change_year,
+               :growth_change_year
     end
 
     drop_trigger :rubygem_stats_calculation_week, :rubygem_download_stats
@@ -41,7 +47,7 @@ class CreateGemTrendsColumnsAndCalculationTrigger < ActiveRecord::Migration[5.2]
   def create_stats_trigger(name, distance_in_days)
     create_trigger("rubygem_stats_calculation_#{name}", compatibility: 1)
       .on(:rubygem_download_stats)
-      .declare("previous_downloads int;")
+      .declare("previous_downloads int; previous_relative_change decimal;")
       .before(:insert,
               :update,
               &difference_to_previous_trigger_sql(name, distance_in_days))
@@ -50,7 +56,7 @@ class CreateGemTrendsColumnsAndCalculationTrigger < ActiveRecord::Migration[5.2]
   def difference_to_previous_trigger_sql(name, distance_in_days)
     lambda do
       <<~SQL
-        SELECT total_downloads INTO previous_downloads
+        SELECT total_downloads, relative_change_#{name} INTO previous_downloads, previous_relative_change
           FROM rubygem_download_stats
           WHERE
             rubygem_name = NEW.rubygem_name AND date = NEW.date - #{distance_in_days};
@@ -59,6 +65,10 @@ class CreateGemTrendsColumnsAndCalculationTrigger < ActiveRecord::Migration[5.2]
           NEW.absolute_change_#{name} := NEW.total_downloads - previous_downloads;
           IF previous_downloads > 0 THEN
             NEW.relative_change_#{name} := ROUND((NEW.absolute_change_#{name} * 100.0) / previous_downloads, 2);
+
+            IF previous_relative_change IS NOT NULL THEN
+              NEW.growth_change_#{name} := NEW.relative_change_#{name} - previous_relative_change;
+            END IF;
           END IF;
         END IF;
       SQL

--- a/db/migrate/20190211104231_add_download_stats_indices.rb
+++ b/db/migrate/20190211104231_add_download_stats_indices.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AddDownloadStatsIndices < ActiveRecord::Migration[5.2]
+  def change
+    add_index :rubygem_download_stats, :date
+    add_index :rubygem_download_stats, :total_downloads, order: "DESC NULLS LAST"
+
+    add_index :rubygem_download_stats, :absolute_change_week, order: "DESC NULLS LAST"
+    add_index :rubygem_download_stats, :relative_change_week, order: "DESC NULLS LAST"
+
+    add_index :rubygem_download_stats, :absolute_change_month, order: "DESC NULLS LAST"
+    add_index :rubygem_download_stats, :relative_change_month, order: "DESC NULLS LAST"
+
+    add_index :rubygem_download_stats, :absolute_change_year, order: "DESC NULLS LAST"
+    add_index :rubygem_download_stats, :relative_change_year, order: "DESC NULLS LAST"
+  end
+end

--- a/db/migrate/20190211104231_add_download_stats_indices.rb
+++ b/db/migrate/20190211104231_add_download_stats_indices.rb
@@ -7,11 +7,14 @@ class AddDownloadStatsIndices < ActiveRecord::Migration[5.2]
 
     add_index :rubygem_download_stats, :absolute_change_week, order: "DESC NULLS LAST"
     add_index :rubygem_download_stats, :relative_change_week, order: "DESC NULLS LAST"
+    add_index :rubygem_download_stats, :growth_change_week, order: "DESC NULLS LAST"
 
     add_index :rubygem_download_stats, :absolute_change_month, order: "DESC NULLS LAST"
     add_index :rubygem_download_stats, :relative_change_month, order: "DESC NULLS LAST"
+    add_index :rubygem_download_stats, :growth_change_month, order: "DESC NULLS LAST"
 
     add_index :rubygem_download_stats, :absolute_change_year, order: "DESC NULLS LAST"
     add_index :rubygem_download_stats, :relative_change_year, order: "DESC NULLS LAST"
+    add_index :rubygem_download_stats, :growth_change_year, order: "DESC NULLS LAST"
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -106,6 +106,110 @@ END;
 $$;
 
 
+--
+-- Name: rubygem_stats_calculation(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.rubygem_stats_calculation() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    previous_downloads int;
+BEGIN
+    SELECT total_downloads INTO previous_downloads
+      FROM rubygem_download_stats
+      WHERE
+        rubygem_name = NEW.rubygem_name AND date = NEW.date - 7;
+
+    IF previous_downloads IS NOT NULL THEN
+      NEW.absolute_change_7_days := NEW.total_downloads - previous_downloads;
+      IF previous_downloads > 0 THEN
+        NEW.relative_change_7_days := (NEW.absolute_change_7_days * 100.0) / previous_downloads;
+      END IF;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+
+--
+-- Name: rubygem_stats_calculation_month(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.rubygem_stats_calculation_month() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    previous_downloads int;
+BEGIN
+    SELECT total_downloads INTO previous_downloads
+      FROM rubygem_download_stats
+      WHERE
+        rubygem_name = NEW.rubygem_name AND date = NEW.date - 28;
+
+    IF previous_downloads IS NOT NULL THEN
+      NEW.absolute_change_month := NEW.total_downloads - previous_downloads;
+      IF previous_downloads > 0 THEN
+        NEW.relative_change_month := ROUND((NEW.absolute_change_month * 100.0) / previous_downloads, 2);
+      END IF;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+
+--
+-- Name: rubygem_stats_calculation_week(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.rubygem_stats_calculation_week() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    previous_downloads int;
+BEGIN
+    SELECT total_downloads INTO previous_downloads
+      FROM rubygem_download_stats
+      WHERE
+        rubygem_name = NEW.rubygem_name AND date = NEW.date - 7;
+
+    IF previous_downloads IS NOT NULL THEN
+      NEW.absolute_change_week := NEW.total_downloads - previous_downloads;
+      IF previous_downloads > 0 THEN
+        NEW.relative_change_week := ROUND((NEW.absolute_change_week * 100.0) / previous_downloads, 2);
+      END IF;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+
+--
+-- Name: rubygem_stats_calculation_year(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.rubygem_stats_calculation_year() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    previous_downloads int;
+BEGIN
+    SELECT total_downloads INTO previous_downloads
+      FROM rubygem_download_stats
+      WHERE
+        rubygem_name = NEW.rubygem_name AND date = NEW.date - 364;
+
+    IF previous_downloads IS NOT NULL THEN
+      NEW.absolute_change_year := NEW.total_downloads - previous_downloads;
+      IF previous_downloads > 0 THEN
+        NEW.relative_change_year := ROUND((NEW.absolute_change_year * 100.0) / previous_downloads, 2);
+      END IF;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+
 SET default_tablespace = '';
 
 SET default_with_oids = false;
@@ -264,6 +368,12 @@ CREATE TABLE public.rubygem_download_stats (
     rubygem_name character varying NOT NULL,
     date date NOT NULL,
     total_downloads integer NOT NULL
+    absolute_change_week integer,
+    relative_change_week numeric,
+    absolute_change_month integer,
+    relative_change_month numeric,
+    absolute_change_year integer,
+    relative_change_year numeric
 );
 
 
@@ -523,6 +633,27 @@ CREATE TRIGGER projects_update_permalink_tsvector_trigger BEFORE INSERT OR UPDAT
 
 
 --
+-- Name: rubygem_download_stats rubygem_stats_calculation_month; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER rubygem_stats_calculation_month BEFORE INSERT OR UPDATE ON public.rubygem_download_stats FOR EACH ROW EXECUTE PROCEDURE public.rubygem_stats_calculation_month();
+
+
+--
+-- Name: rubygem_download_stats rubygem_stats_calculation_week; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER rubygem_stats_calculation_week BEFORE INSERT OR UPDATE ON public.rubygem_download_stats FOR EACH ROW EXECUTE PROCEDURE public.rubygem_stats_calculation_week();
+
+
+--
+-- Name: rubygem_download_stats rubygem_stats_calculation_year; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER rubygem_stats_calculation_year BEFORE INSERT OR UPDATE ON public.rubygem_download_stats FOR EACH ROW EXECUTE PROCEDURE public.rubygem_stats_calculation_year();
+
+
+--
 -- Name: categorizations fk_rails_1c87ed593b; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -599,5 +730,6 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190121165354'),
 ('20190204132920'),
 ('20190218131324');
+('20190207133425');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -107,32 +107,6 @@ $$;
 
 
 --
--- Name: rubygem_stats_calculation(); Type: FUNCTION; Schema: public; Owner: -
---
-
-CREATE FUNCTION public.rubygem_stats_calculation() RETURNS trigger
-    LANGUAGE plpgsql
-    AS $$
-DECLARE
-    previous_downloads int;
-BEGIN
-    SELECT total_downloads INTO previous_downloads
-      FROM rubygem_download_stats
-      WHERE
-        rubygem_name = NEW.rubygem_name AND date = NEW.date - 7;
-
-    IF previous_downloads IS NOT NULL THEN
-      NEW.absolute_change_7_days := NEW.total_downloads - previous_downloads;
-      IF previous_downloads > 0 THEN
-        NEW.relative_change_7_days := (NEW.absolute_change_7_days * 100.0) / previous_downloads;
-      END IF;
-    END IF;
-    RETURN NEW;
-END;
-$$;
-
-
---
 -- Name: rubygem_stats_calculation_month(); Type: FUNCTION; Schema: public; Owner: -
 --
 
@@ -146,7 +120,7 @@ BEGIN
       FROM rubygem_download_stats
       WHERE
         rubygem_name = NEW.rubygem_name AND date = NEW.date - 28;
-
+    
     IF previous_downloads IS NOT NULL THEN
       NEW.absolute_change_month := NEW.total_downloads - previous_downloads;
       IF previous_downloads > 0 THEN
@@ -172,7 +146,7 @@ BEGIN
       FROM rubygem_download_stats
       WHERE
         rubygem_name = NEW.rubygem_name AND date = NEW.date - 7;
-
+    
     IF previous_downloads IS NOT NULL THEN
       NEW.absolute_change_week := NEW.total_downloads - previous_downloads;
       IF previous_downloads > 0 THEN
@@ -198,7 +172,7 @@ BEGIN
       FROM rubygem_download_stats
       WHERE
         rubygem_name = NEW.rubygem_name AND date = NEW.date - 364;
-
+    
     IF previous_downloads IS NOT NULL THEN
       NEW.absolute_change_year := NEW.total_downloads - previous_downloads;
       IF previous_downloads > 0 THEN
@@ -367,7 +341,7 @@ CREATE TABLE public.rubygem_download_stats (
     id bigint NOT NULL,
     rubygem_name character varying NOT NULL,
     date date NOT NULL,
-    total_downloads integer NOT NULL
+    total_downloads integer NOT NULL,
     absolute_change_week integer,
     relative_change_week numeric,
     absolute_change_month integer,
@@ -591,10 +565,66 @@ CREATE UNIQUE INDEX index_projects_on_rubygem_name ON public.projects USING btre
 
 
 --
+-- Name: index_rubygem_download_stats_on_absolute_change_month; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_rubygem_download_stats_on_absolute_change_month ON public.rubygem_download_stats USING btree (absolute_change_month DESC NULLS LAST);
+
+
+--
+-- Name: index_rubygem_download_stats_on_absolute_change_week; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_rubygem_download_stats_on_absolute_change_week ON public.rubygem_download_stats USING btree (absolute_change_week DESC NULLS LAST);
+
+
+--
+-- Name: index_rubygem_download_stats_on_absolute_change_year; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_rubygem_download_stats_on_absolute_change_year ON public.rubygem_download_stats USING btree (absolute_change_year DESC NULLS LAST);
+
+
+--
+-- Name: index_rubygem_download_stats_on_date; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_rubygem_download_stats_on_date ON public.rubygem_download_stats USING btree (date);
+
+
+--
+-- Name: index_rubygem_download_stats_on_relative_change_month; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_rubygem_download_stats_on_relative_change_month ON public.rubygem_download_stats USING btree (relative_change_month DESC NULLS LAST);
+
+
+--
+-- Name: index_rubygem_download_stats_on_relative_change_week; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_rubygem_download_stats_on_relative_change_week ON public.rubygem_download_stats USING btree (relative_change_week DESC NULLS LAST);
+
+
+--
+-- Name: index_rubygem_download_stats_on_relative_change_year; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_rubygem_download_stats_on_relative_change_year ON public.rubygem_download_stats USING btree (relative_change_year DESC NULLS LAST);
+
+
+--
 -- Name: index_rubygem_download_stats_on_rubygem_name_and_date; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_rubygem_download_stats_on_rubygem_name_and_date ON public.rubygem_download_stats USING btree (rubygem_name, date);
+
+
+--
+-- Name: index_rubygem_download_stats_on_total_downloads; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_rubygem_download_stats_on_total_downloads ON public.rubygem_download_stats USING btree (total_downloads DESC NULLS LAST);
 
 
 --
@@ -729,7 +759,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190117101723'),
 ('20190121165354'),
 ('20190204132920'),
+('20190207133425'),
+('20190211104231'),
 ('20190218131324');
-('20190207133425');
 
 

--- a/spec/models/rubygem_download_stat_spec.rb
+++ b/spec/models/rubygem_download_stat_spec.rb
@@ -15,32 +15,47 @@ RSpec.describe RubygemDownloadStat, type: :model do
     expect(&do_create).to raise_error(ActiveRecord::RecordNotUnique)
   end
 
+  # rubocop:disable RSpec/ExampleLength data-heavy examples...
   describe "stats calculation" do
     it "does not calculate any stats when there is no previous record" do
       stat = rubygem.download_stats.create! date: Time.zone.today, total_downloads: 5000
       expect(stat.reload).to have_attributes(
         absolute_change_week:  nil,
         relative_change_week:  nil,
+        growth_change_week:    nil,
         absolute_change_month: nil,
         relative_change_month: nil,
+        growth_change_month:   nil,
         absolute_change_year:  nil,
-        relative_change_year:  nil
+        relative_change_year:  nil,
+        growth_change_year:    nil
       )
     end
 
-    it "calculates expected stats when there are matching previous records" do # rubocop:disable RSpec/ExampleLength
-      rubygem.download_stats.create! date: 52.weeks.ago, total_downloads: 1000
-      rubygem.download_stats.create! date: 4.weeks.ago, total_downloads: 3000
-      rubygem.download_stats.create! date: 7.days.ago, total_downloads: 5000
-      stat = rubygem.download_stats.create! date: Time.zone.today, total_downloads: 6000
+    it "calculates expected stats when there are matching previous records" do
+      {
+        104.weeks => 500, # For growth change
+        52.weeks  => 1000, # For absolute and relative change
+        8.weeks   => 2500, # For growth change
+        4.weeks   => 3000, # For absolute and relative change
+        2.weeks   => 3000, # For growth change
+        1.week    => 5000, # For absolute and relative change
+      }.each do |time, downloads|
+        rubygem.download_stats.create! date: time.ago, total_downloads: downloads
+      end
 
-      expect(stat.reload).to have_attributes(
+      current_stat = rubygem.download_stats.create! date: Time.zone.today, total_downloads: 6000
+
+      expect(current_stat.reload).to have_attributes(
         absolute_change_week:  1000,
         relative_change_week:  20.0,
+        growth_change_week:    -46.67,
         absolute_change_month: 3000,
         relative_change_month: 100.0,
+        growth_change_month:   80.0,
         absolute_change_year:  5000,
-        relative_change_year:  500.0
+        relative_change_year:  500.0,
+        growth_change_year:    400.0
       )
     end
 
@@ -53,4 +68,5 @@ RSpec.describe RubygemDownloadStat, type: :model do
       )
     end
   end
+  # rubocop:enable RSpec/ExampleLength data-heavy examples...
 end

--- a/spec/models/rubygem_download_stat_spec.rb
+++ b/spec/models/rubygem_download_stat_spec.rb
@@ -3,8 +3,9 @@
 require "rails_helper"
 
 RSpec.describe RubygemDownloadStat, type: :model do
+  let(:rubygem) { Factories.rubygem "example" }
+
   it "has a unique index on rubygem name and date" do
-    rubygem = Factories.rubygem "example"
     do_create = lambda {
       rubygem.download_stats.create! total_downloads: 2000, date: Time.zone.today
     }
@@ -12,5 +13,44 @@ RSpec.describe RubygemDownloadStat, type: :model do
     do_create.call
 
     expect(&do_create).to raise_error(ActiveRecord::RecordNotUnique)
+  end
+
+  describe "stats calculation" do
+    it "does not calculate any stats when there is no previous record" do
+      stat = rubygem.download_stats.create! date: Time.zone.today, total_downloads: 5000
+      expect(stat.reload).to have_attributes(
+        absolute_change_week:  nil,
+        relative_change_week:  nil,
+        absolute_change_month: nil,
+        relative_change_month: nil,
+        absolute_change_year:  nil,
+        relative_change_year:  nil
+      )
+    end
+
+    it "calculates expected stats when there are matching previous records" do # rubocop:disable RSpec/ExampleLength
+      rubygem.download_stats.create! date: 52.weeks.ago, total_downloads: 1000
+      rubygem.download_stats.create! date: 4.weeks.ago, total_downloads: 3000
+      rubygem.download_stats.create! date: 7.days.ago, total_downloads: 5000
+      stat = rubygem.download_stats.create! date: Time.zone.today, total_downloads: 6000
+
+      expect(stat.reload).to have_attributes(
+        absolute_change_week:  1000,
+        relative_change_week:  20.0,
+        absolute_change_month: 3000,
+        relative_change_month: 100.0,
+        absolute_change_year:  5000,
+        relative_change_year:  500.0
+      )
+    end
+
+    it "does not calculate relative changes when the previous downloads were 0" do
+      rubygem.download_stats.create! date: 7.days.ago, total_downloads: 0
+      stat = rubygem.download_stats.create! date: Time.zone.today, total_downloads: 1000
+      expect(stat.reload).to have_attributes(
+        absolute_change_week: 1000,
+        relative_change_week: nil
+      )
+    end
   end
 end


### PR DESCRIPTION
This follows up on #412 and adds additional stats to the absolute gem download numbers, calculated via postgresql triggers:

* `absolute_change_(week|month|year)`: The total number of downloads just in that timeframe (if previous record is there)
* `relative_change_(week|month|year)`: The percentage of all-time total downloads the timeframe's absolute downloads constitute
* `growth_change_(week|month|year)`: The difference between current relative change and the previous one in the timeframe

Those will be used for both project download history charts as well as trending project detection in the near future.

The actual historical data is also now restored into production, the process went like this:

* Recover historical daily download data from legacy Ruby Toolbox backups (starting late 2019) and via the http://bestgems.org/ API (starting in early 2013) 
* Close all daily gaps in the data set by interpolating from the surrounding present values (assuming a linear growth on multi-day gaps). The bestgems.org did not need much of this as it's mostly daily, but i.e. Ruby Toolbox used to only pull gem stats for uncategorized gems every 7-14 days, so there were bigger gaps there
* Dropped all data except sundays. Just like in #412, for the Ruby Toolbox weekly data is sufficient and the reduction to 1/7th of the data amount brings significant benefits when juggling the data
* Merged local dataset with data already in production from #412, wiped production stats database table
* Exported the local dataset from postgres using `pg_dump` and piped it into `heroku pg:psql`, feeding it back into production

The final step to actually make this data here will be to invoke `UPDATE rubygem_download_stats SET id = id` on the production db post-deploy. Since the triggers are order-dependent, but the update statement does not have an explicit date-based order the command needs to run multiple times until all data is in place, and going forward it should all work smoothly since the historical data is in place.