### PR TITLE
Quarterly rubygem release activity heat map

### DIFF
--- a/app/assets/stylesheets/components/project_release_history.sass
+++ b/app/assets/stylesheets/components/project_release_history.sass
@@ -21,6 +21,6 @@
       &.high
         background: $red
       &.medium
-        background: rgba($red, 0.5)
+        background: rgba($red, 0.65)
       &.low
-        background: rgba($red, 0.2)
+        background: rgba($red, 0.35)

--- a/app/assets/stylesheets/components/project_release_history.sass
+++ b/app/assets/stylesheets/components/project_release_history.sass
@@ -1,0 +1,26 @@
+.project-release-history
+  display: grid
+  grid-column-gap: 2px
+  grid-row-gap: 8px
+  grid-template-columns: repeat( auto-fit, minmax(70px, 1fr) )
+
+  .label
+    @extend .is-size-7, .has-text-grey
+
+  ul
+    display: grid
+    grid-gap: 2px
+    grid-template-columns: repeat(4, 1fr)
+
+    li
+      background: #eee
+      display: block
+      height: 10px
+      width: 100%
+
+      &.high
+        background: $red
+      &.medium
+        background: rgba($red, 0.5)
+      &.low
+        background: rgba($red, 0.2)

--- a/app/helpers/component_helpers.rb
+++ b/app/helpers/component_helpers.rb
@@ -87,7 +87,7 @@ module ComponentHelpers
     count = release_counts["#{year}-#{quarter}"] || 0
     rank = RELEASE_INDICATOR_RANKS.find { |limit, _| count <= limit }&.last || "high"
 
-    tooltip = "#{quarter.ordinalize} quarter #{year}: #{count} releases"
+    tooltip = "#{quarter.ordinalize} quarter #{year}: #{count} #{'release'.pluralize(count)}"
 
     content_tag "li", class: "tooltip is-tooltip-bottom #{rank}", "data-tooltip" => tooltip do
     end

--- a/app/helpers/component_helpers.rb
+++ b/app/helpers/component_helpers.rb
@@ -2,7 +2,7 @@
 
 #
 # Shorthand methods for displaying UI components. See /pages/components
-#
+# rubocop:disable Metrics/ModuleLength
 module ComponentHelpers
   def category_card(category, compact: false, inline: false)
     extra_classes = inline ? %w[inline] : []
@@ -71,8 +71,26 @@ module ComponentHelpers
     render "components/project_comparison", projects: projects
   end
 
-  def project_release_history(project)
-    render "components/project_release_history", project: project
+  def project_release_history(quarterly_release_counts, compact: false)
+    return unless quarterly_release_counts.is_a?(Hash) && quarterly_release_counts.any?
+
+    render "components/project_release_history", release_counts: quarterly_release_counts, compact: compact
+  end
+
+  RELEASE_INDICATOR_RANKS = {
+    0 => "none",
+    1 => "low",
+    3 => "medium",
+  }.freeze
+
+  def quarterly_release_indicator(release_counts, year:, quarter:)
+    count = release_counts["#{year}-#{quarter}"] || 0
+    rank = RELEASE_INDICATOR_RANKS.find { |limit, _| count <= limit }&.last || "high"
+
+    tooltip = "#{quarter.ordinalize} quarter #{year}: #{count} releases"
+
+    content_tag "li", class: "tooltip is-tooltip-bottom #{rank}", "data-tooltip" => tooltip do
+    end
   end
 
   def trending_project_card(trend)
@@ -125,3 +143,4 @@ module ComponentHelpers
     render "components/component_example", heading: heading, &block
   end
 end
+# rubocop:enable Metrics/ModuleLength

--- a/app/helpers/component_helpers.rb
+++ b/app/helpers/component_helpers.rb
@@ -71,6 +71,10 @@ module ComponentHelpers
     render "components/project_comparison", projects: projects
   end
 
+  def project_release_history(project)
+    render "components/project_release_history", project: project
+  end
+
   def trending_project_card(trend)
     render "components/trending_project_card", trend: trend
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -91,6 +91,7 @@ class Project < ApplicationRecord
            :licenses,
            :url,
            :reverse_dependencies_count,
+           :quarterly_release_counts,
            to:        :rubygem,
            allow_nil: true,
            prefix:    :rubygem

--- a/app/views/components/_project.html.slim
+++ b/app/views/components/_project.html.slim
@@ -34,7 +34,7 @@
     - else
       = project.description
 
-  .columns: .column= project_release_history project
+  .columns: .column= project_release_history project.rubygem_quarterly_release_counts, compact: local_assigns[:compact]
 
   - if local_assigns[:compact]
     .metrics.compact= metrics_row project, :rubygem_downloads, :github_repo_stargazers_count, :rubygem_current_version, :rubygem_releases_count, :rubygem_first_release_on, :rubygem_latest_release_on

--- a/app/views/components/_project.html.slim
+++ b/app/views/components/_project.html.slim
@@ -34,9 +34,11 @@
     - else
       = project.description
 
+  .columns: .column= project_release_history project
 
   - if local_assigns[:compact]
     .metrics.compact= metrics_row project, :rubygem_downloads, :github_repo_stargazers_count, :rubygem_current_version, :rubygem_releases_count, :rubygem_first_release_on, :rubygem_latest_release_on
+
 
     = project_details_buttons project
 

--- a/app/views/components/_project_release_history.html.slim
+++ b/app/views/components/_project_release_history.html.slim
@@ -1,0 +1,9 @@
+.project-release-history
+  - (2004..Time.current.year).each do |year|
+    .year
+      .label= year
+      ul
+        li.q1.high.tooltip.is-tooltip-bottom data-tooltip="Q1 #{year}: 12 releases"
+        li.q2.low.tooltip.is-tooltip-bottom data-tooltip="Q1 #{year}: 12 releases"
+        li.q3.none.tooltip.is-tooltip-bottom data-tooltip="Q1 #{year}: 12 releases"
+        li.q2.medium.tooltip.is-tooltip-bottom data-tooltip="Q1 #{year}: 12 releases"

--- a/app/views/components/_project_release_history.html.slim
+++ b/app/views/components/_project_release_history.html.slim
@@ -1,9 +1,8 @@
 .project-release-history
-  - (2004..Time.current.year).each do |year|
+  - starts_in = compact ? Time.current.year - 5 : 2005
+  - (starts_in..Time.current.year).each do |year|
     .year
       .label= year
       ul
-        li.q1.high.tooltip.is-tooltip-bottom data-tooltip="Q1 #{year}: 12 releases"
-        li.q2.low.tooltip.is-tooltip-bottom data-tooltip="Q1 #{year}: 12 releases"
-        li.q3.none.tooltip.is-tooltip-bottom data-tooltip="Q1 #{year}: 12 releases"
-        li.q2.medium.tooltip.is-tooltip-bottom data-tooltip="Q1 #{year}: 12 releases"
+        - (1..4).each do |quarter|
+          = quarterly_release_indicator release_counts, year: year, quarter: quarter

--- a/app/views/pages/components/project_release_history.html.slim
+++ b/app/views/pages/components/project_release_history.html.slim
@@ -4,6 +4,14 @@
     h2= current_page.split("/").last.humanize
 
 - project = Project.find("rspec")
+- data = { "2018-3" => 1, "2018-4" => 3, "2019-1" => 12 }
 
-= component_example "Project box" do
-  = project_release_history project
+= component_example "Quarterly release counts for a project" do
+  = project_release_history project.rubygem_quarterly_release_counts
+
+
+= component_example "It expects a quarterly mapped counts input" do
+  = project_release_history data
+
+= component_example "Compact view only shows last 6 years" do
+  = project_release_history data, compact: true

--- a/app/views/pages/components/project_release_history.html.slim
+++ b/app/views/pages/components/project_release_history.html.slim
@@ -1,0 +1,9 @@
+.hero
+  section.section: .container
+    p.heading= link_to "Ruby Toolbox UI Components Styleguide", "/pages/components"
+    h2= current_page.split("/").last.humanize
+
+- project = Project.find("rspec")
+
+= component_example "Project box" do
+  = project_release_history project

--- a/app/views/projects/show.html.slim
+++ b/app/views/projects/show.html.slim
@@ -31,6 +31,10 @@
     .columns: .download-chart.column
       = rubygem_download_chart @project.rubygem_name
 
+    .columns: .quarterly-releases.column
+      = project_release_history @project.rubygem_quarterly_release_counts
+
+
 section.section: .container: .project
   = project_metrics @project, expanded_view: true
 

--- a/db/migrate/20190730194020_add_quarterly_releases_to_rubygems.rb
+++ b/db/migrate/20190730194020_add_quarterly_releases_to_rubygems.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddQuarterlyReleasesToRubygems < ActiveRecord::Migration[5.2]
+  def change
+    add_column :rubygems, :quarterly_release_counts, :jsonb, default: {}, null: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5,6 +5,7 @@ SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
+SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
 
@@ -379,7 +380,8 @@ CREATE TABLE public.rubygems (
     latest_release_on date,
     releases_count integer,
     reverse_dependencies_count integer,
-    fetched_at timestamp without time zone
+    fetched_at timestamp without time zone,
+    quarterly_release_counts jsonb DEFAULT '{}'::jsonb NOT NULL
 );
 
 
@@ -784,6 +786,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190226090403'),
 ('20190228101125'),
 ('20190228102103'),
-('20190508190527');
+('20190508190527'),
+('20190730194020');
 
 

--- a/spec/jobs/rubygem_update_job_spec.rb
+++ b/spec/jobs/rubygem_update_job_spec.rb
@@ -45,6 +45,12 @@ RSpec.describe RubygemUpdateJob, type: :job do
       do_perform
     end
 
+    it "stores quarterly release counts" do
+      do_perform
+      expected = { "2005-3" => 1, "2017-2" => 1, "2017-4" => 1 }
+      expect(Rubygem.find(gem_name).quarterly_release_counts).to be == expected
+    end
+
     describe "when rubygems.org is down" do
       let(:gem_name) { "thisisdowninmock" }
 


### PR DESCRIPTION
This PR adds a quarterly release activity heat map (and preparation of the underlying data) to projects that have rubygems to the project details, list and compact views in order to give a quick overview of historical and recent release activity of a project at a glance

![Screenshot from 2019-07-30 22-35-35](https://user-images.githubusercontent.com/13972/62163375-81388f80-b31a-11e9-8d0a-6577ef977514.png)
![Screenshot from 2019-07-30 22-33-09](https://user-images.githubusercontent.com/13972/62163376-81388f80-b31a-11e9-8085-f5834142e79e.png)
![Screenshot from 2019-07-30 22-32-43](https://user-images.githubusercontent.com/13972/62163377-81388f80-b31a-11e9-9c18-243933dfb501.png)
