### PR TITLE
Remove unneccessary n+1 count query on category card

### DIFF
--- a/app/views/components/_category_card.html.slim
+++ b/app/views/components/_category_card.html.slim
@@ -16,6 +16,6 @@
           = link_to project, class: "project" do
             strong= project.permalink
 
-        - if category.projects.count > limit
+        - if category.projects.length > limit
           = link_to category, class: "other" do
-            = "and #{category.projects.count - limit} more"
+            = "and #{category.projects.length - limit} more"

--- a/spec/helpers/component_helpers_spec.rb
+++ b/spec/helpers/component_helpers_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ComponentHelpers, type: :helper do
+  let(:group) do
+    CategoryGroup.create! permalink: "unimportant", name: "unimportant"
+  end
+  let(:category) do
+    Category.create! permalink:      "mocking",
+                     name:           "Mocking Frameworks",
+                     description:    "Widgets Factory",
+                     category_group: group
+  end
+
+  describe "#category_card" do
+    before do
+      Factories.project("sample").update! categories: [category]
+    end
+
+    it "issues no count db queries" do
+      category = Category.includes(:projects).find("mocking")
+
+      expect { helper.category_card(category) }.not_to make_database_queries
+    end
+  end
+end


### PR DESCRIPTION
This addresses an unneccessary n+1 query on the landing page, where each featured category card was issuing a count statement for the project count to show on the footer despite the fact we're correctly pre-loading the collection anyway.