### PR TITLE
Remove obsolete github moved repo workaround that caused new issue

### DIFF
--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -22,7 +22,7 @@ class GithubClient
   end
 
   def fetch_repository(path)
-    owner, name = real_path(path).split("/")
+    owner, name = path.split("/")
     body = { query: REPOSITORY_DATA_QUERY, variables: { owner: owner, name: name } }
     response = authenticated_client.post "https://api.github.com/graphql", body: Oj.dump(body, mode: :compat)
     handle_response response
@@ -30,34 +30,21 @@ class GithubClient
 
   private
 
-  # Unfortunate hack for a limitation in github's graphql API.
-  # See https://github.com/rubytoolbox/rubytoolbox/pull/94#issuecomment-372489342
-  # and https://platform.github.community/t/repository-redirects-in-api-v4-graphql/4417
-  def real_path(path)
-    response = http_client.head File.join("https://github.com", path)
-    case response.status
-    when 200
-      return path
-    # Instead of following 301s, the broken github path
-    # (either coming from the catalog for github-only projects,
-    # or from a rubygems urls) should somehow be flagged and
-    # remapped locally, but this needs some more consideration
-    # regarding the various possible cases
-    when 301, 302
-      location = Github.detect_repo_name response.headers["Location"]
-      return location if location
-    end
-
-    raise UnknownRepoError, "Cannot find repo #{path} on github :("
-  end
-
   def handle_response(response)
     raise InvalidResponseStatus, "status=#{response.status}" unless response.status == 200
 
     parsed_body = Oj.load(response.body)
-    raise InvalidResponse, parsed_body["errors"].map { |e| e["message"] }.join(", ") if parsed_body["errors"]
+    handle_errors! parsed_body["errors"]
 
     RepositoryData.new parsed_body
+  end
+
+  def handle_errors!(errors)
+    return unless errors
+
+    raise UnknownRepoError, errors.inspect if errors.any? { |e| e["type"] == "NOT_FOUND" }
+
+    raise InvalidResponse, errors.map { |e| e["message"] }.join(", ")
   end
 
   def authenticated_client

--- a/spec/cassettes/github/org_reference.yml
+++ b/spec/cassettes/github/org_reference.yml
@@ -70,6 +70,93 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version: null
   recorded_at: Wed, 05 Dec 2018 12:14:33 GMT
-recorded_with: VCR 4.0.0
+- request:
+    method: post
+    uri: https://api.github.com/graphql
+    body:
+      encoding: UTF-8
+      string: '{"query":"query RepositoryDataQuery($owner: String!, $name: String!)
+        {\n\n  repository(owner: $owner, name: $name) {\n    nameWithOwner\n    forks
+        {\n      totalCount\n    }\n    stargazers {\n      totalCount\n    }\n    watchers
+        {\n      totalCount\n    }\n    createdAt\n    defaultBranchRef {\n      name\n      target
+        {\n        ... on Commit {\n          history(first: 50) {\n            edges
+        {\n              node {\n                authoredDate\n              }\n            }\n          }\n        }\n      }\n    }\n    description\n    hasIssuesEnabled\n    hasWikiEnabled\n    homepageUrl\n    isArchived\n    isFork\n    isMirror\n    licenseInfo
+        {\n      key\n    }\n    primaryLanguage {\n      name\n    }\n    pushedAt\n    closedIssues:
+        issues(states: CLOSED) {\n      totalCount\n    }\n    openIssues: issues(states:
+        OPEN) {\n      totalCount\n    }\n    closedPullRequests: pullRequests(states:
+        CLOSED) {\n      totalCount\n    }\n    openPullRequests: pullRequests(states:
+        OPEN) {\n      totalCount\n    }\n    mergedPullRequests: pullRequests(states:
+        MERGED) {\n      totalCount\n    }\n    repositoryTopics(first: 100) {\n      nodes
+        {\n        topic {\n          name\n        }\n      }\n    }\n    codeOfConduct
+        {\n      name\n      url\n    }\n  }\n  rateLimit {\n    limit\n    cost\n    remaining\n    resetAt\n  }\n}\n","variables":{"owner":"orgs","name":"acdcorp"}}'
+    headers:
+      Authorization:
+      - bearer <GITHUB_TOKEN>
+      User-Agent:
+      - ruby-toolbox.com API client
+      Connection:
+      - close
+      Host:
+      - api.github.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 18 Apr 2020 19:53:30 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '270'
+      Connection:
+      - close
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      Cache-Control:
+      - no-cache
+      X-Oauth-Scopes:
+      - ''
+      X-Accepted-Oauth-Scopes:
+      - repo
+      X-Github-Media-Type:
+      - github.v4; format=json
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4993'
+      X-Ratelimit-Reset:
+      - '1587242742'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - A3AC:2E332:26CFCFE:2D8137F:5E9B5AB9
+    body:
+      encoding: UTF-8
+      string: '{"data":{"repository":null,"rateLimit":{"limit":5000,"cost":1,"remaining":4993,"resetAt":"2020-04-18T20:45:42Z"}},"errors":[{"type":"NOT_FOUND","path":["repository"],"locations":[{"line":3,"column":3}],"message":"Could
+        not resolve to a User with the username ''orgs''."}]}'
+    http_version: null
+  recorded_at: Sat, 18 Apr 2020 19:53:30 GMT
+recorded_with: VCR 5.1.0

--- a/spec/cassettes/graphql/fails.yml
+++ b/spec/cassettes/graphql/fails.yml
@@ -58,6 +58,93 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version: null
   recorded_at: Wed, 05 Dec 2018 12:50:15 GMT
-recorded_with: VCR 4.0.0
+- request:
+    method: post
+    uri: https://api.github.com/graphql
+    body:
+      encoding: UTF-8
+      string: '{"query":"query RepositoryDataQuery($owner: String!, $name: String!)
+        {\n\n  repository(owner: $owner, name: $name) {\n    nameWithOwner\n    forks
+        {\n      totalCount\n    }\n    stargazers {\n      totalCount\n    }\n    watchers
+        {\n      totalCount\n    }\n    createdAt\n    defaultBranchRef {\n      name\n      target
+        {\n        ... on Commit {\n          history(first: 50) {\n            edges
+        {\n              node {\n                authoredDate\n              }\n            }\n          }\n        }\n      }\n    }\n    description\n    hasIssuesEnabled\n    hasWikiEnabled\n    homepageUrl\n    isArchived\n    isFork\n    isMirror\n    licenseInfo
+        {\n      key\n    }\n    primaryLanguage {\n      name\n    }\n    pushedAt\n    closedIssues:
+        issues(states: CLOSED) {\n      totalCount\n    }\n    openIssues: issues(states:
+        OPEN) {\n      totalCount\n    }\n    closedPullRequests: pullRequests(states:
+        CLOSED) {\n      totalCount\n    }\n    openPullRequests: pullRequests(states:
+        OPEN) {\n      totalCount\n    }\n    mergedPullRequests: pullRequests(states:
+        MERGED) {\n      totalCount\n    }\n    repositoryTopics(first: 100) {\n      nodes
+        {\n        topic {\n          name\n        }\n      }\n    }\n    codeOfConduct
+        {\n      name\n      url\n    }\n  }\n  rateLimit {\n    limit\n    cost\n    remaining\n    resetAt\n  }\n}\n","variables":{"owner":"thisverylikely","name":"fails"}}'
+    headers:
+      Authorization:
+      - bearer <GITHUB_TOKEN>
+      User-Agent:
+      - ruby-toolbox.com API client
+      Connection:
+      - close
+      Host:
+      - api.github.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 18 Apr 2020 19:53:30 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '280'
+      Connection:
+      - close
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      Cache-Control:
+      - no-cache
+      X-Oauth-Scopes:
+      - ''
+      X-Accepted-Oauth-Scopes:
+      - repo
+      X-Github-Media-Type:
+      - github.v4; format=json
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4991'
+      X-Ratelimit-Reset:
+      - '1587242741'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - A3B0:509B:90AE65:A78DE8:5E9B5ABA
+    body:
+      encoding: UTF-8
+      string: '{"data":{"repository":null,"rateLimit":{"limit":5000,"cost":1,"remaining":4991,"resetAt":"2020-04-18T20:45:41Z"}},"errors":[{"type":"NOT_FOUND","path":["repository"],"locations":[{"line":3,"column":3}],"message":"Could
+        not resolve to a User with the username ''thisverylikely''."}]}'
+    http_version: null
+  recorded_at: Sat, 18 Apr 2020 19:53:30 GMT
+recorded_with: VCR 5.1.0

--- a/spec/cassettes/jnicklas/carrierwave.yml
+++ b/spec/cassettes/jnicklas/carrierwave.yml
@@ -1,0 +1,90 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.github.com/graphql
+    body:
+      encoding: UTF-8
+      string: '{"query":"query RepositoryDataQuery($owner: String!, $name: String!)
+        {\n\n  repository(owner: $owner, name: $name) {\n    nameWithOwner\n    forks
+        {\n      totalCount\n    }\n    stargazers {\n      totalCount\n    }\n    watchers
+        {\n      totalCount\n    }\n    createdAt\n    defaultBranchRef {\n      name\n      target
+        {\n        ... on Commit {\n          history(first: 50) {\n            edges
+        {\n              node {\n                authoredDate\n              }\n            }\n          }\n        }\n      }\n    }\n    description\n    hasIssuesEnabled\n    hasWikiEnabled\n    homepageUrl\n    isArchived\n    isFork\n    isMirror\n    licenseInfo
+        {\n      key\n    }\n    primaryLanguage {\n      name\n    }\n    pushedAt\n    closedIssues:
+        issues(states: CLOSED) {\n      totalCount\n    }\n    openIssues: issues(states:
+        OPEN) {\n      totalCount\n    }\n    closedPullRequests: pullRequests(states:
+        CLOSED) {\n      totalCount\n    }\n    openPullRequests: pullRequests(states:
+        OPEN) {\n      totalCount\n    }\n    mergedPullRequests: pullRequests(states:
+        MERGED) {\n      totalCount\n    }\n    repositoryTopics(first: 100) {\n      nodes
+        {\n        topic {\n          name\n        }\n      }\n    }\n    codeOfConduct
+        {\n      name\n      url\n    }\n  }\n  rateLimit {\n    limit\n    cost\n    remaining\n    resetAt\n  }\n}\n","variables":{"owner":"jnicklas","name":"carrierwave"}}'
+    headers:
+      Authorization:
+      - bearer <GITHUB_TOKEN>
+      User-Agent:
+      - ruby-toolbox.com API client
+      Connection:
+      - close
+      Host:
+      - api.github.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 18 Apr 2020 19:53:30 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '3394'
+      Connection:
+      - close
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      Cache-Control:
+      - no-cache
+      X-Oauth-Scopes:
+      - ''
+      X-Accepted-Oauth-Scopes:
+      - repo
+      X-Github-Media-Type:
+      - github.v4; format=json
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4992'
+      X-Ratelimit-Reset:
+      - '1587242742'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - A3AE:509C:13E663A:17268C2:5E9B5ABA
+    body:
+      encoding: UTF-8
+      string: '{"data":{"repository":{"nameWithOwner":"carrierwaveuploader/carrierwave","forks":{"totalCount":1473},"stargazers":{"totalCount":8483},"watchers":{"totalCount":149},"createdAt":"2008-08-28T18:39:49Z","defaultBranchRef":{"name":"master","target":{"history":{"edges":[{"node":{"authoredDate":"2020-02-24T09:31:06Z"}},{"node":{"authoredDate":"2020-02-18T10:33:16Z"}},{"node":{"authoredDate":"2020-02-16T09:07:08Z"}},{"node":{"authoredDate":"2020-02-16T08:04:46Z"}},{"node":{"authoredDate":"2019-12-27T03:58:41Z"}},{"node":{"authoredDate":"2019-12-25T17:45:42Z"}},{"node":{"authoredDate":"2019-12-24T19:26:45Z"}},{"node":{"authoredDate":"2019-12-24T05:20:29Z"}},{"node":{"authoredDate":"2019-12-24T05:02:05Z"}},{"node":{"authoredDate":"2019-12-13T04:26:27Z"}},{"node":{"authoredDate":"2019-11-25T12:12:07Z"}},{"node":{"authoredDate":"2019-11-18T20:38:47Z"}},{"node":{"authoredDate":"2019-11-15T20:52:00Z"}},{"node":{"authoredDate":"2019-09-28T05:09:48Z"}},{"node":{"authoredDate":"2019-09-10T05:34:24Z"}},{"node":{"authoredDate":"2019-09-10T06:28:19Z"}},{"node":{"authoredDate":"2019-09-10T04:08:00Z"}},{"node":{"authoredDate":"2019-09-10T03:41:49Z"}},{"node":{"authoredDate":"2019-08-31T03:40:41Z"}},{"node":{"authoredDate":"2019-08-25T07:32:53Z"}},{"node":{"authoredDate":"2019-08-18T03:42:05Z"}},{"node":{"authoredDate":"2019-06-23T08:10:56Z"}},{"node":{"authoredDate":"2019-06-23T03:38:18Z"}},{"node":{"authoredDate":"2019-06-23T03:25:01Z"}},{"node":{"authoredDate":"2019-06-22T09:55:16Z"}},{"node":{"authoredDate":"2019-06-22T06:59:28Z"}},{"node":{"authoredDate":"2019-06-21T12:56:13Z"}},{"node":{"authoredDate":"2019-06-21T09:51:16Z"}},{"node":{"authoredDate":"2019-06-21T07:08:47Z"}},{"node":{"authoredDate":"2019-06-20T02:46:42Z"}},{"node":{"authoredDate":"2019-06-19T06:58:45Z"}},{"node":{"authoredDate":"2019-06-19T06:20:15Z"}},{"node":{"authoredDate":"2019-06-19T05:53:18Z"}},{"node":{"authoredDate":"2019-06-18T10:29:04Z"}},{"node":{"authoredDate":"2019-06-18T09:31:22Z"}},{"node":{"authoredDate":"2019-06-18T07:40:08Z"}},{"node":{"authoredDate":"2019-06-18T07:25:32Z"}},{"node":{"authoredDate":"2019-06-18T04:06:18Z"}},{"node":{"authoredDate":"2019-05-19T03:36:30Z"}},{"node":{"authoredDate":"2019-06-16T10:36:12Z"}},{"node":{"authoredDate":"2019-06-15T03:02:31Z"}},{"node":{"authoredDate":"2019-06-11T09:58:47Z"}},{"node":{"authoredDate":"2019-06-11T08:37:32Z"}},{"node":{"authoredDate":"2019-06-07T08:20:00Z"}},{"node":{"authoredDate":"2019-06-03T14:18:13Z"}},{"node":{"authoredDate":"2019-05-23T09:06:00Z"}},{"node":{"authoredDate":"2019-05-22T07:05:51Z"}},{"node":{"authoredDate":"2019-05-19T02:39:37Z"}},{"node":{"authoredDate":"2019-05-16T07:15:10Z"}},{"node":{"authoredDate":"2019-05-16T06:40:58Z"}}]}}},"description":"Classier
+        solution for file uploads for Rails, Sinatra and other Ruby web frameworks","hasIssuesEnabled":true,"hasWikiEnabled":true,"homepageUrl":"https://github.com/carrierwaveuploader/carrierwave","isArchived":false,"isFork":false,"isMirror":false,"licenseInfo":null,"primaryLanguage":{"name":"Ruby"},"pushedAt":"2020-04-18T15:20:46Z","closedIssues":{"totalCount":1573},"openIssues":{"totalCount":141},"closedPullRequests":{"totalCount":252},"openPullRequests":{"totalCount":8},"mergedPullRequests":{"totalCount":496},"repositoryTopics":{"nodes":[]},"codeOfConduct":null},"rateLimit":{"limit":5000,"cost":1,"remaining":4992,"resetAt":"2020-04-18T20:45:42Z"}}}'
+    http_version: null
+  recorded_at: Sat, 18 Apr 2020 19:53:30 GMT
+recorded_with: VCR 5.1.0

--- a/spec/cassettes/rails/unknown_repo.yml
+++ b/spec/cassettes/rails/unknown_repo.yml
@@ -61,6 +61,93 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version: null
   recorded_at: Thu, 22 Mar 2018 23:15:14 GMT
-recorded_with: VCR 4.0.0
+- request:
+    method: post
+    uri: https://api.github.com/graphql
+    body:
+      encoding: UTF-8
+      string: '{"query":"query RepositoryDataQuery($owner: String!, $name: String!)
+        {\n\n  repository(owner: $owner, name: $name) {\n    nameWithOwner\n    forks
+        {\n      totalCount\n    }\n    stargazers {\n      totalCount\n    }\n    watchers
+        {\n      totalCount\n    }\n    createdAt\n    defaultBranchRef {\n      name\n      target
+        {\n        ... on Commit {\n          history(first: 50) {\n            edges
+        {\n              node {\n                authoredDate\n              }\n            }\n          }\n        }\n      }\n    }\n    description\n    hasIssuesEnabled\n    hasWikiEnabled\n    homepageUrl\n    isArchived\n    isFork\n    isMirror\n    licenseInfo
+        {\n      key\n    }\n    primaryLanguage {\n      name\n    }\n    pushedAt\n    closedIssues:
+        issues(states: CLOSED) {\n      totalCount\n    }\n    openIssues: issues(states:
+        OPEN) {\n      totalCount\n    }\n    closedPullRequests: pullRequests(states:
+        CLOSED) {\n      totalCount\n    }\n    openPullRequests: pullRequests(states:
+        OPEN) {\n      totalCount\n    }\n    mergedPullRequests: pullRequests(states:
+        MERGED) {\n      totalCount\n    }\n    repositoryTopics(first: 100) {\n      nodes
+        {\n        topic {\n          name\n        }\n      }\n    }\n    codeOfConduct
+        {\n      name\n      url\n    }\n  }\n  rateLimit {\n    limit\n    cost\n    remaining\n    resetAt\n  }\n}\n","variables":{"owner":"rails","name":"unknown"}}'
+    headers:
+      Authorization:
+      - bearer <GITHUB_TOKEN>
+      User-Agent:
+      - ruby-toolbox.com API client
+      Connection:
+      - close
+      Host:
+      - api.github.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 18 Apr 2020 19:54:42 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '275'
+      Connection:
+      - close
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      Cache-Control:
+      - no-cache
+      X-Oauth-Scopes:
+      - ''
+      X-Accepted-Oauth-Scopes:
+      - repo
+      X-Github-Media-Type:
+      - github.v4; format=json
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4990'
+      X-Ratelimit-Reset:
+      - '1587242741'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - A374:13927:26A4A06:2D29DA9:5E9B5B02
+    body:
+      encoding: UTF-8
+      string: '{"data":{"repository":null,"rateLimit":{"limit":5000,"cost":1,"remaining":4990,"resetAt":"2020-04-18T20:45:41Z"}},"errors":[{"type":"NOT_FOUND","path":["repository"],"locations":[{"line":3,"column":3}],"message":"Could
+        not resolve to a Repository with the name ''unknown''."}]}'
+    http_version: null
+  recorded_at: Sat, 18 Apr 2020 19:54:42 GMT
+recorded_with: VCR 5.1.0

--- a/spec/integration/github_client_spec.rb
+++ b/spec/integration/github_client_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe GithubClient, :real_http do
   describe "for invalid reference to an org", vcr: { cassette_name: "github/org_reference" } do
     it "raises a GithubClient::UnknownRepoError" do
       expect { client.fetch_repository("orgs/acdcorp") }.to raise_error(
-        GithubClient::UnknownRepoError, /Cannot find repo/
+        GithubClient::UnknownRepoError, /NOT_FOUND/
       )
     end
   end
@@ -53,7 +53,7 @@ RSpec.describe GithubClient, :real_http do
   describe "for unknown repo", vcr: { cassette_name: "graphql/fails" } do
     it "raises a GithubClient::UnknownRepoError" do
       expect { client.fetch_repository("thisverylikely/fails") }.to raise_error(
-        GithubClient::UnknownRepoError, /Cannot find repo/
+        GithubClient::UnknownRepoError, /NOT_FOUND/
       )
     end
   end
@@ -70,7 +70,7 @@ RSpec.describe GithubClient, :real_http do
   # This is currently not possible with Github's GraphQL API :(
   # https://platform.github.community/t/repository-redirects-in-api-v4-graphql/4417
   #
-  describe "for a moved repo", vcr: { cassette_name: "graphql/carrierwave" } do
+  describe "for a moved repo", vcr: { cassette_name: "jnicklas/carrierwave" } do
     it "resolves to the real repository path" do
       response = client.fetch_repository "jnicklas/carrierwave"
       expect(response.path).to be == "carrierwaveuploader/carrierwave"

--- a/spec/services/github_client_spec.rb
+++ b/spec/services/github_client_spec.rb
@@ -7,14 +7,22 @@ RSpec.describe GithubClient do
   let(:client) { described_class.new token: token }
 
   it "raises an InvalidResponseStatus when the response has status 400" do
-    stub_request(:head, "https://github.com/rspec/rspec")
-      .to_return(status: 200)
-
     stub_request(:post, "https://api.github.com/graphql")
       .to_return(status: 400)
 
     expect { client.fetch_repository("rspec/rspec") }.to raise_error(
       described_class::InvalidResponseStatus, /status=400/
+    )
+  end
+
+  it "raises an InvalidResponse when there are errors in the graphql response" do
+    response_body = JSON.dump(errors: [{ message: "hello world" }])
+
+    stub_request(:post, "https://api.github.com/graphql")
+      .to_return(status: 200, body: response_body)
+
+    expect { client.fetch_repository("foo/bar") }.to raise_error(
+      described_class::InvalidResponse, /hello world/
     )
   end
 end


### PR DESCRIPTION
Back on original implementation of the graphql API consumption code Github GraphQL API did not support querying for moved repos (i.e. jnicklas/carrierwave moved, but on REST API you'd get a proper redirect), so first we were pinging the regular HTML page to fetch the repo. However I strongly suspect this does nowadays cause https://github.com/rubytoolbox/rubytoolbox/issues/615 as we more often than not get an error response back from Github, maybe due to the anonymous requesting client or whatever.

This should bring the syncing to not erroneously cause the magic "UnknownRepo" exception any longer, leading to the dreaded repo gone red banner on ruby toolbox.