### PR TITLE
Allow CORS requests on API endpoints

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,6 +86,8 @@ gem "turbolinks", "~> 5"
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 
+gem "rack-cors"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,6 +223,8 @@ GEM
     rack-canonical-host (1.0.0)
       addressable (> 0, < 3)
       rack (>= 1.0.0, < 3)
+    rack-cors (1.1.1)
+      rack (>= 2.0.0)
     rack-protection (2.0.8.1)
       rack
     rack-proxy (0.6.5)
@@ -448,6 +450,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rack-canonical-host
+  rack-cors
   rack-ssl-enforcer
   rails (~> 5.2.0)
   rails-controller-testing

--- a/config/application.rb
+++ b/config/application.rb
@@ -46,5 +46,12 @@ module Rubytoolbox
     end
 
     config.http_connect = true
+
+    config.middleware.insert_before 0, Rack::Cors do
+      allow do
+        origins "*"
+        resource "/api/*", headers: :any, methods: :get
+      end
+    end
   end
 end

--- a/spec/requests/api/projects/compare_spec.rb
+++ b/spec/requests/api/projects/compare_spec.rb
@@ -77,4 +77,22 @@ RSpec.describe "Project Comparison API", type: :request do
       }
     end
   end
+
+  describe "when being requested cross-origin" do
+    def do_request
+      get "/api/projects/compare/foo", headers: { "HTTP_ORIGIN" => "foo.com" }
+    end
+
+    it "responds with an appropriate CORS origin header" do
+      do_request
+
+      expect(response.headers).to have_key("Access-Control-Allow-Origin")
+    end
+
+    it "responds with an appropriate CORS methods header" do
+      do_request
+
+      expect(response.headers).to have_key("Access-Control-Allow-Methods")
+    end
+  end
 end


### PR DESCRIPTION
Closes #666

If you're open to it, this would allow other webpages to request things from the API, such that people could build things like chrome plugins or other sites that can take advantage of the great information living in the rubytoolbox!