### PR TITLE
Remove unnecessary RSpec configuration option

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -109,21 +109,6 @@ RSpec.configure do |config|
     Sidekiq::Testing.fake!
   end
 
-  # RSpec Rails can automatically mix in different behaviours to your tests
-  # based on their file location, for example enabling you to call `get` and
-  # `post` in specs under `spec/controllers`.
-  #
-  # You can disable this behaviour by removing the line below, and instead
-  # explicitly tag your specs with their type, e.g.:
-  #
-  #     RSpec.describe UsersController, :type => :controller do
-  #       # ...
-  #     end
-  #
-  # The different available types are documented in the features, such as in
-  # https://relishapp.com/rspec/rspec-rails/docs
-  config.infer_spec_type_from_file_location!
-
   # Filter lines from Rails gems in backtraces.
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:


### PR DESCRIPTION
The tests are explicit about their type, so there is no need to infer it.