### PR TITLE
Drop CI workaround from #639

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
   prepare:
     working_directory: ~/repo
     docker:
-       - image: circleci/ruby:2.6.5-node-browsers
+       - image: circleci/ruby:2.6.6-node-browsers
 
     steps:
       - checkout
@@ -66,7 +66,7 @@ jobs:
     working_directory: ~/repo
 
     docker:
-       - image: circleci/ruby:2.6.5-node-browsers
+       - image: circleci/ruby:2.6.6-node-browsers
        - image: circleci/postgres:12.1-alpine-ram
          environment:
            # Required by the postgres image to setup the appropriate database and user on launch
@@ -103,7 +103,7 @@ jobs:
     working_directory: ~/repo
 
     docker:
-       - image: circleci/ruby:2.6.5-node-browsers
+       - image: circleci/ruby:2.6.6-node-browsers
 
     steps:
       - prepare_repo

--- a/Gemfile
+++ b/Gemfile
@@ -2,13 +2,7 @@
 
 source "https://rubygems.org"
 
-# Hack around issue that circleci ruby docker image for 2.6.6 is not available
-# yet we want to deploy with that to include ruby security fix.
-if ENV["CI"]
-  ruby "2.6.5"
-else
-  ruby File.read(File.join(__dir__, ".ruby-version")).strip
-end
+ruby File.read(File.join(__dir__, ".ruby-version")).strip
 
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 


### PR DESCRIPTION
The docker image is now available, the hack from #639 can go