### PR TITLE
Fix cascading deletion of a gem that was listed as trending

### DIFF
--- a/app/models/rubygem/download_stat.rb
+++ b/app/models/rubygem/download_stat.rb
@@ -37,6 +37,11 @@ class Rubygem::DownloadStat < ApplicationRecord
 
   has_one :project, through: :rubygem
 
+  has_many :trends, class_name:  "Rubygem::Trend",
+                    foreign_key: :rubygem_download_stat_id,
+                    inverse_of:  :rubygem_download_stat,
+                    dependent:   :destroy
+
   def self.monthly(base_date: Rubygem::DownloadStat.maximum(:date))
     where("(#{table_name}.date <= ?)", base_date)
       .where("(#{table_name}.date - ?) % 28 = 0", base_date)

--- a/app/models/rubygem/trend.rb
+++ b/app/models/rubygem/trend.rb
@@ -7,7 +7,8 @@ class Rubygem::Trend < ApplicationRecord
              inverse_of:  :trends
 
   belongs_to :rubygem_download_stat,
-             class_name: "Rubygem::DownloadStat"
+             class_name: "Rubygem::DownloadStat",
+             inverse_of: :trends
 
   has_one :project, through: :rubygem
   has_one :github_repo, through: :project

--- a/spec/models/rubygem/trend_spec.rb
+++ b/spec/models/rubygem/trend_spec.rb
@@ -25,5 +25,9 @@ RSpec.describe Rubygem::Trend, type: :model do
 
       expect(&query).to make_database_queries(count: 1)
     end
+
+    it "allows cascading deletion of a rubygem when it's gone" do
+      expect(Rubygem.find("a").destroy).to be_truthy
+    end
   end
 end


### PR DESCRIPTION
Fixes a bug that actually happened in production: A gem that is referenced from the weekly trends table has been yanked. Since we do not track yanked / gone gems the gem would have been deleted by the gem update job, however this recurringly failed due to the broken foreign key reference on the trends table via download stats. This PR fixes that issue.