### PR TITLE
Remove unused Timecop gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,8 +103,6 @@ group :test do
 
   gem "db-query-matchers"
 
-  gem "timecop"
-
   gem "rspec-retry"
   gem "rspec_junit_formatter"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -368,7 +368,6 @@ GEM
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.8)
-    timecop (0.9.1)
     turbolinks (5.2.0)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
@@ -454,7 +453,6 @@ DEPENDENCIES
   slim-rails
   spring
   spring-watcher-listen (~> 2.0.0)
-  timecop
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)


### PR DESCRIPTION
It seems there are no references to this so it should be safe to remove.