### PR TITLE
Drop timestamp columns from download stats

### DIFF
--- a/app/jobs/rubygem_downloads_persistence_job.rb
+++ b/app/jobs/rubygem_downloads_persistence_job.rb
@@ -16,13 +16,11 @@ class RubygemDownloadsPersistenceJob < ApplicationJob
 
     upsert_sql = <<~SQL
       INSERT INTO
-        rubygem_download_stats (rubygem_name, total_downloads, date, created_at, updated_at)
+        rubygem_download_stats (rubygem_name, total_downloads, date)
         SELECT
           name AS rubygem_name,
           downloads AS total_downloads,
-          DATE '#{date}' as date,
-          current_timestamp as created_at,
-          current_timestamp as updated_at
+          DATE '#{date}' as date
         FROM   rubygems
 
       ON CONFLICT (rubygem_name, date) DO UPDATE

--- a/db/migrate/20190218131324_drop_download_stats_table_timestamps.rb
+++ b/db/migrate/20190218131324_drop_download_stats_table_timestamps.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class DropDownloadStatsTableTimestamps < ActiveRecord::Migration[5.2]
+  def up
+    change_table :rubygem_download_stats, bulk: true do |t|
+      t.remove :created_at, :updated_at
+    end
+  end
+
+  def down
+    change_table :rubygem_download_stats, bulk: true, &:timestamps
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -263,9 +263,7 @@ CREATE TABLE public.rubygem_download_stats (
     id bigint NOT NULL,
     rubygem_name character varying NOT NULL,
     date date NOT NULL,
-    total_downloads integer NOT NULL,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    total_downloads integer NOT NULL
 );
 
 
@@ -599,6 +597,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190117100816'),
 ('20190117101723'),
 ('20190121165354'),
-('20190204132920');
+('20190204132920'),
+('20190218131324');
 
 


### PR DESCRIPTION
The timestamps do not provide much value on this table, and due to the large amount of records here creates a lot of extra storage needs, so dropping the timestamps.