### PR TITLE
Revert "Remove unused Timecop gem"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,6 +103,8 @@ group :test do
 
   gem "db-query-matchers"
 
+  gem "timecop"
+
   gem "rspec-retry"
   gem "rspec_junit_formatter"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -372,6 +372,7 @@ GEM
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.8)
+    timecop (0.9.1)
     turbolinks (5.2.0)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
@@ -458,6 +459,7 @@ DEPENDENCIES
   slim-rails
   spring
   spring-watcher-listen (~> 2.0.0)
+  timecop
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)


### PR DESCRIPTION
Reverts rubytoolbox/rubytoolbox#437

Actually there is a test that uses it :boom: 