### PR TITLE
Handle unknown format more gracefully / less noisy

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,12 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  # There's a few legacy routes being still frequently accessed i.e. for old RSS feeds,
+  # or crawlers asking for crazy things like XML, which makes rails choke and exceptions
+  # being reported, hence we catch them gracefully and just log the path for potential future
+  # investigation
+  rescue_from ActionController::UnknownFormat do
+    logger.info "Unknown path/format requested #{request.path} / #{request.format}"
+    raise ActionController::RoutingError, "Unknown path #{request.path} / format #{request.format}"
+  end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ApplicationController, type: :controller do
+  controller do
+    def index
+      respond_to do |f|
+        f.html { render text: "Hello World" }
+      end
+    end
+  end
+
+  describe "requesting an invalid format" do
+    def do_request
+      get :index, format: :json
+    end
+
+    it "raises a routing error, which will show 404 page on production" do
+      expect { do_request }.to raise_error(ActionController::RoutingError, %r{Unknown path /anonymous.json})
+    end
+  end
+end


### PR DESCRIPTION
I get a bunch of exceptions for i.e. legacy / gone rss feed URLs not supporting the requested format. This changes things to handle unknown requested formats more gracefully by showing a 404 and not causing an exception notification every time...