### PR TITLE
Disable landing page stats temporarily, the counts are slow to calculate

### DIFF
--- a/app/views/welcome/home.html.slim
+++ b/app/views/welcome/home.html.slim
@@ -62,8 +62,8 @@ section.section: .container: .landing-features
 
 - if @featured_categories.any?
   section.section: .container
-    - description = t(:stats, scope: :startpage, projects_with_categories: @stats.projects_with_categories_count, categories: @stats.categories_count, rubygems: @stats.rubygems_count)
-    = section_heading "Popular Categories", description: description do
+    / - description = t(:stats, scope: :startpage, projects_with_categories: @stats.projects_with_categories_count, categories: @stats.categories_count, rubygems: @stats.rubygems_count)
+    = section_heading "Popular Categories" do
       a.button href=categories_path
         span.icon: i.fa.fa-bars
         span Browse all categories


### PR DESCRIPTION
For some reason the production db takes ages to produce the simple counts used here (works just fine on the same dataset on my local machine), but I don't have the time right now to investigate. Appsignal does report however that the queries take a lot of time, so let's just drop this tiny sentence for now ("We list 2500 projects in 190 categories as well as 150300 Rubygems in total. Here are a few categories containing very popular Ruby libraries:") and investigate once I have time to look into it more closely.