### PR TITLE
Enable simple in-memory time/release based cache for landing page

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,6 +5,12 @@ module ApplicationHelper
   include ComponentHelpers
   include StatsHelpers
 
+  def expiring_cache(label, expiration: 10.minutes, &block)
+    key = [label, ENV["HEROKU_RELEASE_VERSION"], (Time.current.to_i / expiration).to_s].join("-")
+
+    cache(key, &block)
+  end
+
   def metric_icon(metric)
     "fa-" + t(:icon, scope: "metrics.#{metric}")
   end

--- a/app/views/welcome/home.html.slim
+++ b/app/views/welcome/home.html.slim
@@ -1,99 +1,100 @@
-= landing_hero title: t(:title, scope: :startpage), image: "startpage/main.png" do
-  markdown:
-    The Ruby Toolbox is a catalog of all [Rubygems](https://www.rubygems.org) that keeps track of popularity and health metrics to help you choose a reliable library
+- cache "welcome" do
+  = landing_hero title: t(:title, scope: :startpage), image: "startpage/main.png" do
+    markdown:
+      The Ruby Toolbox is a catalog of all [Rubygems](https://www.rubygems.org) that keeps track of popularity and health metrics to help you choose a reliable library
 
-  .columns
-    .column
-      a.button.is-primary.is-fullwidth href=categories_path
-        span.icon: i.fa.fa-bars
-        span Browse by category
+    .columns
+      .column
+        a.button.is-primary.is-fullwidth href=categories_path
+          span.icon: i.fa.fa-bars
+          span Browse by category
 
-    .column
-      = render partial: "search_form"
+      .column
+        = render partial: "search_form"
 
-  - if @recent_posts
-    .recent-news
-      .heading
-        span.icon: i.fa.fa-rss-square
-        strong= link_to "Recent News", blog_index_path
-      ul
-        - @recent_posts.each do |post|
-          li
-            a href=blog_post_path(post)
-              span.date= l post.published_on, format: :long
-              | &nbsp;
-              strong= post.title
-
-
-section.section: .container: .landing-features
-  = landing_feature title: "Categories", image: "startpage/box.png" do
-    article
-      markdown:
-        To give you an overview of what open source libraries are available for a given task we group projects for common problems into categories.
-
-        The catalog itself is available for contributions on [GitHub](https://github.com/rubytoolbox/catalog).
-
-    footer
-      a href=categories_path Browse all categories
-
-  = landing_feature title: "Search", image: "startpage/search.png" do
-    article
-      markdown:
-        With our search you can find Ruby open source libraries beyond what is listed in our categories.
-
-        We index all Rubygems published on [Rubygems.org](https://rubygems.org).
-
-    footer
-      a href=search_path(q: "http") Try our search
-
-  = landing_feature title: "Project Popularity", image: "startpage/rocket.png" do
-    article
-      markdown:
-        We sort projects based on their popularity in the Ruby community - Rubygem downloads as well as popularity of the source code repository on GitHub.
-
-        This helps to identify projects that have a big user base, which is an indicator of project stability, maturity and maintenance.
-
-  = landing_feature title: "Project Health", image: "startpage/ruby.png" do
-    article
-      markdown:
-        We assess the maintenance status of projects based on recent activity like package releases, commit activity or open issue counts and display colored indicators based on that.
-
-        This gives you a quick overview of the health of a project.
-
-- if @featured_categories.any?
-  section.section.popular-categories: .container
-    / - description = t(:stats, scope: :startpage, projects_with_categories: @stats.projects_with_categories_count, categories: @stats.categories_count, rubygems: @stats.rubygems_count)
-    = section_heading "Popular Categories", help_path: "docs/features/categories" do
-      a.button href=categories_path
-        span.icon: i.fa.fa-bars
-        span Browse all categories
-
-    .columns.is-multiline
-      - @featured_categories.each do |category|
-        .category-cards.four
-          = category_card category
-
-- if @trending_projects.any?
-  section.section.trending-projects: .container
-    = section_heading "Trending Projects"
-      a.button href=trends_path
-        span.icon: i.fa.fa-bars
-        span See all trending projects
-
-    .columns.is-multiline
-      - @trending_projects.each do |trend|
-        .category-cards.four
-          = trending_project_card trend
+    - if @recent_posts
+      .recent-news
+        .heading
+          span.icon: i.fa.fa-rss-square
+          strong= link_to "Recent News", blog_index_path
+        ul
+          - @recent_posts.each do |post|
+            li
+              a href=blog_post_path(post)
+                span.date= l post.published_on, format: :long
+                | &nbsp;
+                strong= post.title
 
 
-- if @new_categories.any?
-  section.section.recently-added-categories: .container
-    = section_heading "Recently Added Categories", help_path: "docs/features/categories"
-      a.button href=categories_path
-        span.icon: i.fa.fa-bars
-        span Browse all categories
+  section.section: .container: .landing-features
+    = landing_feature title: "Categories", image: "startpage/box.png" do
+      article
+        markdown:
+          To give you an overview of what open source libraries are available for a given task we group projects for common problems into categories.
 
-    .columns.is-multiline
-      - @new_categories.each do |category|
-        .category-cards.four
-          = category_card category
+          The catalog itself is available for contributions on [GitHub](https://github.com/rubytoolbox/catalog).
+
+      footer
+        a href=categories_path Browse all categories
+
+    = landing_feature title: "Search", image: "startpage/search.png" do
+      article
+        markdown:
+          With our search you can find Ruby open source libraries beyond what is listed in our categories.
+
+          We index all Rubygems published on [Rubygems.org](https://rubygems.org).
+
+      footer
+        a href=search_path(q: "http") Try our search
+
+    = landing_feature title: "Project Popularity", image: "startpage/rocket.png" do
+      article
+        markdown:
+          We sort projects based on their popularity in the Ruby community - Rubygem downloads as well as popularity of the source code repository on GitHub.
+
+          This helps to identify projects that have a big user base, which is an indicator of project stability, maturity and maintenance.
+
+    = landing_feature title: "Project Health", image: "startpage/ruby.png" do
+      article
+        markdown:
+          We assess the maintenance status of projects based on recent activity like package releases, commit activity or open issue counts and display colored indicators based on that.
+
+          This gives you a quick overview of the health of a project.
+
+  - if @featured_categories.any?
+    section.section.popular-categories: .container
+      / - description = t(:stats, scope: :startpage, projects_with_categories: @stats.projects_with_categories_count, categories: @stats.categories_count, rubygems: @stats.rubygems_count)
+      = section_heading "Popular Categories", help_path: "docs/features/categories" do
+        a.button href=categories_path
+          span.icon: i.fa.fa-bars
+          span Browse all categories
+
+      .columns.is-multiline
+        - @featured_categories.each do |category|
+          .category-cards.four
+            = category_card category
+
+  - if @trending_projects.any?
+    section.section.trending-projects: .container
+      = section_heading "Trending Projects"
+        a.button href=trends_path
+          span.icon: i.fa.fa-bars
+          span See all trending projects
+
+      .columns.is-multiline
+        - @trending_projects.each do |trend|
+          .category-cards.four
+            = trending_project_card trend
+
+
+  - if @new_categories.any?
+    section.section.recently-added-categories: .container
+      = section_heading "Recently Added Categories", help_path: "docs/features/categories"
+        a.button href=categories_path
+          span.icon: i.fa.fa-bars
+          span Browse all categories
+
+      .columns.is-multiline
+        - @new_categories.each do |category|
+          .category-cards.four
+            = category_card category

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -58,7 +58,7 @@ Rails.application.configure do
   config.log_tags = [:request_id]
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :memory_store, { size: 32.megabytes }
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -3,6 +3,17 @@
 require "rails_helper"
 
 RSpec.describe ApplicationHelper, type: :helper do
+  describe "#expiring_cache" do
+    it "builds a cache key based on given label, time, and release version" do
+      allow(ENV).to receive(:[]).with("HEROKU_RELEASE_VERSION").and_return("v42")
+      timestamp = Time.current.to_i / 10.minutes
+
+      expect(helper).to receive(:cache).with("test-v42-#{timestamp}")
+
+      helper.expiring_cache :test
+    end
+  end
+
   describe "#metrics_row" do
     let(:project) { instance_double(Project, rubygem_downloads: 22_123_122) }
     let(:metrics_row) { helper.metrics_row(project, :rubygem_downloads) }


### PR DESCRIPTION
Following up on https://github.com/rubytoolbox/rubytoolbox/pull/630 which already reduced speed of the landing page quite a bit according to appsignal this should also bring in additional speed by reducing the number of queries made and partials rendered.

The landing page is mostly static anyway, so having this simple 10-minute rolling window expiring cache should already give a decent speed bump on that page even with this quite naive implementation