### PR TITLE
Fix flaky tests

### DIFF
--- a/spec/features/styleguide_spec.rb
+++ b/spec/features/styleguide_spec.rb
@@ -12,12 +12,13 @@ RSpec.describe "Styleguide Display", type: :feature do
     expect(page).to have_text "Ruby Toolbox UI Components Styleguide"
     expect(page).to have_text "Components Overview"
 
-    page_links = page.find_all(".component-list a")
+    page_links = page.find_all(".component-list a").map { |a| [a["href"], a.text] }.to_h
     expect(page_links.size).to be > 0
 
-    page_links.each do |link|
-      visit link["href"]
-      expect(page).to have_text link.text
+    page_links.each do |href, text|
+      visit "/pages/components"
+      visit href
+      expect(page).to have_text text
     end
   end
 end

--- a/spec/jobs/rubygem_trends_job_spec.rb
+++ b/spec/jobs/rubygem_trends_job_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe RubygemTrendsJob, type: :job do
       Factories.rubygem_trend "a", date: 1.week.ago, position: 1
 
       expect { do_perform }
-        .to change { Rubygem::Trend.select(:date).distinct.pluck(:date) }
+        .to change { Rubygem::Trend.select(:date).distinct.order(date: :desc).pluck(:date) }
         .from([Time.current.to_date, 1.week.ago.to_date])
         .to([1.week.ago.to_date])
     end


### PR DESCRIPTION
* Fixes a flaky test that was only failing on sundays, coming from #449 
* Fixes a recently introduced failure in the styleguide check that's iterating over a list of dom nodes, and apparently capybara does not like that anymore since the recent upgrade via #463 