### PR TITLE
Reduce pre-calculated gem stats to monthly

### DIFF
--- a/db/migrate/20190220133053_simplify_gem_trends_stats.rb
+++ b/db/migrate/20190220133053_simplify_gem_trends_stats.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+#
+# See https://github.com/rubytoolbox/rubytoolbox/pull/432 for more details
+#
+class SimplifyGemTrendsStats < ActiveRecord::Migration[5.2]
+  def up
+    drop_trigger :rubygem_stats_calculation_week, :rubygem_download_stats
+    drop_trigger :rubygem_stats_calculation_year, :rubygem_download_stats
+
+    change_table :rubygem_download_stats, bulk: true do |t|
+      t.remove :absolute_change_week,
+               :relative_change_week,
+               :growth_change_week,
+               :absolute_change_year,
+               :relative_change_year,
+               :growth_change_year
+    end
+  end
+
+  def down
+    # It's actually reversible, but you'd have to figure out the `up` path from
+    # 20190207133425, and it's not worth the hassle ;)
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -137,68 +137,6 @@ END;
 $$;
 
 
---
--- Name: rubygem_stats_calculation_week(); Type: FUNCTION; Schema: public; Owner: -
---
-
-CREATE FUNCTION public.rubygem_stats_calculation_week() RETURNS trigger
-    LANGUAGE plpgsql
-    AS $$
-DECLARE
-    previous_downloads int;
-    previous_relative_change decimal;
-BEGIN
-    SELECT total_downloads, relative_change_week INTO previous_downloads, previous_relative_change
-      FROM rubygem_download_stats
-      WHERE
-        rubygem_name = NEW.rubygem_name AND date = NEW.date - 7;
-    
-    IF previous_downloads IS NOT NULL THEN
-      NEW.absolute_change_week := NEW.total_downloads - previous_downloads;
-      IF previous_downloads > 0 THEN
-        NEW.relative_change_week := ROUND((NEW.absolute_change_week * 100.0) / previous_downloads, 2);
-    
-        IF previous_relative_change IS NOT NULL THEN
-          NEW.growth_change_week := NEW.relative_change_week - previous_relative_change;
-        END IF;
-      END IF;
-    END IF;
-    RETURN NEW;
-END;
-$$;
-
-
---
--- Name: rubygem_stats_calculation_year(); Type: FUNCTION; Schema: public; Owner: -
---
-
-CREATE FUNCTION public.rubygem_stats_calculation_year() RETURNS trigger
-    LANGUAGE plpgsql
-    AS $$
-DECLARE
-    previous_downloads int;
-    previous_relative_change decimal;
-BEGIN
-    SELECT total_downloads, relative_change_year INTO previous_downloads, previous_relative_change
-      FROM rubygem_download_stats
-      WHERE
-        rubygem_name = NEW.rubygem_name AND date = NEW.date - 364;
-    
-    IF previous_downloads IS NOT NULL THEN
-      NEW.absolute_change_year := NEW.total_downloads - previous_downloads;
-      IF previous_downloads > 0 THEN
-        NEW.relative_change_year := ROUND((NEW.absolute_change_year * 100.0) / previous_downloads, 2);
-    
-        IF previous_relative_change IS NOT NULL THEN
-          NEW.growth_change_year := NEW.relative_change_year - previous_relative_change;
-        END IF;
-      END IF;
-    END IF;
-    RETURN NEW;
-END;
-$$;
-
-
 SET default_tablespace = '';
 
 SET default_with_oids = false;
@@ -357,15 +295,9 @@ CREATE TABLE public.rubygem_download_stats (
     rubygem_name character varying NOT NULL,
     date date NOT NULL,
     total_downloads integer NOT NULL,
-    absolute_change_week integer,
-    relative_change_week numeric,
-    growth_change_week numeric,
     absolute_change_month integer,
     relative_change_month numeric,
-    growth_change_month numeric,
-    absolute_change_year integer,
-    relative_change_year numeric,
-    growth_change_year numeric
+    growth_change_month numeric
 );
 
 
@@ -590,20 +522,6 @@ CREATE INDEX index_rubygem_download_stats_on_absolute_change_month ON public.rub
 
 
 --
--- Name: index_rubygem_download_stats_on_absolute_change_week; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_rubygem_download_stats_on_absolute_change_week ON public.rubygem_download_stats USING btree (absolute_change_week DESC NULLS LAST);
-
-
---
--- Name: index_rubygem_download_stats_on_absolute_change_year; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_rubygem_download_stats_on_absolute_change_year ON public.rubygem_download_stats USING btree (absolute_change_year DESC NULLS LAST);
-
-
---
 -- Name: index_rubygem_download_stats_on_date; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -618,38 +536,10 @@ CREATE INDEX index_rubygem_download_stats_on_growth_change_month ON public.rubyg
 
 
 --
--- Name: index_rubygem_download_stats_on_growth_change_week; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_rubygem_download_stats_on_growth_change_week ON public.rubygem_download_stats USING btree (growth_change_week DESC NULLS LAST);
-
-
---
--- Name: index_rubygem_download_stats_on_growth_change_year; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_rubygem_download_stats_on_growth_change_year ON public.rubygem_download_stats USING btree (growth_change_year DESC NULLS LAST);
-
-
---
 -- Name: index_rubygem_download_stats_on_relative_change_month; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_rubygem_download_stats_on_relative_change_month ON public.rubygem_download_stats USING btree (relative_change_month DESC NULLS LAST);
-
-
---
--- Name: index_rubygem_download_stats_on_relative_change_week; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_rubygem_download_stats_on_relative_change_week ON public.rubygem_download_stats USING btree (relative_change_week DESC NULLS LAST);
-
-
---
--- Name: index_rubygem_download_stats_on_relative_change_year; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_rubygem_download_stats_on_relative_change_year ON public.rubygem_download_stats USING btree (relative_change_year DESC NULLS LAST);
 
 
 --
@@ -706,20 +596,6 @@ CREATE TRIGGER projects_update_permalink_tsvector_trigger BEFORE INSERT OR UPDAT
 --
 
 CREATE TRIGGER rubygem_stats_calculation_month BEFORE INSERT OR UPDATE ON public.rubygem_download_stats FOR EACH ROW EXECUTE PROCEDURE public.rubygem_stats_calculation_month();
-
-
---
--- Name: rubygem_download_stats rubygem_stats_calculation_week; Type: TRIGGER; Schema: public; Owner: -
---
-
-CREATE TRIGGER rubygem_stats_calculation_week BEFORE INSERT OR UPDATE ON public.rubygem_download_stats FOR EACH ROW EXECUTE PROCEDURE public.rubygem_stats_calculation_week();
-
-
---
--- Name: rubygem_download_stats rubygem_stats_calculation_year; Type: TRIGGER; Schema: public; Owner: -
---
-
-CREATE TRIGGER rubygem_stats_calculation_year BEFORE INSERT OR UPDATE ON public.rubygem_download_stats FOR EACH ROW EXECUTE PROCEDURE public.rubygem_stats_calculation_year();
 
 
 --
@@ -800,6 +676,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190204132920'),
 ('20190207133425'),
 ('20190211104231'),
-('20190218131324');
+('20190218131324'),
+('20190220133053');
 
 

--- a/spec/models/rubygem_download_stat_spec.rb
+++ b/spec/models/rubygem_download_stat_spec.rb
@@ -20,15 +20,9 @@ RSpec.describe RubygemDownloadStat, type: :model do
     it "does not calculate any stats when there is no previous record" do
       stat = rubygem.download_stats.create! date: Time.zone.today, total_downloads: 5000
       expect(stat.reload).to have_attributes(
-        absolute_change_week:  nil,
-        relative_change_week:  nil,
-        growth_change_week:    nil,
         absolute_change_month: nil,
         relative_change_month: nil,
-        growth_change_month:   nil,
-        absolute_change_year:  nil,
-        relative_change_year:  nil,
-        growth_change_year:    nil
+        growth_change_month:   nil
       )
     end
 
@@ -47,24 +41,18 @@ RSpec.describe RubygemDownloadStat, type: :model do
       current_stat = rubygem.download_stats.create! date: Time.zone.today, total_downloads: 6000
 
       expect(current_stat.reload).to have_attributes(
-        absolute_change_week:  1000,
-        relative_change_week:  20.0,
-        growth_change_week:    -46.67,
         absolute_change_month: 3000,
         relative_change_month: 100.0,
-        growth_change_month:   80.0,
-        absolute_change_year:  5000,
-        relative_change_year:  500.0,
-        growth_change_year:    400.0
+        growth_change_month:   80.0
       )
     end
 
     it "does not calculate relative changes when the previous downloads were 0" do
-      rubygem.download_stats.create! date: 7.days.ago, total_downloads: 0
+      rubygem.download_stats.create! date: 4.weeks.ago, total_downloads: 0
       stat = rubygem.download_stats.create! date: Time.zone.today, total_downloads: 1000
       expect(stat.reload).to have_attributes(
-        absolute_change_week: 1000,
-        relative_change_week: nil
+        absolute_change_month: 1000,
+        relative_change_month: nil
       )
     end
   end


### PR DESCRIPTION
Looks like I tried to solve too many problems at once via #424 by generating data that might eventually become useful upfront. Turns out populating the db with the historical data is putting it over capacity and just takes ages. Also, the size of https://data.ruby-toolbox.com data dumps will grow significantly, for no immediate benefit.

I was hoping to put up separate weekly/monthly/yearly trending projects up right from the start, but this is beginning to consume too much time and effort, so let's go back to keeping things pragmatic and just go with the monthly option for now (which is also used in #428), it can always be improved further later on.