### PR TITLE
Dedicated gems and repo remote fetch timestamp

### DIFF
--- a/app/jobs/github_repo_update_job.rb
+++ b/app/jobs/github_repo_update_job.rb
@@ -56,7 +56,7 @@ class GithubRepoUpdateJob < ApplicationJob
   def store_repo(path:, info:)
     GithubRepo.find_or_initialize_by(path: path.downcase).tap do |repo|
       # Set updated at to ensure we flag what we've pulled
-      repo.updated_at = Time.current.utc
+      repo.updated_at = repo.fetched_at = Time.current.utc
       repo.update! mapped_attributes(info)
       trigger_project_updates repo.projects.pluck(:permalink)
     end

--- a/app/jobs/rubygem_update_job.rb
+++ b/app/jobs/rubygem_update_job.rb
@@ -19,7 +19,7 @@ class RubygemUpdateJob < ApplicationJob
     if info
       Rubygem.find_or_initialize_by(name: name).tap do |gem|
         # Set updated at to ensure we flag what we've pulled
-        gem.updated_at = Time.current.utc
+        gem.updated_at = gem.fetched_at = Time.current.utc
         gem.update! mapped_info.merge(extra_attributes)
       end
       ProjectUpdateJob.perform_async name

--- a/db/migrate/20190508190527_add_fetched_at_timestamps.rb
+++ b/db/migrate/20190508190527_add_fetched_at_timestamps.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddFetchedAtTimestamps < ActiveRecord::Migration[5.2]
+  def change
+    add_column :github_repos, :fetched_at, :datetime
+    add_column :rubygems, :fetched_at, :datetime
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -261,7 +261,8 @@ CREATE TABLE public.github_repos (
     total_issues_count integer,
     total_pull_requests_count integer,
     issue_closure_rate numeric(5,2) DEFAULT NULL::numeric,
-    pull_request_acceptance_rate numeric(5,2) DEFAULT NULL::numeric
+    pull_request_acceptance_rate numeric(5,2) DEFAULT NULL::numeric,
+    fetched_at timestamp without time zone
 );
 
 
@@ -377,7 +378,8 @@ CREATE TABLE public.rubygems (
     first_release_on date,
     latest_release_on date,
     releases_count integer,
-    reverse_dependencies_count integer
+    reverse_dependencies_count integer,
+    fetched_at timestamp without time zone
 );
 
 
@@ -781,6 +783,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190226090240'),
 ('20190226090403'),
 ('20190228101125'),
-('20190228102103');
+('20190228102103'),
+('20190508190527');
 
 

--- a/spec/integration/github_repo_update_spec.rb
+++ b/spec/integration/github_repo_update_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe GithubRepoUpdateJob, :real_http do
         expect(GithubRepo.find(repo_path)).to have_attributes(
           stargazers_count: (a_value > 30_000),
           watchers_count:   (a_value > 1000),
-          forks_count:      (a_value > 10_000)
+          forks_count:      (a_value > 10_000),
+          fetched_at:       be_within(5.seconds).of(Time.current)
         )
       end
     end

--- a/spec/integration/rubygem_update_spec.rb
+++ b/spec/integration/rubygem_update_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe RubygemUpdateJob, :real_http do
           first_release_on:           (a_value > Date.new(2012, 4, 25)),
           latest_release_on:          (a_value > Date.new(2017, 2, 21)),
           reverse_dependencies_count: (a_value > 50),
-          releases_count:             (a_value > 20)
+          releases_count:             (a_value > 20),
+          fetched_at:                 be_within(5.seconds).of(Time.current)
         )
       end
     end


### PR DESCRIPTION
This adds a dedicated fetched at column on top of the regular rails updated_at for gems and repos to track when they've last been pulled from their source