### PR TITLE
Fix UI regression tests false positives

### DIFF
--- a/app/assets/javascripts/charts/bar_chart.js
+++ b/app/assets/javascripts/charts/bar_chart.js
@@ -16,6 +16,7 @@ var barChart = function(selector, labels, values) {
       ]
     },
     options: {
+      animation: false,
       legend: {
         display: false
       },

--- a/app/assets/javascripts/charts/line_chart.js
+++ b/app/assets/javascripts/charts/line_chart.js
@@ -19,6 +19,7 @@ var lineChart = function(selector, labels, values, scale) {
       ]
     },
     options: {
+      animation: false,
       legend: {
         display: false
       },

--- a/app/assets/javascripts/charts/rubygem_download_chart.js
+++ b/app/assets/javascripts/charts/rubygem_download_chart.js
@@ -27,6 +27,7 @@ var rubygemDownloadChart = function(selector, totalDownloads, monthlyDownloads) 
       ]
     },
     options: {
+      animation: false,
       tooltips: {
         mode: "index",
         intersect: false,

--- a/app/views/pages/components/landing_feature.html.slim
+++ b/app/views/pages/components/landing_feature.html.slim
@@ -6,13 +6,12 @@
 
 .container
   .landing-features
-    - 4.times do
+    - 4.times do |i|
       = landing_feature title: "Hello World", image: "startpage/ruby.png" do
         article
-          - if rand(10) < 8
-            p Lorem ipsum dolor sit amet, consectetur adipisici elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat.
+          p Lorem ipsum dolor sit amet, consectetur adipisici elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat.
 
-          - if rand(10) < 5
+          - if i.even?
             p Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
 
         footer


### PR DESCRIPTION
The automated UI regression tests introduced via #657 were giving a bunch of false positives on the components example pages - [example can be found here](https://percy.io/rubytoolbox/rubytoolbox/builds/5459155)

One of them was a randomly displayed amount of lorem ipsum, fixed that to be deterministic.

The other part was the chart.js showup animation being in different stages of the animation. I considered waiting for animations to finish or such, but ultimately I just decided to disable them altogether since I believe their presence actually makes the pages appear to load slower then they are, so that should resolve that.