### PR TITLE
add buttons of navigations in trends page

### DIFF
--- a/app/views/trends/show.html.slim
+++ b/app/views/trends/show.html.slim
@@ -9,7 +9,7 @@
           Discover libraries that are gaining popularity within the Ruby community. You can [find an overview of how we calculate these in our documentation](/pages/docs/features/trending_projects).
 
 section.section: .container
-  .columns.is-multiline
+  .top-navigation.columns.is-multiline
     .column.is-one-third-desktop
       .buttons.has-addons
         - %w[year month week].each do |timeframe|
@@ -37,7 +37,7 @@ section.section: .container
         = trending_project_card trend
 
 section.section: .container
-  .columns.is-multiline
+  .bottom-navigation.columns.is-multiline
     .column.is-one-third-desktop
       .buttons.has-addons
         - %w[year month week].each do |timeframe|

--- a/app/views/trends/show.html.slim
+++ b/app/views/trends/show.html.slim
@@ -35,3 +35,25 @@ section.section: .container
     - @trends.each do |trend|
       .category-cards.three
         = trending_project_card trend
+
+section.section: .container
+  .columns.is-multiline
+    .column.is-one-third-desktop
+      .buttons.has-addons
+        - %w[year month week].each do |timeframe|
+          = link_to trend_path(@navigation.public_send("previous_#{timeframe}") || "#"), class: "button previous_#{timeframe}", disabled: !@navigation.public_send("previous_#{timeframe}") do
+            span.icon: i.fa.fa-caret-left
+            span= "1 #{timeframe}"
+
+    .column.is-one-third-desktop.has-text-centered
+      - unless @navigation.latest?
+        = link_to trend_path(@navigation.latest_date), class: "button" do
+          span.icon: i.fa.fa-calendar-o
+          strong Go to latest
+
+    .column.is-one-third-desktop
+      .buttons.has-addons.is-right
+        - %w[week month year].each do |timeframe|
+          = link_to trend_path(@navigation.public_send("next_#{timeframe}") || "#"), class: "button next_#{timeframe}", disabled: !@navigation.public_send("next_#{timeframe}")
+            span= "1 #{timeframe}"
+            span.icon: i.fa.fa-caret-right

--- a/spec/features/trending_spec.rb
+++ b/spec/features/trending_spec.rb
@@ -31,14 +31,14 @@ RSpec.describe "Trending Projects", type: :feature, js: true do
     expect(page).to have_selector(".category-card", count: 2)
     expect(visible_project_names).to be == %w[widget foobar]
 
-    within '.top-navigation' do
+    within ".top-navigation" do
       page.find(".button.previous_week").click
     end
 
     expect(page).to have_selector(".category-card", count: 1)
     expect(visible_project_names).to be == %w[other]
 
-    within '.top-navigation' do
+    within ".top-navigation" do
       click_on "Go to latest"
     end
 

--- a/spec/features/trending_spec.rb
+++ b/spec/features/trending_spec.rb
@@ -31,11 +31,17 @@ RSpec.describe "Trending Projects", type: :feature, js: true do
     expect(page).to have_selector(".category-card", count: 2)
     expect(visible_project_names).to be == %w[widget foobar]
 
-    page.find(".button.previous_week").click
+    within '.top-navigation' do
+      page.find(".button.previous_week").click
+    end
+
     expect(page).to have_selector(".category-card", count: 1)
     expect(visible_project_names).to be == %w[other]
 
-    click_on "Go to latest"
+    within '.top-navigation' do
+      click_on "Go to latest"
+    end
+
     expect(page).to have_selector(".category-card", count: 2)
     expect(visible_project_names).to be == %w[widget foobar]
   end


### PR DESCRIPTION
I am trying improve the ux with buttons of navigation when finish the trends page, but i am not know this slim, I think we can improve how is it write, so if you can help-me, pls do your review. 

Before
![ruby toolbox](https://user-images.githubusercontent.com/20587352/69670075-d474e180-1071-11ea-9415-3fba28522fae.png)

Now
![now](https://user-images.githubusercontent.com/20587352/69829161-b9cf7380-11fd-11ea-9b1f-10f7a9b03199.png)

