### PR TITLE
API followups

### DIFF
--- a/app/controllers/api/projects/comparisons_controller.rb
+++ b/app/controllers/api/projects/comparisons_controller.rb
@@ -1,17 +1,31 @@
 # frozen_string_literal: true
 
 class Api::Projects::ComparisonsController < ActionController::API
+  LIMIT = 100
+  before_action :verify_limit, only: %i[show]
+
   def show
     projects = Project.where(permalink: requested_project_permalinks)
                       .for_display(forks: true)
                       .includes_associations
                       .order(permalink: :asc)
-                      .limit(100)
+                      .limit(LIMIT)
 
     render json: ProjectBlueprint.render(projects, root: :projects, root_url: request_root_url)
   end
 
   private
+
+  def verify_limit
+    return if requested_project_permalinks.count <= LIMIT
+
+    response_body = {
+      error_code: "too_many_projects_requested",
+      message:    "Please request no more than #{LIMIT} projects per API call",
+    }
+
+    render json: response_body, status: 400
+  end
 
   def requested_project_permalinks
     (params[:id].presence || "").split(",")

--- a/app/views/pages/docs/api/projects.html.slim
+++ b/app/views/pages/docs/api/projects.html.slim
@@ -9,10 +9,19 @@
       metrics specific to the Ruby Toolbox like popularity scores and
       project health status.
 
+      The API has currently no rate-limiting policy, however please use it
+      reasonably. If you need larger scale access to data for analysis please
+      use our [production database exports](#{page_path("docs/features/production_database_exports")}) instead.
+
   h5.is-size-5
     strong GET&nbsp;
     code
       | /api/projects/compare/rubocop,rspec-expectations,oj
+
+  markdown:
+    This endpoint is limited to #{Api::Projects::ComparisonsController::LIMIT}
+    projects per request. If you request more than that you will receive an
+    error. Please batch requests in groups to retrieve more projects.
 
   hr
 

--- a/spec/requests/api/projects/compare_spec.rb
+++ b/spec/requests/api/projects/compare_spec.rb
@@ -57,4 +57,24 @@ RSpec.describe "Project Comparison API", type: :request do
       expect(response).to have_http_status(:success)
     end
   end
+
+  describe "when more projects than limit are requested" do
+    let(:limit) { Api::Projects::ComparisonsController::LIMIT }
+    let(:query) { ("aa".."zz").first(limit + 1).join(",") }
+
+    it "responds with a 400 error" do
+      do_request
+      expect(response.status).to be == 400
+    end
+
+    it "responds with an informative error message" do
+      do_request
+      body = Oj.load(response.body).deep_symbolize_keys
+
+      expect(body).to be == {
+        error_code: "too_many_projects_requested",
+        message:    "Please request no more than #{limit} projects per API call",
+      }
+    end
+  end
 end


### PR DESCRIPTION
Minor followups to https://github.com/rubytoolbox/rubytoolbox/pull/598:

* Return explicit error when the requested projects are above the per-request limit to avoid silent ignores
* Add a bit more info on the API docs