### PR TITLE
New landing page section: Recently added categories

### DIFF
--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -51,6 +51,7 @@ $widescreen: 1152px + (2 * $gap)
 $navbar-breakpoint: $widescreen
 
 @import "bulma/bulma"
+@import "bulma-tooltip/dist/css/bulma-tooltip"
 @import "components/**/*"
 
 .border-bottom

--- a/app/assets/stylesheets/components/category_card.sass
+++ b/app/assets/stylesheets/components/category_card.sass
@@ -1,6 +1,8 @@
 .category-cards
   &.four
     @extend .column, .is-half, .is-one-quarter-desktop, .is-flex
+  &.three
+    @extend .column, .is-half, .is-one-third-desktop, .is-flex
   &.two
     @extend .column, .is-full, .is-half-desktop, .is-flex
 

--- a/app/controllers/trends_controller.rb
+++ b/app/controllers/trends_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class TrendsController < ApplicationController
+  def index
+    latest_date = RubygemDownloadStat.maximum(:date)
+    if latest_date
+      redirect_to action: :show, id: latest_date
+    else
+      # This would normally only happen on a local, empty database
+      render plain: "No stats data is available, please seed the database"
+    end
+  end
+
+  def show
+    @date = Date.parse(params[:id]) # parse & validate it! redirect to next matching
+
+    @trends = RubygemDownloadStat
+              .where(date: @date)
+              .with_associations
+              .trending
+              .limit(48)
+  end
+end

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -3,6 +3,7 @@
 class WelcomeController < ApplicationController
   def home
     @featured_categories = Category.featured
+    @new_categories = Category.recently_added
     @stats = Stats.new
     @recent_posts = BlogController::BLOG.recent_posts.presence
   end

--- a/app/helpers/component_helpers.rb
+++ b/app/helpers/component_helpers.rb
@@ -71,8 +71,9 @@ module ComponentHelpers
     render "components/project_comparison", projects: projects
   end
 
-  def section_heading(title, description: nil, &block)
-    render "components/section_heading", title: title, description: description, &block
+  def section_heading(title, description: nil, help_path: nil, &block)
+    help_page = docs.find help_path
+    render "components/section_heading", title: title, description: description, help_page: help_page, &block
   end
 
   def project_display_picker(display_mode)

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -19,6 +19,7 @@ class Category < ApplicationRecord
 
   scope :by_rank, -> { where.not(rank: nil).order(rank: :asc) }
   scope :featured, -> { by_rank.limit(16).includes(:projects) }
+  scope :recently_added, -> { order(created_at: :desc).limit(4).includes(:projects) }
 
   include PgSearch
   pg_search_scope :search_scope,

--- a/app/views/components/_section_heading.html.slim
+++ b/app/views/components/_section_heading.html.slim
@@ -4,6 +4,10 @@
       .level-item
         h3.is-size-4
           span= title
+      - if help_page
+        .level_item
+          a.button href=page_path(help_page.id) title=help_page.title
+            span.icon: i.fa.fa-question-circle
     .level-right
       .level-item= yield
 

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -73,6 +73,11 @@ html.has-navbar-fixed-top lang="en"
                 span.icon: i.fa.fa-arrows-h
                 span Compare
 
+            a.navbar-item href=trends_path class=active_when(controller: :trends)
+              .wrap
+                span.icon: i.fa.fa-line-chart
+                span Trends
+
             a.navbar-item href=page_path("docs/index") class=active_when(controller: :pages)
               .wrap
                 span.icon: i.fa.fa-life-ring
@@ -97,6 +102,7 @@ html.has-navbar-fixed-top lang="en"
             ul
               li= link_to "Home", root_path
               li= link_to "Categories", categories_path
+              li= link_to "Trends", trends_path
               li= link_to "Documentation", page_path("docs/index")
               li= link_to "News", blog_index_path
               li= link_to "Search", search_path

--- a/app/views/pages/components/section_heading.html.slim
+++ b/app/views/pages/components/section_heading.html.slim
@@ -5,7 +5,8 @@
 
 = component_example "Section Headings" do
   = section_heading "Some title"
-  = section_heading "Some title", description: "Some optional description"
+  = section_heading "Can reference help pages", help_path: "docs/features/categories"
+  = section_heading "Some title", description: "Some optional description", help_path: "docs/features/categories"
   = section_heading "Some title", description: "Some optional description" do
     a.button href="#"
       span.icon: i.fa.fa-diamond

--- a/app/views/trends/show.html.slim
+++ b/app/views/trends/show.html.slim
@@ -1,0 +1,32 @@
+- content_for :title, "Trending Rubygems for #{l @date, format: :long}"
+
+.hero
+  section.section: .container
+    h2= content_for :title
+
+section.section: .container
+  .columns.is-multiline
+    - @trends.each do |stat|
+      .category-cards.three
+        .category-card
+          header.card-header
+            a.card-header-icon href=File.join("/projects", stat.project.permalink)
+              span.icon: i.fa.fa-diamond
+            p.card-header-title
+              a href=File.join("/projects", stat.project.permalink)
+                = stat.project.permalink
+            .card-header-icon= small_health_indicator stat.project
+
+          .card-content
+            small.content: strong= stat.project.description
+
+          footer.card-footer
+            .card-footer-item: small
+              span.icon: i.fa.fa-download
+              strong= number_with_delimiter stat.absolute_change_month
+            .card-footer-item: small: strong
+              span.icon: i.fa.fa-arrow-up
+              strong= number_with_delimiter(stat.relative_change_month) + "%"
+            .card-footer-item: small: strong
+              span.icon: i.fa.fa-line-chart
+              strong= number_with_delimiter(stat.growth_change_month) + "%"

--- a/app/views/trends/show.html.slim
+++ b/app/views/trends/show.html.slim
@@ -21,12 +21,15 @@ section.section: .container
             small.content: strong= stat.project.description
 
           footer.card-footer
-            .card-footer-item: small
-              span.icon: i.fa.fa-download
-              strong= number_with_delimiter stat.absolute_change_month
-            .card-footer-item: small: strong
-              span.icon: i.fa.fa-arrow-up
-              strong= number_with_delimiter(stat.relative_change_month) + "%"
-            .card-footer-item: small: strong
-              span.icon: i.fa.fa-line-chart
-              strong= number_with_delimiter(stat.growth_change_month) + "%"
+            .card-footer-item.tooltip.is-tooltip-bottom data-tooltip="Total downloads in past 4 weeks"
+              small
+                span.icon: i.fa.fa-download
+                strong= number_with_delimiter stat.absolute_change_month
+            .card-footer-item.tooltip.is-tooltip-bottom data-tooltip="Increase relative to all time downloads in past 4 weeks"
+              small
+                span.icon: i.fa.fa-arrow-up
+                strong= number_with_delimiter(stat.relative_change_month) + "%"
+            .card-footer-item.tooltip.is-tooltip-bottom data-tooltip="Month-over-month change in relative downloads growth rate"
+              small
+                span.icon: i.fa.fa-line-chart
+                strong= number_with_delimiter(stat.growth_change_month) + "%"

--- a/app/views/welcome/home.html.slim
+++ b/app/views/welcome/home.html.slim
@@ -61,7 +61,7 @@ section.section: .container: .landing-features
         This gives you a quick overview of the health of a project.
 
 - if @featured_categories.any?
-  section.section: .container
+  section.section.popular-categories: .container
     / - description = t(:stats, scope: :startpage, projects_with_categories: @stats.projects_with_categories_count, categories: @stats.categories_count, rubygems: @stats.rubygems_count)
     = section_heading "Popular Categories" do
       a.button href=categories_path
@@ -70,5 +70,17 @@ section.section: .container: .landing-features
 
     .columns.is-multiline
       - @featured_categories.each do |category|
+        .category-cards.four
+          = category_card category
+
+- if @new_categories.any?
+  section.section.recently-added-categories: .container
+    = section_heading "Recently Added Categories"
+      a.button href=categories_path
+        span.icon: i.fa.fa-bars
+        span Browse all categories
+
+    .columns.is-multiline
+      - @new_categories.each do |category|
         .category-cards.four
           = category_card category

--- a/app/views/welcome/home.html.slim
+++ b/app/views/welcome/home.html.slim
@@ -63,7 +63,7 @@ section.section: .container: .landing-features
 - if @featured_categories.any?
   section.section.popular-categories: .container
     / - description = t(:stats, scope: :startpage, projects_with_categories: @stats.projects_with_categories_count, categories: @stats.categories_count, rubygems: @stats.rubygems_count)
-    = section_heading "Popular Categories" do
+    = section_heading "Popular Categories", help_path: "docs/features/categories" do
       a.button href=categories_path
         span.icon: i.fa.fa-bars
         span Browse all categories
@@ -75,7 +75,7 @@ section.section: .container: .landing-features
 
 - if @new_categories.any?
   section.section.recently-added-categories: .container
-    = section_heading "Recently Added Categories"
+    = section_heading "Recently Added Categories", help_path: "docs/features/categories"
       a.button href=categories_path
         span.icon: i.fa.fa-bars
         span Browse all categories

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,17 +5,18 @@ require "sidekiq/web"
 
 # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 Rails.application.routes.draw do
+  resources :blog, only: %i[index show], constraints: { id: /[^\.]+/ }
   resources :categories, only: %i[index show]
-  resources :projects, only: %i[show], constraints: { id: Patterns::ROUTE_PATTERN } do
-  end
+
+  resources :projects, only: %i[show], constraints: { id: Patterns::ROUTE_PATTERN }
   get "compare(/:id)", to: "comparisons#show", constraints: { id: /.*/ }, as: :comparison
+  resources :trends, only: %i[index show]
 
   resource :search, only: %i[show] do
     collection do
       get :by_name
     end
   end
-  resources :blog, only: %i[index show], constraints: { id: /[^\.]+/ }
 
   namespace :webhooks do
     post "github", to: "github#create", defaults: { formats: :json }

--- a/db/migrate/20190226090240_add_index_on_categories_created_at.rb
+++ b/db/migrate/20190226090240_add_index_on_categories_created_at.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIndexOnCategoriesCreatedAt < ActiveRecord::Migration[5.2]
+  def change
+    add_index :categories, :created_at
+  end
+end

--- a/db/migrate/20190226090403_add_categories_rank_index.rb
+++ b/db/migrate/20190226090403_add_categories_rank_index.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddCategoriesRankIndex < ActiveRecord::Migration[5.2]
+  def change
+    add_index :categories, :rank
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -417,6 +417,13 @@ CREATE INDEX index_categories_on_category_group_permalink ON public.categories U
 
 
 --
+-- Name: index_categories_on_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_categories_on_created_at ON public.categories USING btree (created_at);
+
+
+--
 -- Name: index_categories_on_description_tsvector; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -677,6 +684,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190207133425'),
 ('20190211104231'),
 ('20190218131324'),
-('20190220133053');
+('20190220133053'),
+('20190226090240');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -445,6 +445,13 @@ CREATE UNIQUE INDEX index_categories_on_permalink ON public.categories USING btr
 
 
 --
+-- Name: index_categories_on_rank; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_categories_on_rank ON public.categories USING btree (rank);
+
+
+--
 -- Name: index_categorizations_on_category_permalink; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -685,6 +692,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190211104231'),
 ('20190218131324'),
 ('20190220133053'),
-('20190226090240');
+('20190226090240'),
+('20190226090403');
 
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": false,
   "dependencies": {
     "bulma": "^0.7.0",
+    "bulma-tooltip": "^2.0.2",
     "chart.js": "^2.7.3",
     "headroom.js": "^0.9.4",
     "javascript-autocomplete": "^1.0.3"

--- a/spec/controllers/trends_controller_spec.rb
+++ b/spec/controllers/trends_controller_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TrendsController, type: :controller do
+  render_views
+
+  describe "GET index" do
+    it "redirects to show for maximum available stat date" do
+      allow(RubygemDownloadStat).to receive(:maximum).with(:date).and_return(Date.new(2019, 1, 2))
+      get :index
+      expect(response).to redirect_to(action: :show, id: "2019-01-02")
+    end
+
+    it "renders a text message when no data is in the database" do
+      allow(RubygemDownloadStat).to receive(:maximum).with(:date)
+      get :index
+      expect(response.body).to be == "No stats data is available, please seed the database"
+    end
+  end
+
+  describe "GET show" do
+    def do_request
+      get :show, params: { id: "2019-02-24" }
+    end
+
+    it "renders show template" do
+      expect(do_request).to render_template :show
+    end
+  end
+end

--- a/spec/controllers/welcome_controller_spec.rb
+++ b/spec/controllers/welcome_controller_spec.rb
@@ -23,6 +23,13 @@ RSpec.describe WelcomeController, type: :controller do
       expect(assigns(:featured_categories)).to be collection
     end
 
+    it "assigns new categories" do
+      collection = Category.limit(3)
+      allow(Category).to receive(:recently_added).and_return(collection)
+      do_request
+      expect(assigns(:new_categories)).to be collection
+    end
+
     it "assigns a Stats instance" do
       stats = instance_double Stats
       allow(Stats).to receive(:new).and_return(stats)

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -56,6 +56,15 @@ RSpec.describe Category, type: :model do
     end
   end
 
+  describe ".recently_added" do
+    it "returns 4 newest categories" do
+      5.times do |i|
+        Category.create! permalink: (i + 1).to_s, name: (i + 1).to_s, category_group: group, created_at: i.days.ago
+      end
+      expect(Category.recently_added.pluck(:permalink)).to be == %w[1 2 3 4]
+    end
+  end
+
   describe "#catalog_show_url" do
     it "is the url where the category definition can be seen on github" do
       expected = "https://github.com/rubytoolbox/catalog/tree/master/catalog/unimportant/mocking.yml"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+bulma-tooltip@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/bulma-tooltip/-/bulma-tooltip-2.0.2.tgz#cf0bf5ad2dc75492cbcbd4816e1a005314dc90ac"
+  integrity sha512-xsqWeWV7tsUn3uH04SqJeP7/CyC1RaDVIyVzr4/sIO3friIIOi7L6jc5g7qUwDxuBQl72yH/yRPuefpXoQ4hWg==
+
 bulma@^0.7.0:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/bulma/-/bulma-0.7.2.tgz#8e944377b74c7926558830d38d8e19eaf49f5fb6"


### PR DESCRIPTION
This adds a new section to the landing page, featuring the 4 most recently added categories. I also added a little help badge referencing the newly added categories docs page (via #444) from the headings

![screenshot from 2019-02-26 09-59-17](https://user-images.githubusercontent.com/13972/53400105-75cceb00-39ad-11e9-8a12-333c770f996b.png)
