### PR TITLE
Move retriable gem to `test` Bundler group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,8 +62,6 @@ gem "sidekiq"
 gem "redcarpet"
 gem "slim-rails"
 
-gem "retriable"
-
 # Shorter request logs
 gem "lograge"
 # Needed for logstash json_event formatter for lograge
@@ -102,6 +100,8 @@ group :test do
   gem "feedjira"
 
   gem "db-query-matchers"
+
+  gem "retriable"
 
   gem "timecop"
 


### PR DESCRIPTION
It seems this only only referenced from `spec/support/helpers/feature_spec_helpers.rb`.