### PR TITLE
Repo README syncing

### DIFF
--- a/app/jobs/github_repo_update_job.rb
+++ b/app/jobs/github_repo_update_job.rb
@@ -83,12 +83,15 @@ class GithubRepoUpdateJob < ApplicationJob
 
   def update_readme_for_repo(repo)
     readme = client.fetch_readme repo.path, etag: repo.readme_etag
-    return unless readme
 
-    Github::Readme.find_or_initialize_by(path: repo.path).update!(
-      html: readme.html,
-      etag: readme.etag
-    )
+    if readme
+      Github::Readme.find_or_initialize_by(path: repo.path).update!(
+        html: readme.html,
+        etag: readme.etag
+      )
+    else
+      Github::Readme.where(path: repo.path).destroy_all
+    end
   end
 
   def trigger_project_updates(project_permalinks)

--- a/app/jobs/github_repo_update_job.rb
+++ b/app/jobs/github_repo_update_job.rb
@@ -59,6 +59,9 @@ class GithubRepoUpdateJob < ApplicationJob
       # Set updated at to ensure we flag what we've pulled
       repo.updated_at = repo.fetched_at = Time.current.utc
       repo.update! mapped_attributes(info)
+
+      update_readme_for_repo repo
+
       trigger_project_updates repo.projects.pluck(:permalink)
     end
   end
@@ -76,6 +79,16 @@ class GithubRepoUpdateJob < ApplicationJob
   rescue GithubClient::UnknownRepoError
     GithubIgnore.track! path
     nil
+  end
+
+  def update_readme_for_repo(repo)
+    readme = client.fetch_readme repo.path, etag: repo.readme_etag
+    return unless readme
+
+    Github::Readme.find_or_initialize_by(path: repo.path).update!(
+      html: readme.html,
+      etag: readme.etag
+    )
   end
 
   def trigger_project_updates(project_permalinks)

--- a/app/models/github/readme.rb
+++ b/app/models/github/readme.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Github::Readme < ApplicationRecord
+  self.primary_key = :path
+  self.table_name = :github_readmes
+
+  belongs_to :github_repo,
+             primary_key: :path,
+             foreign_key: :path,
+             inverse_of:  :readme
+end

--- a/app/models/github_repo.rb
+++ b/app/models/github_repo.rb
@@ -12,6 +12,19 @@ class GithubRepo < ApplicationRecord
   has_many :rubygems,
            through: :projects
 
+  has_one :readme,
+          primary_key: :path,
+          foreign_key: :path,
+          inverse_of:  :github_repo,
+          class_name:  "Github::Readme",
+          dependent:   :destroy
+
+  delegate :html,
+           :etag,
+           to:        :readme,
+           allow_nil: true,
+           prefix:    :readme
+
   def self.update_batch
     where("updated_at < ? ", 24.hours.ago.utc)
       .order(updated_at: :asc)

--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -5,7 +5,7 @@ class GithubClient
   class InvalidResponseStatus < StandardError; end
   class UnknownRepoError < StandardError; end
 
-  DEFAULT_TIMEOUT = 5.seconds
+  DEFAULT_TIMEOUT = 15.seconds
   REPOSITORY_DATA_QUERY = Rails.root.join("app", "graphql-queries", "github", "repo.graphql").read
 
   attr_accessor :token, :http_client
@@ -25,12 +25,12 @@ class GithubClient
     owner, name = path.split("/")
     body = { query: REPOSITORY_DATA_QUERY, variables: { owner: owner, name: name } }
     response = authenticated_client.post "https://api.github.com/graphql", body: Oj.dump(body, mode: :compat)
-    handle_response response
+    handle_repo_response response
   end
 
   private
 
-  def handle_response(response)
+  def handle_repo_response(response)
     raise InvalidResponseStatus, "status=#{response.status}" unless response.status == 200
 
     parsed_body = Oj.load(response.body)

--- a/db/migrate/20200830205823_create_github_readmes.rb
+++ b/db/migrate/20200830205823_create_github_readmes.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateGithubReadmes < ActiveRecord::Migration[6.0]
+  def change
+    create_table :github_readmes, id: false do |t|
+      t.string :path, null: false
+      t.text :html, null: false
+      t.string :etag, null: false
+      t.timestamps
+    end
+
+    add_index :github_readmes, :path, unique: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -24,20 +24,6 @@ COMMENT ON EXTENSION citext IS 'data type for case-insensitive character strings
 
 
 --
--- Name: pg_stat_statements; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS pg_stat_statements WITH SCHEMA public;
-
-
---
--- Name: EXTENSION pg_stat_statements; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION pg_stat_statements IS 'track execution statistics of all SQL statements executed';
-
-
---
 -- Name: categories_update_description_tsvector_trigger(); Type: FUNCTION; Schema: public; Owner: -
 --
 
@@ -135,8 +121,8 @@ SET default_table_access_method = heap;
 CREATE TABLE public.ar_internal_metadata (
     key character varying NOT NULL,
     value character varying,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
 );
 
 
@@ -210,6 +196,19 @@ CREATE TABLE public.github_ignores (
     path character varying NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: github_readmes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.github_readmes (
+    path character varying NOT NULL,
+    html text NOT NULL,
+    etag character varying NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
 );
 
 
@@ -519,6 +518,13 @@ CREATE UNIQUE INDEX index_github_ignores_on_path ON public.github_ignores USING 
 
 
 --
+-- Name: index_github_readmes_on_path; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_github_readmes_on_path ON public.github_readmes USING btree (path);
+
+
+--
 -- Name: index_github_repos_on_path; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -773,6 +779,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190228101125'),
 ('20190228102103'),
 ('20190508190527'),
-('20190730194020');
+('20190730194020'),
+('20200830205823');
 
 

--- a/spec/cassettes/full-project-sync-from-gem.yml
+++ b/spec/cassettes/full-project-sync-from-gem.yml
@@ -94,7 +94,6 @@ http_interactions:
         to make thread-safe programming in Ruby easier","licenses":["Apache-2.0"],"metadata":{},"sha":"9ed7072821b51c57e8d6b7011a8e282e25aeea3a4065eab326e43f66f063b05a","project_uri":"https://rubygems.org/gems/thread_safe","gem_uri":"https://rubygems.org/gems/thread_safe-0.3.6.gem","homepage_uri":"https://github.com/ruby-concurrency/thread_safe","wiki_uri":"","documentation_uri":"http://ruby-concurrency.github.io/thread_safe/frames.html","mailing_list_uri":"https://groups.google.com/forum/#!forum/concurrent-ruby","source_code_uri":"https://github.com/ruby-concurrency/thread_safe","bug_tracker_uri":"https://github.com/ruby-concurrency/thread_safe/issues","changelog_uri":null,"dependencies":{"development":[{"name":"atomic","requirements":"=
         1.1.16"},{"name":"rake","requirements":"\u003c 12.0"},{"name":"rspec","requirements":"~\u003e
         3.2"}],"runtime":[]}}'
-    http_version: 
   recorded_at: Wed, 05 Dec 2018 14:33:47 GMT
 - request:
     method: get
@@ -288,7 +287,6 @@ http_interactions:
         collections and utilities for Ruby","downloads_count":1895,"metadata":{},"number":"0.0.1","summary":"A
         collection of data structures and utilities to make thread-safe programming
         in Ruby easier","platform":"ruby","rubygems_version":"\u003e= 0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"b1f7dfeb8bc765e421a90836c6a7e7dbe587abe238b2f660a89c6ad6e8e4975d"}]'
-    http_version: 
   recorded_at: Wed, 05 Dec 2018 14:33:48 GMT
 - request:
     method: get
@@ -374,7 +372,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '["killbill-paypal-express","killbill-stripe","killbill-litle","killbill-payment-test","killbill","sportweb","killbill-cybersource","datashift","logstash-input-syslog","asciidoctor-epub3","tzinfo","asciidoctor-revealjs","easy_translate","killbill-chartmogul","killbill-securenet","killbill-firstdata_e4","killbill-payu-latam","rohbau","slack-cli","rester","neo4j_legacy","sliday_backup","asciidoctor-html5s","logstash-input-beats","lines-engine","metanorma-m3d","metanorma-csand","isodoc","gooddata","gooddata","splitclient-rb","splitclient-rb","killbill-orbital","logstash-core","protobuf","asciidoctor-rfc","asciidoctor-doctest","ldclient-rb","html2doc","peastash","sequent","hu","asciidoctor-m3d","asciidoctor-csand","iplan-appsignal","fluent-plugin-multiline-parser","asciidoctor-bespoke","asciidoctor-pdf","gooddata-edge","nexpose_pxgrid","wechat_client","killbill-braintree_blue","protobuffy","docli","backup-ssh","asciidoctor-instant-articles","asciidoctor-accelerated-mobile-pages","mixture","asciidoctor-htmlbook","shuttle_cli","elastics","s3reamer","pg_helper","turbot-ruby-gems","dry-data","ruby-dovado","collectr","zapnito-cli","logstash-filter-throttle","logstash-filter-metrics","fleck","arkency-command_bus","wet-command_bus","rom-generated_id","persie","prepor-protobuf","stapfen","hexx-storage","pd-blender","vigilem-core","hermann","hermann","colossus","aws_student_accounts","deviseOne","thread_hazardous","whisperer","mock_dns_server","venet-backup","devision","postamt","brainsome_devise","multi_connection","backup_zh","email_crawler","ruby_storm","persistent_excon","faraday_persistent_excon","smelter","pagseguro-transparente","ruby_nsq","r4s","cache_digests","tickr_client","racing-sprockets","clasp","gemerald_beanstalk","ruby_skynet","autodeps","dskiplist","barker","memoizable","descendants_tracker","axiom-types","devise-bootstrap","devbootsrap","axiom-memory-adapter","mongoid_connection_pool","cap_proxy","jirabas","gene_pool","metrics_logger"]'
-    http_version: 
   recorded_at: Wed, 05 Dec 2018 14:33:48 GMT
 - request:
     method: head
@@ -442,7 +439,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
   recorded_at: Wed, 05 Dec 2018 14:33:49 GMT
 - request:
     method: post
@@ -527,6 +523,130 @@ http_interactions:
       encoding: UTF-8
       string: '{"data":{"repository":{"nameWithOwner":"ruby-concurrency/thread_safe","forks":{"totalCount":15},"stargazers":{"totalCount":188},"watchers":{"totalCount":13},"createdAt":"2014-06-06T22:13:43Z","defaultBranchRef":{"name":"master","target":{"history":{"edges":[{"node":{"authoredDate":"2017-07-23T14:05:43Z"}},{"node":{"authoredDate":"2017-07-03T16:42:54Z"}},{"node":{"authoredDate":"2017-02-22T19:45:05Z"}},{"node":{"authoredDate":"2017-01-28T23:20:05Z"}},{"node":{"authoredDate":"2017-01-22T18:38:37Z"}},{"node":{"authoredDate":"2017-01-06T13:23:43Z"}},{"node":{"authoredDate":"2016-06-07T13:16:04Z"}},{"node":{"authoredDate":"2016-06-06T12:06:31Z"}},{"node":{"authoredDate":"2015-04-28T02:01:09Z"}},{"node":{"authoredDate":"2015-04-28T01:49:03Z"}},{"node":{"authoredDate":"2015-04-28T01:36:49Z"}},{"node":{"authoredDate":"2015-04-27T20:59:17Z"}},{"node":{"authoredDate":"2015-04-26T20:21:05Z"}},{"node":{"authoredDate":"2015-04-26T19:05:43Z"}},{"node":{"authoredDate":"2015-04-19T13:37:09Z"}},{"node":{"authoredDate":"2015-04-16T22:52:02Z"}},{"node":{"authoredDate":"2015-03-27T21:41:27Z"}},{"node":{"authoredDate":"2015-03-25T23:52:19Z"}},{"node":{"authoredDate":"2015-03-25T22:44:54Z"}},{"node":{"authoredDate":"2015-03-25T22:43:58Z"}},{"node":{"authoredDate":"2015-03-24T22:38:37Z"}},{"node":{"authoredDate":"2015-03-24T20:51:16Z"}},{"node":{"authoredDate":"2015-03-11T14:53:29Z"}},{"node":{"authoredDate":"2015-03-11T13:06:08Z"}},{"node":{"authoredDate":"2015-03-10T02:53:22Z"}},{"node":{"authoredDate":"2015-03-10T01:57:54Z"}},{"node":{"authoredDate":"2015-03-09T15:32:09Z"}},{"node":{"authoredDate":"2015-03-09T14:58:58Z"}},{"node":{"authoredDate":"2015-03-09T14:46:32Z"}},{"node":{"authoredDate":"2015-03-09T14:45:27Z"}},{"node":{"authoredDate":"2015-03-09T14:45:07Z"}},{"node":{"authoredDate":"2015-03-09T14:44:32Z"}},{"node":{"authoredDate":"2015-03-09T13:43:43Z"}},{"node":{"authoredDate":"2015-03-09T03:12:17Z"}},{"node":{"authoredDate":"2015-03-08T22:10:06Z"}},{"node":{"authoredDate":"2015-03-08T22:03:48Z"}},{"node":{"authoredDate":"2015-03-08T21:50:50Z"}},{"node":{"authoredDate":"2015-03-08T20:02:49Z"}},{"node":{"authoredDate":"2015-03-08T19:47:17Z"}},{"node":{"authoredDate":"2015-03-06T12:22:37Z"}},{"node":{"authoredDate":"2015-03-06T12:15:26Z"}},{"node":{"authoredDate":"2015-02-15T13:43:02Z"}},{"node":{"authoredDate":"2015-02-15T00:19:11Z"}},{"node":{"authoredDate":"2014-05-27T19:48:23Z"}},{"node":{"authoredDate":"2014-05-27T19:54:14Z"}},{"node":{"authoredDate":"2014-05-27T19:47:37Z"}},{"node":{"authoredDate":"2014-05-27T19:45:13Z"}},{"node":{"authoredDate":"2014-04-12T17:48:35Z"}},{"node":{"authoredDate":"2014-04-12T17:47:24Z"}},{"node":{"authoredDate":"2014-04-12T17:46:44Z"}}]}}},"description":"[DEPRECATED]
         Thread-safe collections for Ruby (merged with concurrent-ruby)","hasIssuesEnabled":true,"hasWikiEnabled":true,"homepageUrl":"http://concurrent-ruby.com","isArchived":false,"isFork":false,"isMirror":false,"licenseInfo":{"key":"apache-2.0"},"primaryLanguage":{"name":"Java"},"pushedAt":"2018-01-29T06:45:29Z","closedIssues":{"totalCount":12},"openIssues":{"totalCount":1},"closedPullRequests":{"totalCount":3},"openPullRequests":{"totalCount":0},"mergedPullRequests":{"totalCount":16},"repositoryTopics":{"nodes":[]},"codeOfConduct":null},"rateLimit":{"limit":5000,"cost":1,"remaining":2436,"resetAt":"2018-12-05T14:55:35Z"}}}'
-    http_version: 
   recorded_at: Wed, 05 Dec 2018 14:33:50 GMT
-recorded_with: VCR 4.0.0
+- request:
+    method: get
+    uri: https://api.github.com/repos/ruby-concurrency/thread_safe/readme
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Authorization:
+      - bearer <GITHUB_TOKEN>
+      User-Agent:
+      - ruby-toolbox.com API client
+      Accept:
+      - application/vnd.github.v3.html
+      Connection:
+      - close
+      Host:
+      - api.github.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 30 Aug 2020 21:40:33 GMT
+      Content-Type:
+      - application/vnd.github.v3.html; charset=utf-8
+      Content-Length:
+      - '8412'
+      Connection:
+      - close
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding
+      - Accept-Encoding, Accept, X-Requested-With
+      Etag:
+      - '"9989bcf5eab45cb8f347e0a9ae3b9c9b"'
+      Last-Modified:
+      - Sun, 23 Jul 2017 14:05:43 GMT
+      X-Oauth-Scopes:
+      - ''
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; param=html
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4966'
+      X-Ratelimit-Reset:
+      - '1598827195'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - 893C:59C6:D3D46AE:FFEA768:5F4C1CD1
+    body:
+      encoding: UTF-8
+      string: |-
+        <div id="readme" class="md" data-path="README.md"><article class="markdown-body entry-content container-lg" itemprop="text"><h1><a id="user-content-threadsafe-inactive-code-moved-to-concurrent-ruby-gem-and-repo" class="anchor" aria-hidden="true" href="#threadsafe-inactive-code-moved-to-concurrent-ruby-gem-and-repo"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Threadsafe (Inactive, code moved to concurrent-ruby gem and repo.)</h1>
+        <p><a href="http://badge.fury.io/rb/thread_safe" rel="nofollow"><img src="https://camo.githubusercontent.com/a603c1f6213d1519feeef38afdd85b01da126ef8/68747470733a2f2f62616467652e667572792e696f2f72622f7468726561645f736166652e737667" alt="Gem Version" data-canonical-src="https://badge.fury.io/rb/thread_safe.svg" style="max-width:100%;"></a> <a href="https://travis-ci.org/ruby-concurrency/thread_safe" rel="nofollow"><img src="https://camo.githubusercontent.com/a374999c8acfadc2da1ec4cc56a56706201edd70/68747470733a2f2f7472617669732d63692e6f72672f727562792d636f6e63757272656e63792f7468726561645f736166652e7376673f6272616e63683d6d6173746572" alt="Build Status" data-canonical-src="https://travis-ci.org/ruby-concurrency/thread_safe.svg?branch=master" style="max-width:100%;"></a> <a href="https://coveralls.io/r/ruby-concurrency/thread_safe" rel="nofollow"><img src="https://camo.githubusercontent.com/eb717218d847c138070156abaada1402c499be47/68747470733a2f2f696d672e736869656c64732e696f2f636f766572616c6c732f727562792d636f6e63757272656e63792f7468726561645f736166652f6d61737465722e737667" alt="Coverage Status" data-canonical-src="https://img.shields.io/coveralls/ruby-concurrency/thread_safe/master.svg" style="max-width:100%;"></a> <a href="https://codeclimate.com/github/ruby-concurrency/thread_safe" rel="nofollow"><img src="https://camo.githubusercontent.com/fad29936ff5bf3caa355314766c61c4dde995162/68747470733a2f2f636f6465636c696d6174652e636f6d2f6769746875622f727562792d636f6e63757272656e63792f7468726561645f736166652e737667" alt="Code Climate" data-canonical-src="https://codeclimate.com/github/ruby-concurrency/thread_safe.svg" style="max-width:100%;"></a> <a href="https://gemnasium.com/ruby-concurrency/thread_safe" rel="nofollow"><img src="https://camo.githubusercontent.com/66aa77014e2dd696094dff1182237a040e6a7cd1/68747470733a2f2f67656d6e617369756d2e636f6d2f727562792d636f6e63757272656e63792f7468726561645f736166652e737667" alt="Dependency Status" data-canonical-src="https://gemnasium.com/ruby-concurrency/thread_safe.svg" style="max-width:100%;"></a> <a href="http://opensource.org/licenses/MIT" rel="nofollow"><img src="https://camo.githubusercontent.com/7b3fba2a0efa6c0702424028a9adfd40edd15206/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f6c6963656e73652d6170616368652d677265656e2e737667" alt="License" data-canonical-src="https://img.shields.io/badge/license-apache-green.svg" style="max-width:100%;"></a> <a href="https://gitter.im/ruby-concurrency/concurrent-ruby" rel="nofollow"><img src="https://camo.githubusercontent.com/0565e65837c81ceeaf29bc0c23c9a2225ce35991/687474703a2f2f696d672e736869656c64732e696f2f62616467652f6769747465722d6a6f696e253230636861742532302545322538362539322d627269676874677265656e2e737667" alt="Gitter chat" data-canonical-src="http://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg" style="max-width:100%;"></a></p>
+        <p>A collection of thread-safe versions of common core Ruby classes.</p>
+        <p><strong>This code base is now part of the concurrent-ruby gem
+        at <a href="https://github.com/ruby-concurrency/concurrent-ruby">https://github.com/ruby-concurrency/concurrent-ruby</a>.
+        The code in this repository is no longer maintained.</strong></p>
+        <h2><a id="user-content-installation" class="anchor" aria-hidden="true" href="#installation"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Installation</h2>
+        <p>Add this line to your application's Gemfile:</p>
+        <pre><code>gem 'thread_safe'
+        </code></pre>
+        <p>And then execute:</p>
+        <pre><code>$ bundle
+        </code></pre>
+        <p>Or install it yourself as:</p>
+        <pre><code>$ gem install thread_safe
+        </code></pre>
+        <h2><a id="user-content-usage" class="anchor" aria-hidden="true" href="#usage"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Usage</h2>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-en">require</span> <span class="pl-s">'thread_safe'</span>
+
+        <span class="pl-s1">sa</span> <span class="pl-c1">=</span> <span class="pl-v">ThreadSafe</span>::<span class="pl-v">Array</span><span class="pl-kos">.</span><span class="pl-en">new</span> <span class="pl-c"># supports standard Array.new forms</span>
+        <span class="pl-s1">sh</span> <span class="pl-c1">=</span> <span class="pl-v">ThreadSafe</span>::<span class="pl-v">Hash</span><span class="pl-kos">.</span><span class="pl-en">new</span> <span class="pl-c"># supports standard Hash.new forms</span></pre></div>
+        <p><code>ThreadSafe::Cache</code> also exists, as a hash-like object, and should have
+        much better performance characteristics esp. under high concurrency than
+        <code>ThreadSafe::Hash</code>. However, <code>ThreadSafe::Cache</code> is not strictly semantically
+        equivalent to a ruby <code>Hash</code> -- for instance, it does not necessarily retain
+        ordering by insertion time as <code>Hash</code> does. For most uses it should do fine
+        though, and we recommend you consider <code>ThreadSafe::Cache</code> instead of
+        <code>ThreadSafe::Hash</code> for your concurrency-safe hash needs. It understands some
+        options when created (depending on your ruby platform) that control some of the
+        internals - when unsure just leave them out:</p>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-en">require</span> <span class="pl-s">'thread_safe'</span>
+
+        <span class="pl-s1">cache</span> <span class="pl-c1">=</span> <span class="pl-v">ThreadSafe</span>::<span class="pl-v">Cache</span><span class="pl-kos">.</span><span class="pl-en">new</span></pre></div>
+        <h2><a id="user-content-contributing" class="anchor" aria-hidden="true" href="#contributing"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Contributing</h2>
+        <ol>
+        <li>Fork it</li>
+        <li>Clone it (<code>git clone git@github.com:you/thread_safe.git</code>)</li>
+        <li>Create your feature branch (<code>git checkout -b my-new-feature</code>)</li>
+        <li>Build the jar (<code>rake jar</code>) NOTE: Requires JRuby</li>
+        <li>Install dependencies (<code>bundle install</code>)</li>
+        <li>Commit your changes (<code>git commit -am 'Added some feature'</code>)</li>
+        <li>Push to the branch (<code>git push origin my-new-feature</code>)</li>
+        <li>Create new Pull Request</li>
+        </ol>
+        </article></div>
+  recorded_at: Sun, 30 Aug 2020 21:40:34 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/full-project-sync-from-github.yml
+++ b/spec/cassettes/full-project-sync-from-github.yml
@@ -66,7 +66,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
   recorded_at: Wed, 05 Dec 2018 14:33:46 GMT
 - request:
     method: post
@@ -151,6 +150,364 @@ http_interactions:
       encoding: UTF-8
       string: '{"data":{"repository":{"nameWithOwner":"postmodern/chruby","forks":{"totalCount":160},"stargazers":{"totalCount":2195},"watchers":{"totalCount":52},"createdAt":"2012-08-01T23:46:08Z","defaultBranchRef":{"name":"master","target":{"history":{"edges":[{"node":{"authoredDate":"2017-07-18T20:59:40Z"}},{"node":{"authoredDate":"2017-07-09T19:50:51Z"}},{"node":{"authoredDate":"2017-03-02T01:45:48Z"}},{"node":{"authoredDate":"2016-12-25T03:54:09Z"}},{"node":{"authoredDate":"2016-12-23T09:48:19Z"}},{"node":{"authoredDate":"2016-12-18T22:38:58Z"}},{"node":{"authoredDate":"2016-12-16T01:10:03Z"}},{"node":{"authoredDate":"2016-12-04T06:10:17Z"}},{"node":{"authoredDate":"2016-11-11T23:42:43Z"}},{"node":{"authoredDate":"2016-11-07T18:38:18Z"}},{"node":{"authoredDate":"2016-11-05T02:07:52Z"}},{"node":{"authoredDate":"2016-04-08T21:31:14Z"}},{"node":{"authoredDate":"2016-01-05T23:06:35Z"}},{"node":{"authoredDate":"2015-12-27T23:49:55Z"}},{"node":{"authoredDate":"2015-12-27T23:49:04Z"}},{"node":{"authoredDate":"2015-12-27T23:48:06Z"}},{"node":{"authoredDate":"2015-12-27T10:11:10Z"}},{"node":{"authoredDate":"2015-12-27T09:58:26Z"}},{"node":{"authoredDate":"2015-12-27T09:49:42Z"}},{"node":{"authoredDate":"2015-12-24T02:31:18Z"}},{"node":{"authoredDate":"2015-11-20T02:15:21Z"}},{"node":{"authoredDate":"2015-09-17T18:24:21Z"}},{"node":{"authoredDate":"2015-07-09T20:16:56Z"}},{"node":{"authoredDate":"2015-06-22T17:38:25Z"}},{"node":{"authoredDate":"2015-05-03T23:10:07Z"}},{"node":{"authoredDate":"2015-05-02T05:29:47Z"}},{"node":{"authoredDate":"2015-05-02T04:10:43Z"}},{"node":{"authoredDate":"2015-05-02T03:50:25Z"}},{"node":{"authoredDate":"2015-05-02T03:49:31Z"}},{"node":{"authoredDate":"2015-04-26T22:45:54Z"}},{"node":{"authoredDate":"2015-04-26T22:44:28Z"}},{"node":{"authoredDate":"2015-03-26T21:56:43Z"}},{"node":{"authoredDate":"2015-03-21T21:01:47Z"}},{"node":{"authoredDate":"2015-03-18T22:35:02Z"}},{"node":{"authoredDate":"2015-03-14T02:01:58Z"}},{"node":{"authoredDate":"2015-03-13T23:39:22Z"}},{"node":{"authoredDate":"2015-03-13T23:09:30Z"}},{"node":{"authoredDate":"2015-03-13T23:07:08Z"}},{"node":{"authoredDate":"2015-03-13T23:05:48Z"}},{"node":{"authoredDate":"2015-03-13T22:56:45Z"}},{"node":{"authoredDate":"2015-03-02T21:02:52Z"}},{"node":{"authoredDate":"2014-12-30T00:11:34Z"}},{"node":{"authoredDate":"2014-12-30T00:06:47Z"}},{"node":{"authoredDate":"2014-12-30T00:04:12Z"}},{"node":{"authoredDate":"2014-02-07T20:39:04Z"}},{"node":{"authoredDate":"2014-12-22T20:53:29Z"}},{"node":{"authoredDate":"2014-12-19T16:59:13Z"}},{"node":{"authoredDate":"2014-12-18T05:02:50Z"}},{"node":{"authoredDate":"2014-12-18T04:50:08Z"}},{"node":{"authoredDate":"2014-11-23T19:04:59Z"}}]}}},"description":"Changes
         the current Ruby","hasIssuesEnabled":true,"hasWikiEnabled":true,"homepageUrl":"","isArchived":false,"isFork":false,"isMirror":false,"licenseInfo":{"key":"mit"},"primaryLanguage":{"name":"Shell"},"pushedAt":"2018-10-25T11:41:56Z","closedIssues":{"totalCount":199},"openIssues":{"totalCount":54},"closedPullRequests":{"totalCount":63},"openPullRequests":{"totalCount":20},"mergedPullRequests":{"totalCount":72},"repositoryTopics":{"nodes":[]},"codeOfConduct":null},"rateLimit":{"limit":5000,"cost":1,"remaining":2437,"resetAt":"2018-12-05T14:55:35Z"}}}'
-    http_version: 
   recorded_at: Wed, 05 Dec 2018 14:33:47 GMT
-recorded_with: VCR 4.0.0
+- request:
+    method: get
+    uri: https://api.github.com/repos/postmodern/chruby/readme
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Authorization:
+      - bearer <GITHUB_TOKEN>
+      User-Agent:
+      - ruby-toolbox.com API client
+      Accept:
+      - application/vnd.github.v3.html
+      Connection:
+      - close
+      Host:
+      - api.github.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 30 Aug 2020 21:40:34 GMT
+      Content-Type:
+      - application/vnd.github.v3.html; charset=utf-8
+      Content-Length:
+      - '33061'
+      Connection:
+      - close
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding
+      - Accept-Encoding, Accept, X-Requested-With
+      Etag:
+      - '"5fa50adc4d7eb3f121831be1d6aec7ba"'
+      Last-Modified:
+      - Thu, 02 Apr 2020 19:43:41 GMT
+      X-Oauth-Scopes:
+      - ''
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; param=html
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4965'
+      X-Ratelimit-Reset:
+      - '1598827195'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - 893E:59C5:74A5600:8D1D581:5F4C1CD2
+    body:
+      encoding: UTF-8
+      string: |-
+        <div id="readme" class="md" data-path="README.md"><article class="markdown-body entry-content container-lg" itemprop="text"><h1><a id="user-content-chruby" class="anchor" aria-hidden="true" href="#chruby"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>chruby</h1>
+        <p><a href="https://travis-ci.org/postmodern/chruby" rel="nofollow"><img src="https://camo.githubusercontent.com/e3e7553ad688a4b835c7fd43289d6396129e4619/68747470733a2f2f7472617669732d63692e6f72672f706f73746d6f6465726e2f6368727562792e7376673f6272616e63683d6d6173746572" alt="Build Status" data-canonical-src="https://travis-ci.org/postmodern/chruby.svg?branch=master" style="max-width:100%;"></a></p>
+        <p>Changes the current Ruby.</p>
+        <h2><a id="user-content-features" class="anchor" aria-hidden="true" href="#features"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Features</h2>
+        <ul>
+        <li>Updates <code>$PATH</code>.
+        <ul>
+        <li>Also adds RubyGems <code>bin/</code> directories to <code>$PATH</code>.</li>
+        </ul>
+        </li>
+        <li>Correctly sets <code>$GEM_HOME</code> and <code>$GEM_PATH</code>.
+        <ul>
+        <li>Users: gems are installed into <code>~/.gem/$ruby/$version</code>.</li>
+        <li>Root: gems are installed directly into <code>/path/to/$ruby/$gemdir</code>.</li>
+        </ul>
+        </li>
+        <li>Additionally sets <code>$RUBY_ROOT</code>, <code>$RUBY_ENGINE</code>, <code>$RUBY_VERSION</code> and
+        <code>$GEM_ROOT</code>.</li>
+        <li>Optionally sets <code>$RUBYOPT</code> if second argument is given.</li>
+        <li>Calls <code>hash -r</code> to clear the command-lookup hash-table.</li>
+        <li>Fuzzy matching of Rubies by name.</li>
+        <li>Defaults to the system Ruby.</li>
+        <li>Optionally supports auto-switching and the <code>.ruby-version</code> file.</li>
+        <li>Supports <a href="http://www.gnu.org/software/bash/" rel="nofollow">bash</a> and <a href="http://www.zsh.org/" rel="nofollow">zsh</a>.</li>
+        <li>Small (~100 LOC).</li>
+        <li>Has tests.</li>
+        </ul>
+        <h2><a id="user-content-anti-features" class="anchor" aria-hidden="true" href="#anti-features"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Anti-Features</h2>
+        <ul>
+        <li>Does not hook <code>cd</code>.</li>
+        <li>Does not install executable shims.</li>
+        <li>Does not require Rubies be installed into your home directory.</li>
+        <li>Does not automatically switch Rubies by default.</li>
+        <li>Does not require write-access to the Ruby directory in order to install gems.</li>
+        </ul>
+        <h2><a id="user-content-requirements" class="anchor" aria-hidden="true" href="#requirements"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Requirements</h2>
+        <ul>
+        <li><a href="http://www.gnu.org/software/bash/" rel="nofollow">bash</a> &gt;= 3 or <a href="http://www.zsh.org/" rel="nofollow">zsh</a></li>
+        </ul>
+        <h2><a id="user-content-install" class="anchor" aria-hidden="true" href="#install"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Install</h2>
+        <pre><code>wget -O chruby-0.3.9.tar.gz https://github.com/postmodern/chruby/archive/v0.3.9.tar.gz
+        tar -xzvf chruby-0.3.9.tar.gz
+        cd chruby-0.3.9/
+        sudo make install
+        </code></pre>
+        <h3><a id="user-content-pgp" class="anchor" aria-hidden="true" href="#pgp"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>PGP</h3>
+        <p>All releases are <a href="http://en.wikipedia.org/wiki/Pretty_Good_Privacy" rel="nofollow">PGP</a> signed for security. Instructions on how to import my
+        PGP key can be found on my <a href="http://postmodern.github.io/contact.html#pgp" rel="nofollow">blog</a>. To verify that a release was not tampered
+        with:</p>
+        <pre><code>wget https://raw.github.com/postmodern/chruby/master/pkg/chruby-0.3.9.tar.gz.asc
+        gpg --verify chruby-0.3.9.tar.gz.asc chruby-0.3.9.tar.gz
+        </code></pre>
+        <h3><a id="user-content-setupsh" class="anchor" aria-hidden="true" href="#setupsh"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>setup.sh</h3>
+        <p>chruby also includes a <code>setup.sh</code> script, which installs chruby. Simply run the
+        script as root or via <code>sudo</code>:</p>
+        <pre><code>sudo ./scripts/setup.sh
+        </code></pre>
+        <h3><a id="user-content-homebrew" class="anchor" aria-hidden="true" href="#homebrew"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Homebrew</h3>
+        <p>chruby can also be installed with <a href="http://brew.sh/" rel="nofollow">homebrew</a>:</p>
+        <pre><code>brew install chruby
+        </code></pre>
+        <p>Or the absolute latest chruby can be installed from source:</p>
+        <pre><code>brew install chruby --HEAD
+        </code></pre>
+        <h3><a id="user-content-arch-linux" class="anchor" aria-hidden="true" href="#arch-linux"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Arch Linux</h3>
+        <p>chruby is already included in the <a href="https://aur.archlinux.org/packages/chruby/" rel="nofollow">AUR</a>:</p>
+        <pre><code>yaourt -S chruby
+        </code></pre>
+        <h3><a id="user-content-fedora-linux" class="anchor" aria-hidden="true" href="#fedora-linux"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Fedora Linux</h3>
+        <p>chruby is available as an rpm on <a href="https://copr.fedorainfracloud.org/coprs/postmodern/chruby/" rel="nofollow">Fedora Copr</a>.</p>
+        <h3><a id="user-content-freebsd" class="anchor" aria-hidden="true" href="#freebsd"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>FreeBSD</h3>
+        <p>chruby is included in the official <a href="https://www.freshports.org/devel/chruby/" rel="nofollow">FreeBSD ports collection</a>:</p>
+        <pre><code>cd /usr/ports/devel/chruby/ &amp;&amp; make install clean
+        </code></pre>
+        <h3><a id="user-content-rubies" class="anchor" aria-hidden="true" href="#rubies"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Rubies</h3>
+        <h4><a id="user-content-manually" class="anchor" aria-hidden="true" href="#manually"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Manually</h4>
+        <p>Chruby provides detailed instructions for installing additional Rubies:</p>
+        <ul>
+        <li><a href="https://github.com/postmodern/chruby/wiki/Ruby">Ruby</a></li>
+        <li><a href="https://github.com/postmodern/chruby/wiki/JRuby">JRuby</a></li>
+        <li><a href="https://github.com/postmodern/chruby/wiki/Rubinius">Rubinius</a></li>
+        <li><a href="https://github.com/postmodern/chruby/wiki/MagLev">MagLev</a></li>
+        </ul>
+        <h4><a id="user-content-ruby-install" class="anchor" aria-hidden="true" href="#ruby-install"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>ruby-install</h4>
+        <p>You can also use <a href="https://github.com/postmodern/ruby-install#readme">ruby-install</a> to install additional Rubies:</p>
+        <p>Installing to <code>/opt/rubies</code> or <code>~/.rubies</code>:</p>
+        <pre><code>ruby-install ruby
+        ruby-install jruby
+        ruby-install rubinius
+        ruby-install maglev
+        </code></pre>
+        <h4><a id="user-content-ruby-build" class="anchor" aria-hidden="true" href="#ruby-build"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>ruby-build</h4>
+        <p>You can also use <a href="https://github.com/sstephenson/ruby-build#readme">ruby-build</a> to install additional Rubies:</p>
+        <p>Installing to <code>/opt/rubies</code>:</p>
+        <pre><code>ruby-build 1.9.3-p392 /opt/rubies/ruby-1.9.3-p392
+        ruby-build jruby-1.7.3 /opt/rubies/jruby-1.7.3
+        ruby-build rbx-2.0.0-rc1 /opt/rubies/rubinius-2.0.0-rc1
+        ruby-build maglev-1.0.0 /opt/rubies/maglev-1.0.0
+        </code></pre>
+        <h2><a id="user-content-configuration" class="anchor" aria-hidden="true" href="#configuration"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Configuration</h2>
+        <p>Add the following to the <code>~/.bashrc</code> or <code>~/.zshrc</code> file:</p>
+        <div class="highlight highlight-source-shell"><pre><span class="pl-c1">source</span> /usr/local/share/chruby/chruby.sh</pre></div>
+        <p><em>Note:</em> OSX does not automatically execute <code>~/.bashrc</code>, instead try adding to <code>/etc/bashrc</code>.</p>
+        <h3><a id="user-content-system-wide" class="anchor" aria-hidden="true" href="#system-wide"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>System Wide</h3>
+        <p>If you wish to enable chruby system-wide, add the following to
+        <code>/etc/profile.d/chruby.sh</code>:</p>
+        <div class="highlight highlight-source-shell"><pre><span class="pl-k">if</span> [ <span class="pl-k">-n</span> <span class="pl-s"><span class="pl-pds">"</span><span class="pl-smi">$BASH_VERSION</span><span class="pl-pds">"</span></span> ] <span class="pl-k">||</span> [ <span class="pl-k">-n</span> <span class="pl-s"><span class="pl-pds">"</span><span class="pl-smi">$ZSH_VERSION</span><span class="pl-pds">"</span></span> ]<span class="pl-k">;</span> <span class="pl-k">then</span>
+          <span class="pl-c1">source</span> /usr/local/share/chruby/chruby.sh
+          ...
+        <span class="pl-k">fi</span></pre></div>
+        <p>This will prevent chruby from accidentally being loaded by <code>/bin/sh</code>, which
+        is not always the same as <code>/bin/bash</code>.</p>
+        <h3><a id="user-content-rubies-1" class="anchor" aria-hidden="true" href="#rubies-1"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Rubies</h3>
+        <p>When chruby is first loaded by the shell, it will auto-detect Rubies installed
+        in <code>/opt/rubies/</code> and <code>~/.rubies/</code>. After installing new Rubies, you <em>must</em>
+        restart the shell before chruby can recognize them.</p>
+        <p>For Rubies installed in non-standard locations, simply append their paths to
+        the <code>RUBIES</code> variable:</p>
+        <div class="highlight highlight-source-shell"><pre><span class="pl-c1">source</span> /usr/local/share/chruby/chruby.sh
+
+        RUBIES+=(
+          /opt/jruby-1.7.0
+          <span class="pl-s"><span class="pl-pds">"</span><span class="pl-smi">$HOME</span>/src/rubinius<span class="pl-pds">"</span></span>
+        )</pre></div>
+        <h3><a id="user-content-migrating" class="anchor" aria-hidden="true" href="#migrating"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Migrating</h3>
+        <p>If you are migrating from another Ruby manager, set <code>RUBIES</code> accordingly:</p>
+        <h4><a id="user-content-rvm" class="anchor" aria-hidden="true" href="#rvm"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>RVM</h4>
+        <div class="highlight highlight-source-shell"><pre>RUBIES+=(~/.rvm/rubies/<span class="pl-k">*</span>)</pre></div>
+        <h4><a id="user-content-rbenv" class="anchor" aria-hidden="true" href="#rbenv"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>rbenv</h4>
+        <div class="highlight highlight-source-shell"><pre>RUBIES+=(~/.rbenv/versions/<span class="pl-k">*</span>)</pre></div>
+        <h4><a id="user-content-rbfu" class="anchor" aria-hidden="true" href="#rbfu"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>rbfu</h4>
+        <div class="highlight highlight-source-shell"><pre>RUBIES+=(~/.rbfu/rubies/<span class="pl-k">*</span>)</pre></div>
+        <h3><a id="user-content-auto-switching" class="anchor" aria-hidden="true" href="#auto-switching"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Auto-Switching</h3>
+        <p>If you want chruby to auto-switch the current version of Ruby when you <code>cd</code>
+        between your different projects, simply load <code>auto.sh</code> in <code>~/.bashrc</code> or
+        <code>~/.zshrc</code>:</p>
+        <div class="highlight highlight-source-shell"><pre><span class="pl-c1">source</span> /usr/local/share/chruby/chruby.sh
+        <span class="pl-c1">source</span> /usr/local/share/chruby/auto.sh</pre></div>
+        <p><em>Note:</em> OSX does not automatically execute <code>~/.bashrc</code>, instead try adding to <code>/etc/bashrc</code>.</p>
+        <p>chruby will check the current and parent directories for a <a href="https://gist.github.com/1912050">.ruby-version</a>
+        file. Other Ruby switchers also understand this file:
+        <a href="https://gist.github.com/1912050">https://gist.github.com/1912050</a></p>
+        <p>If you want to automatically run the version of a gem executable specified in
+        your project's Gemfile, try
+        <a href="https://github.com/mpapis/rubygems-bundler">rubygems-bundler</a>.</p>
+        <h3><a id="user-content-default-ruby" class="anchor" aria-hidden="true" href="#default-ruby"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Default Ruby</h3>
+        <p>Once you have loaded <code>chruby.sh</code> and/or <code>auto.sh</code> in your shell configuration,
+        you can also set a default Ruby. Simply call the <code>chruby</code> function in
+        <code>~/.bash_profile</code> or <code>~/.zprofile</code>:</p>
+        <pre><code>chruby ruby-1.9
+        </code></pre>
+        <p>If you have enabled auto-switching, simply create a <code>.ruby-version</code> file:</p>
+        <pre><code>echo "ruby-1.9" &gt; ~/.ruby-version
+        </code></pre>
+        <h3><a id="user-content-rubygems" class="anchor" aria-hidden="true" href="#rubygems"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>RubyGems</h3>
+        <p>Gems installed as a non-root user via <code>gem install</code> will be installed into
+        <code>~/.gem/$ruby/X.Y.Z</code>.  By default, RubyGems will use the absolute path to the
+        currently selected ruby for the shebang of any binstubs it generates.  In some
+        cases, this path may contain extra version information (e.g.
+        <code>ruby-2.0.0-p451</code>).  To mitigate potential problems when removing rubies, you
+        can force RubyGems to generate binstubs with shebangs that will search for
+        ruby in your <code>$PATH</code> by using <code>gem install --env-shebang</code> (or the equivalent
+        short option <code>-E</code>).  This parameter can also be added to your gemrc file.</p>
+        <h3><a id="user-content-integration" class="anchor" aria-hidden="true" href="#integration"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Integration</h3>
+        <p>For instructions on using chruby with other tools, please see the <a href="https://github.com/postmodern/chruby/wiki">wiki</a>:</p>
+        <ul>
+        <li><a href="https://github.com/capistrano/chruby#readme">Capistrano</a></li>
+        <li><a href="https://supermarket.getchef.com/cookbooks/chruby_install" rel="nofollow">Chef</a></li>
+        <li><a href="https://github.com/postmodern/chruby/wiki/Cron">Cron</a></li>
+        <li><a href="https://github.com/arnebrasseur/chruby.el#readme">Emacs</a></li>
+        <li><a href="https://github.com/postmodern/chruby/wiki/Pow">Pow</a></li>
+        <li><a href="https://github.com/dgoodlad/puppet-chruby#readme">Puppet</a></li>
+        <li><a href="https://github.com/postmodern/chruby/wiki/Sudo">Sudo</a></li>
+        <li><a href="https://github.com/postmodern/chruby/wiki/Vim">Vim</a></li>
+        <li><a href="https://github.com/JeanMertz/chruby-fish#readme">Fish</a></li>
+        </ul>
+        <h2><a id="user-content-examples" class="anchor" aria-hidden="true" href="#examples"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Examples</h2>
+        <p>List available Rubies:</p>
+        <pre><code>$ chruby
+           ruby-1.9.3-p392
+           jruby-1.7.0
+           rubinius-2.0.0-rc1
+        </code></pre>
+        <p>Select a Ruby:</p>
+        <pre><code>$ chruby 1.9.3
+        $ chruby
+         * ruby-1.9.3-p392
+           jruby-1.7.0
+           rubinius-2.0.0-rc1
+        $ echo $PATH
+        /home/hal/.gem/ruby/1.9.3/bin:/opt/rubies/ruby-1.9.3-p392/lib/ruby/gems/1.9.1/bin:/opt/rubies/ruby-1.9.3-p392/bin:/usr/lib64/qt-3.3/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/home/hal/bin:/home/hal/bin
+        $ gem env
+        RubyGems Environment:
+          - RUBYGEMS VERSION: 1.8.23
+          - RUBY VERSION: 1.9.3 (2013-02-22 patchlevel 392) [x86_64-linux]
+          - INSTALLATION DIRECTORY: /home/hal/.gem/ruby/1.9.3
+          - RUBY EXECUTABLE: /opt/rubies/ruby-1.9.3-p392/bin/ruby
+          - EXECUTABLE DIRECTORY: /home/hal/.gem/ruby/1.9.3/bin
+          - RUBYGEMS PLATFORMS:
+            - ruby
+            - x86_64-linux
+          - GEM PATHS:
+             - /home/hal/.gem/ruby/1.9.3
+             - /opt/rubies/ruby-1.9.3-p392/lib/ruby/gems/1.9.1
+          - GEM CONFIGURATION:
+             - :update_sources =&gt; true
+             - :verbose =&gt; true
+             - :benchmark =&gt; false
+             - :backtrace =&gt; false
+             - :bulk_threshold =&gt; 1000
+             - "gem" =&gt; "--no-rdoc"
+          - REMOTE SOURCES:
+             - http://rubygems.org/
+        </code></pre>
+        <p>Switch to JRuby in 1.9 mode:</p>
+        <pre><code>$ chruby jruby --1.9
+        $ ruby -v
+        jruby 1.7.0 (1.9.3p203) 2012-10-22 ff1ebbe on OpenJDK 64-Bit Server VM 1.7.0_09-icedtea-mockbuild_2012_10_17_15_53-b00 [linux-amd64]
+        </code></pre>
+        <p>Switch back to system Ruby:</p>
+        <pre><code>$ chruby system
+        $ echo $PATH
+        /usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin:/home/hal/bin
+        </code></pre>
+        <p>Run a command under a Ruby with <code>chruby-exec</code>:</p>
+        <pre><code>$ chruby-exec jruby -- gem update
+        </code></pre>
+        <p>Switch to an arbitrary Ruby on the fly:</p>
+        <pre><code>$ chruby_use /path/to/ruby
+        </code></pre>
+        <h2><a id="user-content-uninstall" class="anchor" aria-hidden="true" href="#uninstall"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Uninstall</h2>
+        <ol>
+        <li>Remove or comment out chruby from your shell configuration.</li>
+        <li>Restart your shell (ex: <code>exec $SHELL</code>).</li>
+        <li><code>sudo make uninstall</code></li>
+        </ol>
+        <h2><a id="user-content-alternatives" class="anchor" aria-hidden="true" href="#alternatives"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Alternatives</h2>
+        <ul>
+        <li><a href="https://rvm.io/" rel="nofollow">RVM</a></li>
+        <li><a href="https://github.com/sstephenson/rbenv#readme">rbenv</a></li>
+        <li><a href="https://github.com/hmans/rbfu#readme">rbfu</a>*</li>
+        <li><a href="https://github.com/jayferd/ry#readme">ry</a></li>
+        <li><a href="https://github.com/wilmoore/ruby-version#readme">ruby-version</a>*</li>
+        </ul>
+        <p>* <em>Deprecated in favor of chruby.</em></p>
+        <h2><a id="user-content-endorsements" class="anchor" aria-hidden="true" href="#endorsements"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Endorsements</h2>
+        <blockquote>
+        <p>yeah <code>chruby</code> is nice, does the limited thing of switching really good,
+        the only hope it never grows</p>
+        </blockquote>
+        <p>-- <a href="https://twitter.com/mpapis/status/258049391791841280" rel="nofollow">Michal Papis</a> of <a href="https://rvm.io/" rel="nofollow">RVM</a></p>
+        <blockquote>
+        <p>I just looooove <a href="#readme">chruby</a> For the first time I'm in total control of
+        all aspects of my Ruby installation.</p>
+        </blockquote>
+        <p>-- <a href="https://twitter.com/zmalltalker/status/271192206268829696" rel="nofollow">Marius Mathiesen</a></p>
+        <blockquote>
+        <p>Written by Postmodern, it's basically the simplest possible thing that can
+        work.</p>
+        </blockquote>
+        <p>-- <a href="http://blog.steveklabnik.com/posts/2012-12-13-getting-started-with-chruby" rel="nofollow">Steve Klabnik</a></p>
+        <blockquote>
+        <p>So far, I'm a huge fan. The tool does what it advertises exactly and simply.
+        The small feature-set is also exactly and only the features I need.</p>
+        </blockquote>
+        <p>-- <a href="http://pbrisbin.com/posts/chruby" rel="nofollow">Patrick Brisbin</a></p>
+        <blockquote>
+        <p>I wrote ruby-version; however, chruby is already what ruby-version wanted to
+        be. I've deprecated ruby-version in favor of chruby.</p>
+        </blockquote>
+        <p>-- <a href="https://github.com/wilmoore">Wil Moore III</a></p>
+        <h2><a id="user-content-credits" class="anchor" aria-hidden="true" href="#credits"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Credits</h2>
+        <ul>
+        <li><a href="https://github.com/mpapis">mpapis</a> for reviewing the code.</li>
+        <li><a href="https://github.com/havenwood">havenwood</a> for handling the homebrew formula.</li>
+        <li><a href="https://github.com/zendeavor">zendeavor</a> for style fixes.</li>
+        <li><code>#bash</code>, <code>#zsh</code>, <code>#machomebrew</code> for answering all my questions.</li>
+        </ul>
+        </article></div>
+  recorded_at: Sun, 30 Aug 2020 21:40:34 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/github/readme/existing.yml
+++ b/spec/cassettes/github/readme/existing.yml
@@ -1,0 +1,191 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.github.com/repos/rspec/rspec/readme
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Authorization:
+      - bearer <GITHUB_TOKEN>
+      User-Agent:
+      - ruby-toolbox.com API client
+      Accept:
+      - application/vnd.github.v3.html
+      Connection:
+      - close
+      Host:
+      - api.github.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 30 Aug 2020 20:42:45 GMT
+      Content-Type:
+      - application/vnd.github.v3.html; charset=utf-8
+      Content-Length:
+      - '6137'
+      Connection:
+      - close
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding
+      - Accept-Encoding, Accept, X-Requested-With
+      Etag:
+      - '"51bb7383556e6b63039e5699d95841bc"'
+      Last-Modified:
+      - Fri, 24 Jul 2020 12:13:19 GMT
+      X-Oauth-Scopes:
+      - ''
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; param=html
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4967'
+      X-Ratelimit-Reset:
+      - '1598823521'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - 8706:59C6:D29D780:FE757B7:5F4C0F44
+    body:
+      encoding: UTF-8
+      string: |-
+        <div id="readme" class="md" data-path="README.md"><article class="markdown-body entry-content container-lg" itemprop="text"><h1><a id="user-content-rspec" class="anchor" aria-hidden="true" href="#rspec"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>RSpec</h1>
+        <p>Behaviour Driven Development for Ruby</p>
+        <h1><a id="user-content-description" class="anchor" aria-hidden="true" href="#description"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Description</h1>
+        <p>rspec is a meta-gem, which depends on the
+        <a href="https://github.com/rspec/rspec-core">rspec-core</a>,
+        <a href="https://github.com/rspec/rspec-expectations">rspec-expectations</a>
+        and <a href="https://github.com/rspec/rspec-mocks">rspec-mocks</a> gems. Each of these
+        can be installed separately and loaded in isolation using <code>require</code>. Among
+        other benefits, this allows you to use rspec-expectations, for example, in
+        Test::Unit::TestCase if you happen to prefer that style.</p>
+        <p>Conversely, if you like RSpec's approach to declaring example groups and
+        examples (<code>describe</code> and <code>it</code>) but prefer Test::Unit assertions and
+        <a href="https://github.com/freerange/mocha">mocha</a>, <a href="https://github.com/rr/rr">rr</a>
+        or <a href="https://github.com/jimweirich/flexmock">flexmock</a> for mocking, you'll be
+        able to do that without having to install or load the components of RSpec that
+        you're not using.</p>
+        <h2><a id="user-content-documentation" class="anchor" aria-hidden="true" href="#documentation"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Documentation</h2>
+        <p>See <a href="http://rspec.info/documentation/" rel="nofollow">http://rspec.info/documentation/</a> for links to documentation for all gems.</p>
+        <h2><a id="user-content-install" class="anchor" aria-hidden="true" href="#install"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Install</h2>
+        <pre><code>gem install rspec
+        </code></pre>
+        <h2><a id="user-content-setup" class="anchor" aria-hidden="true" href="#setup"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Setup</h2>
+        <pre><code>rspec --init
+        </code></pre>
+        <h2><a id="user-content-contribute" class="anchor" aria-hidden="true" href="#contribute"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Contribute</h2>
+        <ul>
+        <li><a href="http://github.com/rspec/rspec-dev">http://github.com/rspec/rspec-dev</a></li>
+        </ul>
+        <h2><a id="user-content-also-see" class="anchor" aria-hidden="true" href="#also-see"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Also see</h2>
+        <ul>
+        <li><a href="https://github.com/rspec/rspec-core">https://github.com/rspec/rspec-core</a></li>
+        <li><a href="https://github.com/rspec/rspec-expectations">https://github.com/rspec/rspec-expectations</a></li>
+        <li><a href="https://github.com/rspec/rspec-mocks">https://github.com/rspec/rspec-mocks</a></li>
+        <li><a href="https://github.com/rspec/rspec-rails">https://github.com/rspec/rspec-rails</a></li>
+        </ul>
+        </article></div>
+  recorded_at: Sun, 30 Aug 2020 20:42:45 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repos/rspec/rspec/readme
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Authorization:
+      - bearer <GITHUB_TOKEN>
+      User-Agent:
+      - ruby-toolbox.com API client
+      Accept:
+      - application/vnd.github.v3.html
+      If-None-Match:
+      - '"51bb7383556e6b63039e5699d95841bc"'
+      Connection:
+      - close
+      Host:
+      - api.github.com
+  response:
+    status:
+      code: 304
+      message: Not Modified
+    headers:
+      Date:
+      - Sun, 30 Aug 2020 20:42:45 GMT
+      Connection:
+      - close
+      Server:
+      - GitHub.com
+      Status:
+      - 304 Not Modified
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding
+      - Accept-Encoding, Accept, X-Requested-With
+      Etag:
+      - '"51bb7383556e6b63039e5699d95841bc"'
+      Last-Modified:
+      - Fri, 24 Jul 2020 12:13:19 GMT
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4967'
+      X-Ratelimit-Reset:
+      - '1598823521'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - 8708:B50D:166BD96:1B27CA6:5F4C0F45
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+  recorded_at: Sun, 30 Aug 2020 20:42:45 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/github/readme/moved.yml
+++ b/spec/cassettes/github/readme/moved.yml
@@ -1,0 +1,796 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.github.com/repos/colszowka/simplecov/readme
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Authorization:
+      - bearer <GITHUB_TOKEN>
+      User-Agent:
+      - ruby-toolbox.com API client
+      Accept:
+      - application/vnd.github.v3.html
+      Connection:
+      - close
+      Host:
+      - api.github.com
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Sun, 30 Aug 2020 20:42:44 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '154'
+      Connection:
+      - close
+      Server:
+      - GitHub.com
+      Status:
+      - 301 Moved Permanently
+      X-Oauth-Scopes:
+      - ''
+      X-Accepted-Oauth-Scopes:
+      - admin:repo_hook, delete_repo, read:repo_hook, repo, repo:status, repo_deployment,
+        security_events, write:repo_hook
+      Location:
+      - https://api.github.com/repositories/839336/readme
+      X-Github-Media-Type:
+      - github.v3; param=html
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4969'
+      X-Ratelimit-Reset:
+      - '1598823521'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - 8702:B39D:565674:67771B:5F4C0F44
+    body:
+      encoding: UTF-8
+      string: '{"message":"Moved Permanently","url":"https://api.github.com/repositories/839336/readme","documentation_url":"https://docs.github.com/v3/#http-redirects"}'
+  recorded_at: Sun, 30 Aug 2020 20:42:44 GMT
+- request:
+    method: get
+    uri: https://api.github.com/repositories/839336/readme
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Authorization:
+      - bearer <GITHUB_TOKEN>
+      User-Agent:
+      - ruby-toolbox.com API client
+      Accept:
+      - application/vnd.github.v3.html
+      Connection:
+      - close
+      Host:
+      - api.github.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 30 Aug 2020 20:42:44 GMT
+      Content-Type:
+      - application/vnd.github.v3.html; charset=utf-8
+      Content-Length:
+      - '85661'
+      Connection:
+      - close
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding
+      - Accept-Encoding, Accept, X-Requested-With
+      Etag:
+      - '"07afeb8ac0e2e67c4aea452694168fb4"'
+      Last-Modified:
+      - Sun, 16 Aug 2020 18:46:53 GMT
+      X-Oauth-Scopes:
+      - ''
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; param=html
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4968'
+      X-Ratelimit-Reset:
+      - '1598823521'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - 8704:DA25:D6E1D0F:10434756:5F4C0F44
+    body:
+      encoding: UTF-8
+      string: |-
+        <div id="readme" class="md" data-path="README.md"><article class="markdown-body entry-content container-lg" itemprop="text"><h1><a id="user-content-simplecov----" class="anchor" aria-hidden="true" href="#simplecov----"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>SimpleCov <a href="https://badge.fury.io/rb/simplecov" rel="nofollow"><img src="https://camo.githubusercontent.com/ea14b2a0db244718ff130d0836cc953de6304616/68747470733a2f2f62616467652e667572792e696f2f72622f73696d706c65636f762e737667" alt="Gem Version" data-canonical-src="https://badge.fury.io/rb/simplecov.svg" style="max-width:100%;"></a> <a href="https://github.com/simplecov-ruby/simplecov/actions?query=workflow%3Astable" title="SimpleCov is built around the clock by github.com"><img src="https://github.com/simplecov-ruby/simplecov/workflows/stable/badge.svg?branch=main" alt="Build Status" style="max-width:100%;"></a> <a href="https://codeclimate.com/github/simplecov-ruby/simplecov/maintainability" rel="nofollow"><img src="https://camo.githubusercontent.com/579bc5c99b24dde77420ca34e586d81b13758c97/68747470733a2f2f6170692e636f6465636c696d6174652e636f6d2f76312f6261646765732f63303731643139376436313935336137653438322f6d61696e7461696e6162696c697479" alt="Maintainability" data-canonical-src="https://api.codeclimate.com/v1/badges/c071d197d61953a7e482/maintainability" style="max-width:100%;"></a> <a href="http://inch-ci.org/github/simplecov-ruby/simplecov" rel="nofollow"><img src="https://camo.githubusercontent.com/eee16189ee2344a301875f7fbeca9f84578d6aaa/687474703a2f2f696e63682d63692e6f72672f6769746875622f73696d706c65636f762d727562792f73696d706c65636f762e7376673f6272616e63683d6d61696e" alt="Inline docs" data-canonical-src="http://inch-ci.org/github/simplecov-ruby/simplecov.svg?branch=main" style="max-width:100%;"></a></h1>
+        <p><strong>Code coverage for Ruby</strong></p>
+        <ul>
+        <li><a href="https://github.com/simplecov-ruby/simplecov" title="Source Code @ GitHub">Source Code</a></li>
+        <li><a href="http://rubydoc.info/gems/simplecov/frames" title="RDoc API Documentation at Rubydoc.info" rel="nofollow">API documentation</a></li>
+        <li><a href="https://github.com/simplecov-ruby/simplecov/blob/main/CHANGELOG.md" title="Project Changelog">Changelog</a></li>
+        <li><a href="http://rubygems.org/gems/simplecov" title="SimpleCov @ rubygems.org" rel="nofollow">Rubygem</a></li>
+        <li><a href="https://github.com/simplecov-ruby/simplecov/actions?query=workflow%3Astable" title="SimpleCov is built around the clock by github.com">Continuous Integration</a></li>
+        </ul>
+        <p>SimpleCov is a code coverage analysis tool for Ruby. It uses <a href="https://ruby-doc.org/stdlib/libdoc/coverage/rdoc/Coverage.html" title="API doc for Ruby's Coverage library" rel="nofollow">Ruby's built-in Coverage</a> library to gather code
+        coverage data, but makes processing its results much easier by providing a clean API to filter, group, merge, format,
+        and display those results, giving you a complete code coverage suite that can be set up with just a couple lines of
+        code.
+        SimpleCov/Coverage track covered ruby code, gathering coverage for common templating solutions like erb, slim and haml is not supported.</p>
+        <p>In most cases, you'll want overall coverage results for your projects, including all types of tests, Cucumber features,
+        etc. SimpleCov automatically takes care of this by caching and merging results when generating reports, so your
+        report actually includes coverage across your test suites and thereby gives you a better picture of blank spots.</p>
+        <p>The official formatter of SimpleCov is packaged as a separate gem called <a href="https://github.com/simplecov-ruby/simplecov-html" title="SimpleCov HTML Formatter Source Code @ GitHub">simplecov-html</a>, but will be installed and
+        configured automatically when you launch SimpleCov. If you're curious, you can find it <a href="https://github.com/simplecov-ruby/simplecov-html" title="SimpleCov HTML Formatter Source Code @ GitHub">on GitHub, too</a>.</p>
+        <h2><a id="user-content-contact" class="anchor" aria-hidden="true" href="#contact"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Contact</h2>
+        <p><em>Code and Bug Reports</em></p>
+        <ul>
+        <li><a href="https://github.com/simplecov-ruby/simplecov/issues">Issue Tracker</a></li>
+        <li>See <a href="https://github.com/simplecov-ruby/simplecov/blob/main/CONTRIBUTING.md">CONTRIBUTING</a> for how to contribute along
+        with some common problems to check out before creating an issue.</li>
+        </ul>
+        <p><em>Questions, Problems, Suggestions, etc.</em></p>
+        <ul>
+        <li><a href="https://groups.google.com/forum/#!forum/simplecov" rel="nofollow">Mailing List</a> "Open mailing list for discussion and announcements
+        on Google Groups"</li>
+        </ul>
+        <h2><a id="user-content-getting-started" class="anchor" aria-hidden="true" href="#getting-started"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Getting started</h2>
+        <ol>
+        <li>
+        <p>Add SimpleCov to your <code>Gemfile</code> and <code>bundle install</code>:</p>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-en">gem</span> <span class="pl-s">'simplecov'</span><span class="pl-kos">,</span> <span class="pl-pds">require</span>: <span class="pl-c1">false</span><span class="pl-kos">,</span> <span class="pl-pds">group</span>: <span class="pl-pds">:test</span></pre></div>
+        </li>
+        <li>
+        <p>Load and launch SimpleCov <strong>at the very top</strong> of your <code>test/test_helper.rb</code>
+        (<em>or <code>spec_helper.rb</code>, <code>rails_helper</code>, cucumber <code>env.rb</code>, or whatever your preferred test
+        framework uses</em>):</p>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-en">require</span> <span class="pl-s">'simplecov'</span>
+        <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span>
+
+        <span class="pl-c"># Previous content of test helper now starts here</span></pre></div>
+        <p><strong>Note:</strong> If SimpleCov starts after your application code is already loaded
+        (via <code>require</code>), it won't be able to track your files and their coverage!
+        The <code>SimpleCov.start</code> <strong>must</strong> be issued <strong>before any of your application
+        code is required!</strong></p>
+        <p>SimpleCov must be running in the process that you want the code coverage
+        analysis to happen on. When testing a server process (e.g. a JSON API
+        endpoint) via a separate test process (e.g. when using Selenium) where you
+        want to see all code executed by the <code>rails server</code>, and not just code
+        executed in your actual test files, you'll want to add something like this
+        to the top of <code>bin/rails</code>, but below the "shebang" line (<code>#! /usr/bin/env ruby</code>):</p>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-k">if</span> <span class="pl-c1">ENV</span><span class="pl-kos">[</span><span class="pl-s">'RAILS_ENV'</span><span class="pl-kos">]</span> == <span class="pl-s">'test'</span>
+          <span class="pl-en">require</span> <span class="pl-s">'simplecov'</span>
+          <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span> <span class="pl-s">'rails'</span>
+          <span class="pl-en">puts</span> <span class="pl-s">"required simplecov"</span>
+        <span class="pl-k">end</span></pre></div>
+        </li>
+        <li>
+        <p>Run your full test suite to see the percent coverage that your application has.</p>
+        </li>
+        <li>
+        <p>After running your tests, open <code>coverage/index.html</code> in the browser of your choice. For example, in a Mac Terminal,
+        run the following command from your application's root directory:</p>
+        <pre><code>open coverage/index.html
+        </code></pre>
+        <p>in a debian/ubuntu Terminal,</p>
+        <pre><code>xdg-open coverage/index.html
+        </code></pre>
+        <p><strong>Note:</strong> <a href="https://dwheeler.com/essays/open-files-urls.html" rel="nofollow">This guide</a> can help if you're unsure which command your particular
+        operating system requires.</p>
+        </li>
+        <li>
+        <p>Add the following to your <code>.gitignore</code> file to ensure that coverage results
+        are not tracked by Git (optional):</p>
+        <pre><code>echo "coverage" &gt;&gt; .gitignore
+        </code></pre>
+        <p>Or if you use Windows:</p>
+        <pre><code>echo coverage &gt;&gt; .gitignore
+        </code></pre>
+        <p>If you're making a Rails application, SimpleCov comes with built-in configurations (see below for information on
+        profiles) that will get you started with groups for your Controllers, Models and Helpers. To use it, the
+        first two lines of your test_helper should be like this:</p>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-en">require</span> <span class="pl-s">'simplecov'</span>
+        <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span> <span class="pl-s">'rails'</span></pre></div>
+        </li>
+        </ol>
+        <h2><a id="user-content-example-output" class="anchor" aria-hidden="true" href="#example-output"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Example output</h2>
+        <p><strong>Coverage results report, fully browsable locally with sorting and much more:</strong></p>
+        <p><a target="_blank" rel="noopener noreferrer" href="https://cloud.githubusercontent.com/assets/137793/17071162/db6f253e-502d-11e6-9d84-e40c3d75f333.png"><img src="https://cloud.githubusercontent.com/assets/137793/17071162/db6f253e-502d-11e6-9d84-e40c3d75f333.png" alt="SimpleCov coverage report" style="max-width:100%;"></a></p>
+        <p><strong>Source file coverage details view:</strong></p>
+        <p><a target="_blank" rel="noopener noreferrer" href="https://cloud.githubusercontent.com/assets/137793/17071163/db6f9f0a-502d-11e6-816c-edb2c66fad8d.png"><img src="https://cloud.githubusercontent.com/assets/137793/17071163/db6f9f0a-502d-11e6-816c-edb2c66fad8d.png" alt="SimpleCov source file detail view" style="max-width:100%;"></a></p>
+        <h2><a id="user-content-use-it-with-any-framework" class="anchor" aria-hidden="true" href="#use-it-with-any-framework"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Use it with any framework!</h2>
+        <p>Similarly to the usage with Test::Unit described above, the only thing you have to do is to add the SimpleCov
+        config to the very top of your Cucumber/RSpec/whatever setup file.</p>
+        <p>Add the setup code to the <strong>top</strong> of <code>features/support/env.rb</code> (for Cucumber) or <code>spec/spec_helper.rb</code> (for RSpec).
+        Other test frameworks should work accordingly, whatever their setup file may be:</p>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-en">require</span> <span class="pl-s">'simplecov'</span>
+        <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span> <span class="pl-s">'rails'</span></pre></div>
+        <p>You could even track what kind of code your UI testers are touching if you want to go overboard with things. SimpleCov
+        does not care what kind of framework it is running in; it just looks at what code is being executed and generates a
+        report about it.</p>
+        <h3><a id="user-content-notes-on-specific-frameworks-and-test-utilities" class="anchor" aria-hidden="true" href="#notes-on-specific-frameworks-and-test-utilities"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Notes on specific frameworks and test utilities</h3>
+        <p>For some frameworks and testing tools there are quirks and problems you might want to know about if you want
+        to use SimpleCov with them. Here's an overview of the known ones:</p>
+        <table>
+          <tbody><tr><th>Framework</th><th>Notes</th><th>Issue</th></tr>
+          <tr>
+            <th>
+              parallel_tests
+            </th>
+            <td>
+              As of 0.8.0, SimpleCov should correctly recognize parallel_tests and
+              supplement your test suite names with their corresponding test env
+              numbers. SimpleCov locks the resultset cache while merging, ensuring no
+              race conditions occur when results are merged.
+            </td>
+            <td>
+              <a href="https://github.com/simplecov-ruby/simplecov/issues/64">#64</a> &amp;
+              <a href="https://github.com/simplecov-ruby/simplecov/pull/185">#185</a>
+            </td>
+          </tr>
+          <tr>
+            <th>
+              knapsack_pro
+            </th>
+            <td>
+              To make SimpleCov work with Knapsack Pro Queue Mode to split tests in parallel on CI jobs you need to provide CI node index number to the <code>SimpleCov.command_name</code> in <code>KnapsackPro::Hooks::Queue.before_queue</code> hook.
+            </td>
+            <td>
+              <a href="https://knapsackpro.com/faq/question/how-to-use-simplecov-in-queue-mode" rel="nofollow">Tip</a>
+            </td>
+          </tr>
+          <tr>
+            <th>
+              RubyMine
+            </th>
+            <td>
+              The <a href="https://www.jetbrains.com/ruby/" rel="nofollow">RubyMine IDE</a> has
+              built-in support for SimpleCov's coverage reports, though you might need
+              to explicitly set the output root using `SimpleCov.root('foo/bar/baz')`
+            </td>
+            <td>
+              <a href="https://github.com/simplecov-ruby/simplecov/issues/95">#95</a>
+            </td>
+          </tr>
+          <tr>
+            <th>
+              Spork
+            </th>
+            <td>
+              Because of how Spork works internally (using preforking), there used to
+              be trouble when using SimpleCov with it, but that has apparently been
+              resolved with a specific configuration strategy. See <a href="https://github.com/simplecov-ruby/simplecov/issues/42#issuecomment-4440284">this</a>
+              comment.
+            </td>
+            <td>
+              <a href="https://github.com/simplecov-ruby/simplecov/issues/42#issuecomment-4440284">#42</a>
+            </td>
+          </tr>
+          <tr>
+            <th>
+              Spring
+            </th>
+            <td>
+              <a href="#want-to-use-spring-with-simplecov">See section below.</a>
+            </td>
+            <td>
+              <a href="https://github.com/simplecov-ruby/simplecov/issues/381">#381</a>
+            </td>
+          </tr>
+          <tr>
+            <th>
+              Test/Unit
+            </th>
+            <td>
+              Test Unit 2 used to mess with ARGV, leading to a failure to detect the
+              test process name in SimpleCov. <code>test-unit</code> releases 2.4.3+
+              (Dec 11th, 2011) should have this problem resolved.
+            </td>
+            <td>
+              <a href="https://github.com/simplecov-ruby/simplecov/issues/45">#45</a> &amp;
+              <a href="https://github.com/test-unit/test-unit/pull/12">test-unit/test-unit#12</a>
+            </td>
+          </tr>
+        </tbody></table>
+        <h2><a id="user-content-configuring-simplecov" class="anchor" aria-hidden="true" href="#configuring-simplecov"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Configuring SimpleCov</h2>
+        <p><a href="http://rubydoc.info/gems/simplecov/SimpleCov/Configuration" title="Configuration options API documentation" rel="nofollow">Configuration</a> settings can be applied in three formats, which are completely equivalent:</p>
+        <ul>
+        <li>
+        <p>The most common way is to configure it directly in your start block:</p>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span> <span class="pl-k">do</span>
+          <span class="pl-en">some_config_option</span> <span class="pl-s">'foo'</span>
+        <span class="pl-k">end</span></pre></div>
+        </li>
+        <li>
+        <p>You can also set all configuration options directly:</p>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">some_config_option</span> <span class="pl-s">'foo'</span></pre></div>
+        </li>
+        <li>
+        <p>If you do not want to start coverage immediately after launch or want to add additional configuration later on in a
+        concise way, use:</p>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">configure</span> <span class="pl-k">do</span>
+          <span class="pl-en">some_config_option</span> <span class="pl-s">'foo'</span>
+        <span class="pl-k">end</span></pre></div>
+        </li>
+        </ul>
+        <p>Please check out the <a href="http://rubydoc.info/gems/simplecov/SimpleCov/Configuration" title="Configuration options API documentation" rel="nofollow">Configuration</a> API documentation to find out what you can customize.</p>
+        <h2><a id="user-content-using-simplecov-for-centralized-config" class="anchor" aria-hidden="true" href="#using-simplecov-for-centralized-config"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Using .simplecov for centralized config</h2>
+        <p>If you use SimpleCov to merge multiple test suite results (e.g. Test/Unit and Cucumber) into a single report, you'd
+        normally have to set up all your config options twice, once in <code>test_helper.rb</code> and once in <code>env.rb</code>.</p>
+        <p>To avoid this, you can place a file called <code>.simplecov</code> in your project root. You can then just leave the
+        <code>require 'simplecov'</code> in each test setup helper (<strong>at the top</strong>) and move the <code>SimpleCov.start</code> code with all your
+        custom config options into <code>.simplecov</code>:</p>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-c"># test/test_helper.rb</span>
+        <span class="pl-en">require</span> <span class="pl-s">'simplecov'</span>
+
+        <span class="pl-c"># features/support/env.rb</span>
+        <span class="pl-en">require</span> <span class="pl-s">'simplecov'</span>
+
+        <span class="pl-c"># .simplecov</span>
+        <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span> <span class="pl-s">'rails'</span> <span class="pl-k">do</span>
+          <span class="pl-c"># any custom configs like groups and filters can be here at a central place</span>
+        <span class="pl-k">end</span></pre></div>
+        <p>Using <code>.simplecov</code> rather than separately requiring SimpleCov multiple times is recommended if you are merging multiple
+        test frameworks like Cucumber and RSpec that rely on each other, as invoking SimpleCov multiple times can cause coverage
+        information to be lost.</p>
+        <h2><a id="user-content-branch-coverage-ruby--25" class="anchor" aria-hidden="true" href="#branch-coverage-ruby--25"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Branch coverage (ruby "~&gt; 2.5")</h2>
+        <p>Add branch coverage measurement statistics to your results. Supported in CRuby versions 2.5+.</p>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-c"># or in configure or just SimpleCov.enable_coverage :branch</span>
+        <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span> <span class="pl-k">do</span>
+          <span class="pl-en">enable_coverage</span> <span class="pl-pds">:branch</span>
+        <span class="pl-k">end</span></pre></div>
+        <p>Branch coverage is a feature introduced in Ruby 2.5 concerning itself with whether a
+        particular branch of a condition had been executed. Line coverage on the other hand
+        is only interested in whether a line of code has been executed.</p>
+        <p>This comes in handy for instance for one line conditionals:</p>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-en">number</span><span class="pl-kos">.</span><span class="pl-en">odd?</span> ? <span class="pl-s">"odd"</span> : <span class="pl-s">"even"</span></pre></div>
+        <p>In line coverage this line would always be marked as executed but you'd never know if both
+        conditions were met. Guard clauses have a similar story:</p>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-k">return</span> <span class="pl-k">if</span> <span class="pl-en">number</span><span class="pl-kos">.</span><span class="pl-en">odd?</span>
+
+        <span class="pl-c"># more code</span></pre></div>
+        <p>If all the code in that method was covered you'd never know if the guard clause was ever
+        triggered! With line coverage as just evaluating the condition marks it as covered.</p>
+        <p>In the HTML report the lines of code will be annotated like <code>branch_type: hit_count</code>:</p>
+        <ul>
+        <li><code>then: 2</code> - the then branch (of an <code>if</code>) was executed twice</li>
+        <li><code>else: 0</code> - the else branch (of an <code>if</code> or <code>case</code>) was never executed</li>
+        </ul>
+        <p>Not that even if you don't declare an <code>else</code> branch it will still show up in the coverage
+        reports meaning that the condition of the <code>if</code> was not hit or that no <code>when</code> of <code>case</code>
+        was hit during the test runs.</p>
+        <p><strong>Is branch coverage strictly better?</strong> No. Branch coverage really only concerns itself with
+        conditionals - meaning coverage of sequential code is of no interest to it. A file without
+        conditional logic will have no branch coverage data and SimpleCov will report 0 of 0
+        branches covered as 100% (as everything that can be covered was covered).</p>
+        <p>Hence, we recommend looking at both metrics together. Branch coverage might also be a good
+        overall metric to look at - while you might be missing only 10% of your lines that might
+        account for 50% of your branches for instance.</p>
+        <h2><a id="user-content-filters" class="anchor" aria-hidden="true" href="#filters"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Filters</h2>
+        <p>Filters can be used to remove selected files from your coverage data. By default, a filter is applied that removes all
+        files OUTSIDE of your project's root directory - otherwise you'd end up with billions of coverage reports for source
+        files in the gems you are using.</p>
+        <p>You can define your own to remove things like configuration files, tests or whatever you don't need in your coverage
+        report.</p>
+        <h3><a id="user-content-defining-custom-filters" class="anchor" aria-hidden="true" href="#defining-custom-filters"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Defining custom filters</h3>
+        <p>You can currently define a filter using either a String or Regexp (that will then be Regexp-matched against each source
+        file's path), a block or by passing in your own Filter class.</p>
+        <h4><a id="user-content-string-filter" class="anchor" aria-hidden="true" href="#string-filter"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>String filter</h4>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span> <span class="pl-k">do</span>
+          <span class="pl-en">add_filter</span> <span class="pl-s">"/test/"</span>
+        <span class="pl-k">end</span></pre></div>
+        <p>This simple string filter will remove all files that match "/test/" in their path.</p>
+        <h4><a id="user-content-regex-filter" class="anchor" aria-hidden="true" href="#regex-filter"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Regex filter</h4>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span> <span class="pl-k">do</span>
+          <span class="pl-en">add_filter</span> <span class="pl-pds">%r{^/test/}</span>
+        <span class="pl-k">end</span></pre></div>
+        <p>This simple regex filter will remove all files that start with /test/ in their path.</p>
+        <h4><a id="user-content-block-filter" class="anchor" aria-hidden="true" href="#block-filter"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Block filter</h4>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span> <span class="pl-k">do</span>
+          <span class="pl-en">add_filter</span> <span class="pl-k">do</span> |<span class="pl-s1">source_file</span>|
+            <span class="pl-s1">source_file</span><span class="pl-kos">.</span><span class="pl-en">lines</span><span class="pl-kos">.</span><span class="pl-en">count</span> &lt; <span class="pl-c1">5</span>
+          <span class="pl-k">end</span>
+        <span class="pl-k">end</span></pre></div>
+        <p>Block filters receive a SimpleCov::SourceFile instance and expect your block to return either true (if the file is to be
+        removed from the result) or false (if the result should be kept). Please check out the RDoc for SimpleCov::SourceFile to
+        learn about the methods available to you. In the above example, the filter will remove all files that have less than 5
+        lines of code.</p>
+        <h4><a id="user-content-custom-filter-class" class="anchor" aria-hidden="true" href="#custom-filter-class"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Custom filter class</h4>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-k">class</span> <span class="pl-v">LineFilter</span> &lt; <span class="pl-v">SimpleCov</span>::<span class="pl-v">Filter</span>
+          <span class="pl-k">def</span> <span class="pl-en">matches?</span><span class="pl-kos">(</span><span class="pl-s1">source_file</span><span class="pl-kos">)</span>
+            <span class="pl-s1">source_file</span><span class="pl-kos">.</span><span class="pl-en">lines</span><span class="pl-kos">.</span><span class="pl-en">count</span> &lt; <span class="pl-en">filter_argument</span>
+          <span class="pl-k">end</span>
+        <span class="pl-k">end</span>
+
+        <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">add_filter</span> <span class="pl-v">LineFilter</span><span class="pl-kos">.</span><span class="pl-en">new</span><span class="pl-kos">(</span><span class="pl-c1">5</span><span class="pl-kos">)</span></pre></div>
+        <p>Defining your own filters is pretty easy: Just inherit from SimpleCov::Filter and define a method
+        'matches?(source_file)'. When running the filter, a true return value from this method will result in the removal of the
+        given source_file. The filter_argument method is being set in the SimpleCov::Filter initialize method and thus is set to
+        5 in this example.</p>
+        <h4><a id="user-content-array-filter" class="anchor" aria-hidden="true" href="#array-filter"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Array filter</h4>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span> <span class="pl-k">do</span>
+          <span class="pl-s1">proc</span> <span class="pl-c1">=</span> <span class="pl-v">Proc</span><span class="pl-kos">.</span><span class="pl-en">new</span> <span class="pl-kos">{</span> |<span class="pl-s1">source_file</span>| <span class="pl-c1">false</span> <span class="pl-kos">}</span>
+          <span class="pl-en">add_filter</span> <span class="pl-kos">[</span><span class="pl-s">"string"</span><span class="pl-kos">,</span> <span class="pl-pds">/regex/</span><span class="pl-kos">,</span> <span class="pl-s1">proc</span><span class="pl-kos">,</span> <span class="pl-v">LineFilter</span><span class="pl-kos">.</span><span class="pl-en">new</span><span class="pl-kos">(</span><span class="pl-c1">5</span><span class="pl-kos">)</span><span class="pl-kos">]</span>
+        <span class="pl-k">end</span></pre></div>
+        <p>You can pass in an array containing any of the other filter types.</p>
+        <h4><a id="user-content-ignoringskipping-code" class="anchor" aria-hidden="true" href="#ignoringskipping-code"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Ignoring/skipping code</h4>
+        <p>You can exclude code from the coverage report by wrapping it in <code># :nocov:</code>.</p>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-c"># :nocov:</span>
+        <span class="pl-k">def</span> <span class="pl-en">skip_this_method</span>
+          <span class="pl-en">never_reached</span>
+        <span class="pl-k">end</span>
+        <span class="pl-c"># :nocov:</span></pre></div>
+        <p>The name of the token can be changed to your liking. <a href="https://github.com/simplecov-ruby/simplecov/blob/main/features/config_nocov_token.feature">Learn more about the nocov feature.</a></p>
+        <p><strong>Note:</strong> You shouldn't have to use the nocov token to skip private methods that are being included in your coverage. If
+        you appropriately test the public interface of your classes and objects you should automatically get full coverage of
+        your private methods.</p>
+        <h2><a id="user-content-default-root-filter-and-coverage-for-things-outside-of-it" class="anchor" aria-hidden="true" href="#default-root-filter-and-coverage-for-things-outside-of-it"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Default root filter and coverage for things outside of it</h2>
+        <p>By default, SimpleCov filters everything outside of the <code>SimpleCov.root</code> directory. However, sometimes you may want
+        to include coverage reports for things you include as a gem, for example a Rails Engine.</p>
+        <p>Here's an example by <a href="https://github.com/lsaffie">@lsaffie</a> from <a href="https://github.com/simplecov-ruby/simplecov/issues/221">#221</a>
+        that shows how you can achieve just that:</p>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span> <span class="pl-pds">:rails</span> <span class="pl-k">do</span>
+          <span class="pl-en">filters</span><span class="pl-kos">.</span><span class="pl-en">clear</span> <span class="pl-c"># This will remove the :root_filter and :bundler_filter that come via simplecov's defaults</span>
+          <span class="pl-en">add_filter</span> <span class="pl-k">do</span> |<span class="pl-s1">src</span>|
+            !<span class="pl-kos">(</span><span class="pl-s1">src</span><span class="pl-kos">.</span><span class="pl-en">filename</span> =~ <span class="pl-pds">/^<span class="pl-s1"><span class="pl-kos">#{</span><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">root</span><span class="pl-kos">}</span></span>/</span><span class="pl-kos">)</span> <span class="pl-k">unless</span> <span class="pl-s1">src</span><span class="pl-kos">.</span><span class="pl-en">filename</span> =~ <span class="pl-pds">/my_engine/</span>
+          <span class="pl-k">end</span>
+        <span class="pl-k">end</span></pre></div>
+        <h2><a id="user-content-groups" class="anchor" aria-hidden="true" href="#groups"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Groups</h2>
+        <p>You can separate your source files into groups. For example, in a Rails app, you'll want to have separate listings for
+        Models, Controllers, Helpers, and Libs. Group definition works similarly to Filters (and also accepts custom
+        filter classes), but source files end up in a group when the filter passes (returns true), as opposed to filtering
+        results, which exclude files from results when the filter results in a true value.</p>
+        <p>Add your groups with:</p>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span> <span class="pl-k">do</span>
+          <span class="pl-en">add_group</span> <span class="pl-s">"Models"</span><span class="pl-kos">,</span> <span class="pl-s">"app/models"</span>
+          <span class="pl-en">add_group</span> <span class="pl-s">"Controllers"</span><span class="pl-kos">,</span> <span class="pl-s">"app/controllers"</span>
+          <span class="pl-en">add_group</span> <span class="pl-s">"Long files"</span> <span class="pl-k">do</span> |<span class="pl-s1">src_file</span>|
+            <span class="pl-s1">src_file</span><span class="pl-kos">.</span><span class="pl-en">lines</span><span class="pl-kos">.</span><span class="pl-en">count</span> &gt; <span class="pl-c1">100</span>
+          <span class="pl-k">end</span>
+          <span class="pl-en">add_group</span> <span class="pl-s">"Multiple Files"</span><span class="pl-kos">,</span> <span class="pl-kos">[</span><span class="pl-s">"app/models"</span><span class="pl-kos">,</span> <span class="pl-s">"app/controllers"</span><span class="pl-kos">]</span> <span class="pl-c"># You can also pass in an array</span>
+          <span class="pl-en">add_group</span> <span class="pl-s">"Short files"</span><span class="pl-kos">,</span> <span class="pl-v">LineFilter</span><span class="pl-kos">.</span><span class="pl-en">new</span><span class="pl-kos">(</span><span class="pl-c1">5</span><span class="pl-kos">)</span> <span class="pl-c"># Using the LineFilter class defined in Filters section above</span>
+        <span class="pl-k">end</span></pre></div>
+        <h2><a id="user-content-merging-results" class="anchor" aria-hidden="true" href="#merging-results"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Merging results</h2>
+        <p>You normally want to have your coverage analyzed across ALL of your test suites, right?</p>
+        <p>Simplecov automatically caches coverage results in your
+        (coverage_path)/.resultset.json, and will merge or override those with
+        subsequent runs, depending on whether simplecov considers those subsequent runs
+        as different test suites or as the same test suite as the cached results. To
+        make this distinction, simplecov has the concept of "test suite names".</p>
+        <h3><a id="user-content-test-suite-names" class="anchor" aria-hidden="true" href="#test-suite-names"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Test suite names</h3>
+        <p>SimpleCov tries to guess the name of the currently running test suite based upon the shell command the tests
+        are running on. This should work fine for Unit Tests, RSpec, and Cucumber. If it fails, it will use the shell
+        command that invoked the test suite as a command name.</p>
+        <p>If you have some non-standard setup and still want nicely labeled test suites, you have to give Simplecov a
+        cue as to what the name of the currently running test suite is. You can do so by specifying
+        <code>SimpleCov.command_name</code> in one test file that is part of your specific suite.</p>
+        <p>To customize the suite names on a Rails app (yeah, sorry for being Rails-biased, but everyone knows what
+        the structure of those projects is. You can apply this accordingly to the RSpecs in your
+        Outlook-WebDAV-Calendar-Sync gem), you could do something like this:</p>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-c"># test/unit/some_test.rb</span>
+        <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">command_name</span> <span class="pl-s">'test:units'</span>
+
+        <span class="pl-c"># test/functionals/some_controller_test.rb</span>
+        <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">command_name</span> <span class="pl-s">"test:functionals"</span>
+
+        <span class="pl-c"># test/integration/some_integration_test.rb</span>
+        <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">command_name</span> <span class="pl-s">"test:integration"</span>
+
+        <span class="pl-c"># features/support/env.rb</span>
+        <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">command_name</span> <span class="pl-s">"features"</span></pre></div>
+        <p>Note that this only has to be invoked ONCE PER TEST SUITE, so even if you have 200 unit test files,
+        specifying it in <code>some_test.rb</code> is enough.</p>
+        <p>Last but not least <strong>if multiple suites resolve to the same <code>command_name</code></strong> be aware that the coverage results <strong>will
+        clobber each other instead of being merged</strong>.  SimpleCov is smart enough to detect unique names for the most common
+        setups, but if you have more than one test suite that doesn't follow a common pattern then you will want to manually
+        ensure that each suite gets a unique <code>command_name</code>.</p>
+        <p>If you are running tests in parallel each process has the potential to clobber results from the other test processes.
+        If you are relying on the default <code>command_name</code> then SimpleCov will attempt to detect and avoid parallel test suite
+        <code>command_name</code> collisions based on the presence of <code>ENV['PARALLEL_TEST_GROUPS']</code> and <code>ENV['TEST_ENV_NUMBER']</code>.  If your
+        parallel test runner does not set one or both of these then <em>you must</em> set a <code>command_name</code> and ensure that it is unique
+        per process (eg. <code>command_name "Unit Tests PID #{$$}"</code>).</p>
+        <p>If you are using parallel_tests, you must incorporate <code>TEST_ENV_NUMBER</code> into the command name yourself, in
+        order for SimpleCov to merge the results correctly. For example:</p>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-c"># spec/spec_helper.rb</span>
+        <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">command_name</span> <span class="pl-s">"features"</span> + <span class="pl-kos">(</span><span class="pl-c1">ENV</span><span class="pl-kos">[</span><span class="pl-s">'TEST_ENV_NUMBER'</span><span class="pl-kos">]</span> || <span class="pl-s">''</span><span class="pl-kos">)</span></pre></div>
+        <p><a href="https://github.com/simplecov-ruby/simplecov-html" title="SimpleCov HTML Formatter Source Code @ GitHub">simplecov-html</a> prints the used test suites in the footer of the generated coverage report.</p>
+        <h3><a id="user-content-merging-test-runs-under-the-same-execution-environment" class="anchor" aria-hidden="true" href="#merging-test-runs-under-the-same-execution-environment"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Merging test runs under the same execution environment</h3>
+        <p>Test results are automatically merged with previous runs in the same execution
+        environment when generating the result, so when coverage is set up properly for
+        Cucumber and your unit / functional / integration tests, all of those test
+        suites will be taken into account when building the coverage report.</p>
+        <h4><a id="user-content-timeout-for-merge" class="anchor" aria-hidden="true" href="#timeout-for-merge"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Timeout for merge</h4>
+        <p>Of course, your cached coverage data is likely to become invalid at some point. Thus, when automatically merging
+        subsequent test runs, result sets that are older than <code>SimpleCov.merge_timeout</code> will not be used any more. By default,
+        the timeout is 600 seconds (10 minutes), and you can raise (or lower) it by specifying <code>SimpleCov.merge_timeout 3600</code>
+        (1 hour), or, inside a configure/start block, with just <code>merge_timeout 3600</code>.</p>
+        <p>You can deactivate this automatic merging altogether with <code>SimpleCov.use_merging false</code>.</p>
+        <h3><a id="user-content-merging-test-runs-under-different-execution-environments" class="anchor" aria-hidden="true" href="#merging-test-runs-under-different-execution-environments"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Merging test runs under different execution environments</h3>
+        <p>If your tests are done in parallel across multiple build machines, you can fetch them all and merge them into a single
+        result set using the <code>SimpleCov.collate</code> method. This can be added to a Rakefile or script file, having downloaded a set of
+        <code>.resultset.json</code> files from each parallel test run.</p>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-c"># lib/tasks/coverage_report.rake</span>
+        <span class="pl-en">namespace</span> <span class="pl-pds">:coverage</span> <span class="pl-k">do</span>
+          <span class="pl-en">desc</span> <span class="pl-s">"Collates all result sets generated by the different test runners"</span>
+          <span class="pl-en">task</span> <span class="pl-pds">:report</span> <span class="pl-k">do</span>
+            <span class="pl-en">require</span> <span class="pl-s">'simplecov'</span>
+
+            <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">collate</span> <span class="pl-v">Dir</span><span class="pl-kos">[</span><span class="pl-s">"simplecov-resultset-*/.resultset.json"</span><span class="pl-kos">]</span>
+          <span class="pl-k">end</span>
+        <span class="pl-k">end</span></pre></div>
+        <p><code>SimpleCov.collate</code> also takes an optional simplecov profile and an optional
+        block for configuration, just the same as <code>SimpleCov.start</code> or
+        <code>SimpleCov.configure</code>.  This means you can configure a separate formatter for
+        the collated output. For instance, you can make the formatter in
+        <code>SimpleCov.start</code> the <code>SimpleCov::Formatter::SimpleFormatter</code>, and only use more
+        complex formatters in the final <code>SimpleCov.collate</code> run.</p>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-c"># spec/spec_helper.rb</span>
+        <span class="pl-en">require</span> <span class="pl-s">'simplecov'</span>
+
+        <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span> <span class="pl-s">'rails'</span> <span class="pl-k">do</span>
+          <span class="pl-c"># Disambiguates individual test runs</span>
+          <span class="pl-en">command_name</span> <span class="pl-s">"Job <span class="pl-s1"><span class="pl-kos">#{</span><span class="pl-c1">ENV</span><span class="pl-kos">[</span><span class="pl-s">"TEST_ENV_NUMBER"</span><span class="pl-kos">]</span><span class="pl-kos">}</span></span>"</span> <span class="pl-k">if</span> <span class="pl-c1">ENV</span><span class="pl-kos">[</span><span class="pl-s">"TEST_ENV_NUMBER"</span><span class="pl-kos">]</span>
+
+          <span class="pl-k">if</span> <span class="pl-c1">ENV</span><span class="pl-kos">[</span><span class="pl-s">'CI'</span><span class="pl-kos">]</span>
+            <span class="pl-en">formatter</span> <span class="pl-v">SimpleCov</span>::<span class="pl-v">Formatter</span>::<span class="pl-v">SimpleFormatter</span>
+          <span class="pl-k">else</span>
+            <span class="pl-en">formatter</span> <span class="pl-v">SimpleCov</span>::<span class="pl-v">Formatter</span>::<span class="pl-v">MultiFormatter</span><span class="pl-kos">.</span><span class="pl-en">new</span><span class="pl-kos">(</span><span class="pl-kos">[</span>
+              <span class="pl-v">SimpleCov</span>::<span class="pl-v">Formatter</span>::<span class="pl-v">SimpleFormatter</span><span class="pl-kos">,</span>
+              <span class="pl-v">SimpleCov</span>::<span class="pl-v">Formatter</span>::<span class="pl-v">HTMLFormatter</span>
+            <span class="pl-kos">]</span><span class="pl-kos">)</span>
+          <span class="pl-k">end</span>
+
+          <span class="pl-en">track_files</span> <span class="pl-s">"**/*.rb"</span>
+        <span class="pl-k">end</span></pre></div>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-c"># lib/tasks/coverage_report.rake</span>
+        <span class="pl-en">namespace</span> <span class="pl-pds">:coverage</span> <span class="pl-k">do</span>
+          <span class="pl-en">task</span> <span class="pl-pds">:report</span> <span class="pl-k">do</span>
+            <span class="pl-en">require</span> <span class="pl-s">'simplecov'</span>
+
+            <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">collate</span> <span class="pl-v">Dir</span><span class="pl-kos">[</span><span class="pl-s">"simplecov-resultset-*/.resultset.json"</span><span class="pl-kos">]</span><span class="pl-kos">,</span> <span class="pl-s">'rails'</span> <span class="pl-k">do</span>
+              <span class="pl-en">formatter</span> <span class="pl-v">SimpleCov</span>::<span class="pl-v">Formatter</span>::<span class="pl-v">MultiFormatter</span><span class="pl-kos">.</span><span class="pl-en">new</span><span class="pl-kos">(</span><span class="pl-kos">[</span>
+                <span class="pl-v">SimpleCov</span>::<span class="pl-v">Formatter</span>::<span class="pl-v">SimpleFormatter</span><span class="pl-kos">,</span>
+                <span class="pl-v">SimpleCov</span>::<span class="pl-v">Formatter</span>::<span class="pl-v">HTMLFormatter</span>
+              <span class="pl-kos">]</span><span class="pl-kos">)</span>
+            <span class="pl-k">end</span>
+          <span class="pl-k">end</span>
+        <span class="pl-k">end</span></pre></div>
+        <h2><a id="user-content-running-simplecov-against-subprocesses" class="anchor" aria-hidden="true" href="#running-simplecov-against-subprocesses"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Running simplecov against subprocesses</h2>
+        <p><code>SimpleCov.enable_for_subprocesses</code> will allow SimpleCov to observe subprocesses starting using <code>Process.fork</code>.
+        This modifies ruby's core Process.fork method so that SimpleCov can see into it, appending <code>" (subprocess #{pid})"</code>
+        to the <code>SimpleCov.command_name</code>, with results that can be merged together using SimpleCov's merging feature.</p>
+        <p>To configure this, use <code>.at_fork</code>.</p>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">enable_for_subprocesses</span> <span class="pl-c1">true</span>
+        <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">at_fork</span> <span class="pl-k">do</span> |<span class="pl-s1">pid</span>|
+          <span class="pl-c"># This needs a unique name so it won't be ovewritten</span>
+          <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">command_name</span> <span class="pl-s">"<span class="pl-s1"><span class="pl-kos">#{</span><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">command_name</span><span class="pl-kos">}</span></span> (subprocess: <span class="pl-s1"><span class="pl-kos">#{</span><span class="pl-s1">pid</span><span class="pl-kos">}</span></span>)"</span>
+          <span class="pl-c"># be quiet, the parent process will be in charge of output and checking coverage totals</span>
+          <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">print_error_status</span> <span class="pl-c1">=</span> <span class="pl-c1">false</span>
+          <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">formatter</span> <span class="pl-v">SimpleCov</span>::<span class="pl-v">Formatter</span>::<span class="pl-v">SimpleFormatter</span>
+          <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">minimum_coverage</span> <span class="pl-c1">0</span>
+          <span class="pl-c"># start</span>
+          <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span>
+        <span class="pl-k">end</span></pre></div>
+        <p>NOTE: SimpleCov must have already been started before <code>Process.fork</code> was called.</p>
+        <h3><a id="user-content-running-simplecov-against-spawned-subprocesses" class="anchor" aria-hidden="true" href="#running-simplecov-against-spawned-subprocesses"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Running simplecov against spawned subprocesses</h3>
+        <p>Perhaps you're testing a ruby script with <code>PTY.spawn</code> or <code>Open3.popen</code>, or <code>Process.spawn</code> or etc.
+        SimpleCov can cover this too.</p>
+        <p>Add a .simplecov_spawn.rb file to your project root</p>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-c"># .simplecov_spawn.rb</span>
+        <span class="pl-en">require</span> <span class="pl-s">'simplecov'</span> <span class="pl-c"># this will also pick up whatever config is in .simplecov</span>
+                            <span class="pl-c"># so ensure it just contains configuration, and doesn't call SimpleCov.start.</span>
+        <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">command_name</span> <span class="pl-s">'spawn'</span> <span class="pl-c"># As this is not for a test runner directly, script doesn't have a pre-defined base command_name</span>
+        <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">at_fork</span><span class="pl-kos">.</span><span class="pl-en">call</span><span class="pl-kos">(</span><span class="pl-v">Process</span><span class="pl-kos">.</span><span class="pl-en">pid</span><span class="pl-kos">)</span> <span class="pl-c"># Use the per-process setup described previously</span>
+        <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span> <span class="pl-c"># only now can we start.</span></pre></div>
+        <p>Then, instead of calling your script directly, like:</p>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-c1">PTY</span><span class="pl-kos">.</span><span class="pl-en">spawn</span><span class="pl-kos">(</span><span class="pl-s">'my_script.rb'</span><span class="pl-kos">)</span> <span class="pl-k">do</span> <span class="pl-c"># ...</span><span class="pl-k"></span></pre></div>
+        <p>Use bin/ruby to require the new .simplecov_spawn file, then your script</p>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-c1">PTY</span><span class="pl-kos">.</span><span class="pl-en">spawn</span><span class="pl-kos">(</span><span class="pl-s">'ruby -r./.simplecov_spawn my_script.rb'</span><span class="pl-kos">)</span> <span class="pl-k">do</span> <span class="pl-c"># ...</span><span class="pl-k"></span></pre></div>
+        <h2><a id="user-content-running-coverage-only-on-demand" class="anchor" aria-hidden="true" href="#running-coverage-only-on-demand"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Running coverage only on demand</h2>
+        <p>The Ruby STDLIB Coverage library that SimpleCov builds upon is <em>very</em> fast (on a ~10 min Rails test suite, the speed
+        drop was only a couple seconds for me), and therefore it's SimpleCov's policy to just generate coverage every time you
+        run your tests because it doesn't do your test speed any harm and you're always equipped with the latest and greatest
+        coverage results.</p>
+        <p>Because of this, SimpleCov has no explicit built-in mechanism to run coverage only on demand.</p>
+        <p>However, you can still accomplish this very easily by introducing an ENV variable conditional into your SimpleCov setup
+        block, like this:</p>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span> <span class="pl-k">if</span> <span class="pl-c1">ENV</span><span class="pl-kos">[</span><span class="pl-s">"COVERAGE"</span><span class="pl-kos">]</span></pre></div>
+        <p>Then, SimpleCov will only run if you execute your tests like this:</p>
+        <div class="highlight highlight-source-shell"><pre>COVERAGE=true rake <span class="pl-c1">test</span></pre></div>
+        <h2><a id="user-content-errors-and-exit-statuses" class="anchor" aria-hidden="true" href="#errors-and-exit-statuses"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Errors and exit statuses</h2>
+        <p>To aid in debugging issues, if an error is raised, SimpleCov will print a message to <code>STDERR</code>
+        with the exit status of the error, like:</p>
+        <pre><code>SimpleCov failed with exit 1
+        </code></pre>
+        <p>This <code>STDERR</code> message can be disabled with:</p>
+        <pre><code>SimpleCov.print_error_status = false
+        </code></pre>
+        <h2><a id="user-content-profiles" class="anchor" aria-hidden="true" href="#profiles"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Profiles</h2>
+        <p>By default, SimpleCov's only config assumption is that you only want coverage reports for files inside your project
+        root. To save yourself from repetitive configuration, you can use predefined blocks of configuration, called 'profiles',
+        or define your own.</p>
+        <p>You can then pass the name of the profile to be used as the first argument to SimpleCov.start. For example, simplecov
+        comes bundled with a 'rails' profile. It looks somewhat like this:</p>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">profiles</span><span class="pl-kos">.</span><span class="pl-en">define</span> <span class="pl-s">'rails'</span> <span class="pl-k">do</span>
+          <span class="pl-en">add_filter</span> <span class="pl-s">'/test/'</span>
+          <span class="pl-en">add_filter</span> <span class="pl-s">'/config/'</span>
+
+          <span class="pl-en">add_group</span> <span class="pl-s">'Controllers'</span><span class="pl-kos">,</span> <span class="pl-s">'app/controllers'</span>
+          <span class="pl-en">add_group</span> <span class="pl-s">'Models'</span><span class="pl-kos">,</span> <span class="pl-s">'app/models'</span>
+          <span class="pl-en">add_group</span> <span class="pl-s">'Helpers'</span><span class="pl-kos">,</span> <span class="pl-s">'app/helpers'</span>
+          <span class="pl-en">add_group</span> <span class="pl-s">'Libraries'</span><span class="pl-kos">,</span> <span class="pl-s">'lib'</span>
+        <span class="pl-k">end</span></pre></div>
+        <p>As you can see, it's just a SimpleCov.configure block. In your test_helper.rb, launch SimpleCov with:</p>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span> <span class="pl-s">'rails'</span></pre></div>
+        <p>or</p>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span> <span class="pl-s">'rails'</span> <span class="pl-k">do</span>
+          <span class="pl-c"># additional config here</span>
+        <span class="pl-k">end</span></pre></div>
+        <h3><a id="user-content-custom-profiles" class="anchor" aria-hidden="true" href="#custom-profiles"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Custom profiles</h3>
+        <p>You can load additional profiles with the SimpleCov.load_profile('xyz') method. This allows you to build upon an
+        existing profile and customize it so you can reuse it in unit tests and Cucumber features. For example:</p>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-c"># lib/simplecov_custom_profile.rb</span>
+        <span class="pl-en">require</span> <span class="pl-s">'simplecov'</span>
+        <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">profiles</span><span class="pl-kos">.</span><span class="pl-en">define</span> <span class="pl-s">'myprofile'</span> <span class="pl-k">do</span>
+          <span class="pl-en">load_profile</span> <span class="pl-s">'rails'</span>
+          <span class="pl-en">add_filter</span> <span class="pl-s">'vendor'</span> <span class="pl-c"># Don't include vendored stuff</span>
+        <span class="pl-k">end</span>
+
+        <span class="pl-c"># features/support/env.rb</span>
+        <span class="pl-en">require</span> <span class="pl-s">'simplecov_custom_profile'</span>
+        <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span> <span class="pl-s">'myprofile'</span>
+
+        <span class="pl-c"># test/test_helper.rb</span>
+        <span class="pl-en">require</span> <span class="pl-s">'simplecov_custom_profile'</span>
+        <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span> <span class="pl-s">'myprofile'</span></pre></div>
+        <h2><a id="user-content-customizing-exit-behaviour" class="anchor" aria-hidden="true" href="#customizing-exit-behaviour"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Customizing exit behaviour</h2>
+        <p>You can define what SimpleCov should do when your test suite finishes by customizing the at_exit hook:</p>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">at_exit</span> <span class="pl-k">do</span>
+          <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">result</span><span class="pl-kos">.</span><span class="pl-en">format!</span>
+        <span class="pl-k">end</span></pre></div>
+        <p>Above is the default behaviour. Do whatever you like instead!</p>
+        <h3><a id="user-content-minimum-coverage" class="anchor" aria-hidden="true" href="#minimum-coverage"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Minimum coverage</h3>
+        <p>You can define the minimum coverage percentage expected. SimpleCov will return non-zero if unmet.</p>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">minimum_coverage</span> <span class="pl-c1">90</span>
+        <span class="pl-c"># same as above (the default is to check line coverage)</span>
+        <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">minimum_coverage</span> <span class="pl-pds">line</span>: <span class="pl-c1">90</span>
+        <span class="pl-c"># check for a minimum line coverage of 90% and minimum 80% branch coverage</span>
+        <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">minimum_coverage</span> <span class="pl-pds">line</span>: <span class="pl-c1">90</span><span class="pl-kos">,</span> <span class="pl-pds">branch</span>: <span class="pl-c1">80</span></pre></div>
+        <h3><a id="user-content-minimum-coverage-by-file" class="anchor" aria-hidden="true" href="#minimum-coverage-by-file"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Minimum coverage by file</h3>
+        <p>You can define the minimum coverage by file percentage expected. SimpleCov will return non-zero if unmet. This is useful
+        to help ensure coverage is relatively consistent, rather than being skewed by particularly good or bad areas of the code.</p>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">minimum_coverage_by_file</span> <span class="pl-c1">80</span></pre></div>
+        <p>(not yet supported for branch coverage)</p>
+        <h3><a id="user-content-maximum-coverage-drop" class="anchor" aria-hidden="true" href="#maximum-coverage-drop"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Maximum coverage drop</h3>
+        <p>You can define the maximum coverage drop percentage at once. SimpleCov will return non-zero if exceeded.</p>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">maximum_coverage_drop</span> <span class="pl-c1">5</span></pre></div>
+        <p>(not yet supported for branch coverage)</p>
+        <h3><a id="user-content-refuse-dropping-coverage" class="anchor" aria-hidden="true" href="#refuse-dropping-coverage"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Refuse dropping coverage</h3>
+        <p>You can also entirely refuse dropping coverage between test runs:</p>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">refuse_coverage_drop</span></pre></div>
+        <p>(not yet supported for branch coverage)</p>
+        <h2><a id="user-content-using-your-own-formatter" class="anchor" aria-hidden="true" href="#using-your-own-formatter"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Using your own formatter</h2>
+        <p>You can use your own formatter with:</p>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">formatter</span> <span class="pl-c1">=</span> <span class="pl-v">SimpleCov</span>::<span class="pl-v">Formatter</span>::<span class="pl-v">HTMLFormatter</span></pre></div>
+        <p>When calling SimpleCov.result.format!, it will be invoked with SimpleCov::Formatter::YourFormatter.new.format(result),
+        "result" being an instance of SimpleCov::Result. Do whatever your wish with that!</p>
+        <h2><a id="user-content-using-multiple-formatters" class="anchor" aria-hidden="true" href="#using-multiple-formatters"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Using multiple formatters</h2>
+        <p>As of SimpleCov 0.9, you can specify multiple result formats:</p>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">formatters</span> <span class="pl-c1">=</span> <span class="pl-v">SimpleCov</span>::<span class="pl-v">Formatter</span>::<span class="pl-v">MultiFormatter</span><span class="pl-kos">.</span><span class="pl-en">new</span><span class="pl-kos">(</span><span class="pl-kos">[</span>
+          <span class="pl-v">SimpleCov</span>::<span class="pl-v">Formatter</span>::<span class="pl-v">HTMLFormatter</span><span class="pl-kos">,</span>
+          <span class="pl-v">SimpleCov</span>::<span class="pl-v">Formatter</span>::<span class="pl-v">CSVFormatter</span><span class="pl-kos">,</span>
+        <span class="pl-kos">]</span><span class="pl-kos">)</span></pre></div>
+        <h2><a id="user-content-available-formatters-editor-integrations-and-hosted-services" class="anchor" aria-hidden="true" href="#available-formatters-editor-integrations-and-hosted-services"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Available formatters, editor integrations and hosted services</h2>
+        <ul>
+        <li><a href="doc/alternate-formatters.md">Open Source formatter and integration plugins for SimpleCov</a></li>
+        <li><a href="doc/editor-integration.md">Editor Integration</a></li>
+        <li><a href="doc/commercial-services.md">Hosted (commercial) services</a></li>
+        </ul>
+        <h2><a id="user-content-ruby-version-compatibility" class="anchor" aria-hidden="true" href="#ruby-version-compatibility"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Ruby version compatibility</h2>
+        <p>SimpleCov is built in <a href="https://github.com/simplecov-ruby/simplecov/actions?query=workflow%3Astable" title="SimpleCov is built around the clock by github.com">Continuous Integration</a> on Ruby 2.5+ as well as JRuby 9.2+.</p>
+        <p>Note for JRuby =&gt; You need to pass JRUBY_OPTS="--debug" or create .jrubyrc and add debug.fullTrace=true</p>
+        <h2><a id="user-content-want-to-find-dead-code-in-production" class="anchor" aria-hidden="true" href="#want-to-find-dead-code-in-production"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Want to find dead code in production?</h2>
+        <p>Try <a href="https://github.com/danmayer/coverband">Coverband</a>.</p>
+        <h2><a id="user-content-want-to-use-spring-with-simplecov" class="anchor" aria-hidden="true" href="#want-to-use-spring-with-simplecov"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Want to use Spring with SimpleCov?</h2>
+        <p>If you're using <a href="https://github.com/rails/spring">Spring</a> to speed up test suite runs and want to run SimpleCov along
+        with them, you'll find that it often misreports coverage with the default config due to some sort of eager loading
+        issue. Don't despair!</p>
+        <p>One solution is to <a href="https://github.com/simplecov-ruby/simplecov/issues/381#issuecomment-347651728">explicitly call eager
+        load</a>
+        in your <code>test_helper.rb</code> / <code>spec_helper.rb</code> after calling <code>SimpleCov.start</code>.</p>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-en">require</span> <span class="pl-s">'simplecov'</span>
+        <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span> <span class="pl-s">'rails'</span>
+        <span class="pl-v">Rails</span><span class="pl-kos">.</span><span class="pl-en">application</span><span class="pl-kos">.</span><span class="pl-en">eager_load!</span></pre></div>
+        <p>Alternatively, you could disable Spring while running SimpleCov:</p>
+        <pre><code>DISABLE_SPRING=1 rake test
+        </code></pre>
+        <p>Or you could remove <code>gem 'spring'</code> from your <code>Gemfile</code>.</p>
+        <h2><a id="user-content-troubleshooting" class="anchor" aria-hidden="true" href="#troubleshooting"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Troubleshooting</h2>
+        <p>The <strong>most common problem is that simplecov isn't required and started before everything else</strong>. In order to track
+        coverage for your whole application <strong>simplecov needs to be the first one</strong> so that it (and the underlying coverage
+        library) can subsequently track loaded files and their usage.</p>
+        <p>If you are missing coverage for some code a simple trick is to put a puts statement in there and right after
+        <code>SimpleCov.start</code> so you can see if the file really was loaded after simplecov was started.</p>
+        <div class="highlight highlight-source-ruby"><pre><span class="pl-c"># my_code.rb</span>
+        <span class="pl-k">class</span> <span class="pl-v">MyCode</span>
+
+          <span class="pl-en">puts</span> <span class="pl-s">"MyCode is being loaded!"</span>
+
+          <span class="pl-k">def</span> <span class="pl-en">my_method</span>
+            <span class="pl-c"># ...</span>
+          <span class="pl-k">end</span>
+        <span class="pl-k">end</span>
+
+        <span class="pl-c"># spec_helper.rb/rails_helper.rb/test_helper.rb/.simplecov whatever</span>
+
+        <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span>
+        <span class="pl-en">puts</span> <span class="pl-s">"SimpleCov started successfully!"</span></pre></div>
+        <p>Now when you run your test suite and you see:</p>
+        <pre><code>SimpleCov started successfully!
+        MyCode is being loaded!
+        </code></pre>
+        <p>then it's good otherwise you likely have a problem :)</p>
+        <h2><a id="user-content-code-of-conduct" class="anchor" aria-hidden="true" href="#code-of-conduct"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Code of Conduct</h2>
+        <p>Everyone participating in this project's development, issue trackers and other channels is expected to follow our
+        <a href="./CODE_OF_CONDUCT.md">Code of Conduct</a></p>
+        <h2><a id="user-content-contributing" class="anchor" aria-hidden="true" href="#contributing"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Contributing</h2>
+        <p>See the <a href="https://github.com/simplecov-ruby/simplecov/blob/main/CONTRIBUTING.md">contributing guide</a>.</p>
+        <h2><a id="user-content-kudos" class="anchor" aria-hidden="true" href="#kudos"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Kudos</h2>
+        <p>Thanks to Aaron Patterson for the original idea for this!</p>
+        <h2><a id="user-content-copyright" class="anchor" aria-hidden="true" href="#copyright"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Copyright</h2>
+        <p>Copyright (c) 2010-2017 Christoph Olszowka. See MIT-LICENSE for details.</p>
+        </article></div>
+  recorded_at: Sun, 30 Aug 2020 20:42:44 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/github/readme/unknown.yml
+++ b/spec/cassettes/github/readme/unknown.yml
@@ -1,0 +1,75 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.github.com/repos/colszowka/nope/readme
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Authorization:
+      - bearer <GITHUB_TOKEN>
+      User-Agent:
+      - ruby-toolbox.com API client
+      Accept:
+      - application/vnd.github.v3.html
+      Connection:
+      - close
+      Host:
+      - api.github.com
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Sun, 30 Aug 2020 20:42:44 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '114'
+      Connection:
+      - close
+      Server:
+      - GitHub.com
+      Status:
+      - 404 Not Found
+      X-Oauth-Scopes:
+      - ''
+      X-Accepted-Oauth-Scopes:
+      - repo
+      X-Github-Media-Type:
+      - github.v3; param=html
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4970'
+      X-Ratelimit-Reset:
+      - '1598823521'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - 8700:5DBD:76114D6:8E4FB91:5F4C0F44
+    body:
+      encoding: UTF-8
+      string: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/reference/repos#get-a-repository-readme"}'
+  recorded_at: Sun, 30 Aug 2020 20:42:44 GMT
+recorded_with: VCR 6.0.0

--- a/spec/cassettes/rails/rails.yml
+++ b/spec/cassettes/rails/rails.yml
@@ -66,7 +66,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
   recorded_at: Wed, 05 Dec 2018 13:43:50 GMT
 - request:
     method: post
@@ -151,6 +150,175 @@ http_interactions:
       encoding: UTF-8
       string: '{"data":{"repository":{"nameWithOwner":"rails/rails","forks":{"totalCount":16273},"stargazers":{"totalCount":41549},"watchers":{"totalCount":2652},"createdAt":"2008-04-11T02:19:47Z","defaultBranchRef":{"name":"master","target":{"history":{"edges":[{"node":{"authoredDate":"2018-12-05T04:30:43Z"}},{"node":{"authoredDate":"2018-12-05T04:24:20Z"}},{"node":{"authoredDate":"2018-12-05T00:55:22Z"}},{"node":{"authoredDate":"2018-12-05T00:03:27Z"}},{"node":{"authoredDate":"2018-12-04T23:48:35Z"}},{"node":{"authoredDate":"2018-11-29T03:40:41Z"}},{"node":{"authoredDate":"2018-12-04T21:50:44Z"}},{"node":{"authoredDate":"2018-12-04T19:05:36Z"}},{"node":{"authoredDate":"2018-12-04T19:04:04Z"}},{"node":{"authoredDate":"2018-12-04T18:45:45Z"}},{"node":{"authoredDate":"2018-12-04T18:40:05Z"}},{"node":{"authoredDate":"2018-12-04T18:34:44Z"}},{"node":{"authoredDate":"2018-12-04T18:05:53Z"}},{"node":{"authoredDate":"2018-12-04T16:48:40Z"}},{"node":{"authoredDate":"2018-12-04T12:46:00Z"}},{"node":{"authoredDate":"2018-12-03T09:52:59Z"}},{"node":{"authoredDate":"2018-12-04T06:48:22Z"}},{"node":{"authoredDate":"2018-12-04T06:47:00Z"}},{"node":{"authoredDate":"2018-12-04T05:33:31Z"}},{"node":{"authoredDate":"2018-12-03T22:24:29Z"}},{"node":{"authoredDate":"2018-12-04T00:40:46Z"}},{"node":{"authoredDate":"2018-12-03T16:02:18Z"}},{"node":{"authoredDate":"2018-12-03T15:47:50Z"}},{"node":{"authoredDate":"2018-12-03T11:41:13Z"}},{"node":{"authoredDate":"2018-12-03T08:58:10Z"}},{"node":{"authoredDate":"2018-12-03T10:57:27Z"}},{"node":{"authoredDate":"2018-12-02T20:50:00Z"}},{"node":{"authoredDate":"2018-12-03T09:12:14Z"}},{"node":{"authoredDate":"2018-12-03T02:39:54Z"}},{"node":{"authoredDate":"2018-12-03T02:13:39Z"}},{"node":{"authoredDate":"2018-12-03T01:16:02Z"}},{"node":{"authoredDate":"2018-12-03T00:36:01Z"}},{"node":{"authoredDate":"2018-12-02T23:29:57Z"}},{"node":{"authoredDate":"2018-12-02T20:01:28Z"}},{"node":{"authoredDate":"2018-12-02T19:50:05Z"}},{"node":{"authoredDate":"2018-12-02T19:47:36Z"}},{"node":{"authoredDate":"2018-12-01T19:59:16Z"}},{"node":{"authoredDate":"2018-12-02T17:10:03Z"}},{"node":{"authoredDate":"2018-12-01T22:48:24Z"}},{"node":{"authoredDate":"2018-12-01T21:25:02Z"}},{"node":{"authoredDate":"2018-12-01T17:47:54Z"}},{"node":{"authoredDate":"2018-12-01T09:06:52Z"}},{"node":{"authoredDate":"2018-12-01T08:44:28Z"}},{"node":{"authoredDate":"2018-12-01T06:18:32Z"}},{"node":{"authoredDate":"2018-12-01T00:12:55Z"}},{"node":{"authoredDate":"2018-11-30T22:37:00Z"}},{"node":{"authoredDate":"2018-11-30T18:40:27Z"}},{"node":{"authoredDate":"2018-11-30T18:17:33Z"}},{"node":{"authoredDate":"2018-11-30T16:42:44Z"}},{"node":{"authoredDate":"2018-11-30T16:39:12Z"}}]}}},"description":"Ruby
         on Rails","hasIssuesEnabled":true,"hasWikiEnabled":false,"homepageUrl":"https://rubyonrails.org","isArchived":false,"isFork":false,"isMirror":false,"licenseInfo":{"key":"mit"},"primaryLanguage":{"name":"Ruby"},"pushedAt":"2018-12-05T13:18:39Z","closedIssues":{"totalCount":11757},"openIssues":{"totalCount":329},"closedPullRequests":{"totalCount":7023},"openPullRequests":{"totalCount":686},"mergedPullRequests":{"totalCount":14730},"repositoryTopics":{"nodes":[{"topic":{"name":"rails"}},{"topic":{"name":"mvc"}},{"topic":{"name":"html"}},{"topic":{"name":"activerecord"}},{"topic":{"name":"activejob"}},{"topic":{"name":"ruby"}},{"topic":{"name":"framework"}}]},"codeOfConduct":{"name":"Other","url":"https://github.com/rails/rails/blob/master/CODE_OF_CONDUCT.md"}},"rateLimit":{"limit":5000,"cost":1,"remaining":1205,"resetAt":"2018-12-05T13:55:34Z"}}}'
-    http_version: 
   recorded_at: Wed, 05 Dec 2018 13:43:52 GMT
-recorded_with: VCR 4.0.0
+- request:
+    method: get
+    uri: https://api.github.com/repos/rails/rails/readme
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Authorization:
+      - bearer <GITHUB_TOKEN>
+      User-Agent:
+      - ruby-toolbox.com API client
+      Accept:
+      - application/vnd.github.v3.html
+      Connection:
+      - close
+      Host:
+      - api.github.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 30 Aug 2020 21:08:30 GMT
+      Content-Type:
+      - application/vnd.github.v3.html; charset=utf-8
+      Content-Length:
+      - '12610'
+      Connection:
+      - close
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding
+      - Accept-Encoding, Accept, X-Requested-With
+      Etag:
+      - '"7151ed3021cfe8ec2cdb0f16765c127a"'
+      Last-Modified:
+      - Sun, 30 Aug 2020 12:58:39 GMT
+      X-Oauth-Scopes:
+      - ''
+      X-Accepted-Oauth-Scopes:
+      - ''
+      X-Github-Media-Type:
+      - github.v3; param=html
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4866'
+      X-Ratelimit-Reset:
+      - '1598823521'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type, Deprecation, Sunset
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Github-Request-Id:
+      - 87A8:3477:7494946:8D50FFB:5F4C154E
+    body:
+      encoding: UTF-8
+      string: |-
+        <div id="readme" class="md" data-path="README.md"><article class="markdown-body entry-content container-lg" itemprop="text"><h1><a id="user-content-welcome-to-rails" class="anchor" aria-hidden="true" href="#welcome-to-rails"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Welcome to Rails</h1>
+        <h2><a id="user-content-whats-rails" class="anchor" aria-hidden="true" href="#whats-rails"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>What's Rails?</h2>
+        <p>Rails is a web-application framework that includes everything needed to
+        create database-backed web applications according to the
+        <a href="https://en.wikipedia.org/wiki/Model-view-controller" rel="nofollow">Model-View-Controller (MVC)</a>
+        pattern.</p>
+        <p>Understanding the MVC pattern is key to understanding Rails. MVC divides your
+        application into three layers: Model, View, and Controller, each with a specific responsibility.</p>
+        <h2><a id="user-content-model-layer" class="anchor" aria-hidden="true" href="#model-layer"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Model layer</h2>
+        <p>The <em><strong>Model layer</strong></em> represents the domain model (such as Account, Product,
+        Person, Post, etc.) and encapsulates the business logic specific to
+        your application. In Rails, database-backed model classes are derived from
+        <code>ActiveRecord::Base</code>. <a href="activerecord/README.rdoc">Active Record</a> allows you to present the data from
+        database rows as objects and embellish these data objects with business logic
+        methods.
+        Although most Rails models are backed by a database, models can also be ordinary
+        Ruby classes, or Ruby classes that implement a set of interfaces as provided by
+        the <a href="activemodel/README.rdoc">Active Model</a> module.</p>
+        <h2><a id="user-content-controller-layer" class="anchor" aria-hidden="true" href="#controller-layer"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Controller layer</h2>
+        <p>The <em><strong>Controller layer</strong></em> is responsible for handling incoming HTTP requests and
+        providing a suitable response. Usually, this means returning HTML, but Rails controllers
+        can also generate XML, JSON, PDFs, mobile-specific views, and more. Controllers load and
+        manipulate models, and render view templates in order to generate the appropriate HTTP response.
+        In Rails, incoming requests are routed by Action Dispatch to an appropriate controller, and
+        controller classes are derived from <code>ActionController::Base</code>. Action Dispatch and Action Controller
+        are bundled together in <a href="actionpack/README.rdoc">Action Pack</a>.</p>
+        <h2><a id="user-content-view-layer" class="anchor" aria-hidden="true" href="#view-layer"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>View layer</h2>
+        <p>The <em><strong>View layer</strong></em> is composed of "templates" that are responsible for providing
+        appropriate representations of your application's resources. Templates can
+        come in a variety of formats, but most view templates are HTML with embedded
+        Ruby code (ERB files). Views are typically rendered to generate a controller response
+        or to generate the body of an email. In Rails, View generation is handled by <a href="actionview/README.rdoc">Action View</a>.</p>
+        <h2><a id="user-content-frameworks-and-libraries" class="anchor" aria-hidden="true" href="#frameworks-and-libraries"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Frameworks and libraries</h2>
+        <p><a href="activerecord/README.rdoc">Active Record</a>, <a href="activemodel/README.rdoc">Active Model</a>, <a href="actionpack/README.rdoc">Action Pack</a>, and <a href="actionview/README.rdoc">Action View</a> can each be used independently outside Rails.
+        In addition to that, Rails also comes with <a href="actionmailer/README.rdoc">Action Mailer</a>, a library
+        to generate and send emails; <a href="actionmailbox/README.md">Action Mailbox</a>, a library to receive emails within a Rails application;
+        <a href="activejob/README.md">Active Job</a>, a framework for declaring jobs and making them run on a variety of queuing
+        backends; <a href="actioncable/README.md">Action Cable</a>, a framework to
+        integrate WebSockets with a Rails application; <a href="activestorage/README.md">Active Storage</a>, a library to attach cloud
+        and local files to Rails applications; <a href="actiontext/README.md">Action Text</a>, a library to handle rich text content;
+        and <a href="activesupport/README.rdoc">Active Support</a>, a collection
+        of utility classes and standard library extensions that are useful for Rails,
+        and may also be used independently outside Rails.</p>
+        <h2><a id="user-content-getting-started" class="anchor" aria-hidden="true" href="#getting-started"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Getting Started</h2>
+        <ol>
+        <li>
+        <p>Install Rails at the command prompt if you haven't yet:</p>
+        <pre><code> $ gem install rails
+        </code></pre>
+        </li>
+        <li>
+        <p>At the command prompt, create a new Rails application:</p>
+        <pre><code> $ rails new myapp
+        </code></pre>
+        <p>where "myapp" is the application name.</p>
+        </li>
+        <li>
+        <p>Change directory to <code>myapp</code> and start the web server:</p>
+        <pre><code> $ cd myapp
+         $ bin/rails server
+        </code></pre>
+        <p>Run with <code>--help</code> or <code>-h</code> for options.</p>
+        </li>
+        <li>
+        <p>Go to <code>http://localhost:3000</code> and you'll see:
+        "Yay! You’re on Rails!"</p>
+        </li>
+        <li>
+        <p>Follow the guidelines to start developing your application. You may find
+        the following resources handy:</p>
+        <ul>
+        <li><a href="https://guides.rubyonrails.org/getting_started.html" rel="nofollow">Getting Started with Rails</a></li>
+        <li><a href="https://guides.rubyonrails.org" rel="nofollow">Ruby on Rails Guides</a></li>
+        <li><a href="https://api.rubyonrails.org" rel="nofollow">The API Documentation</a></li>
+        </ul>
+        </li>
+        </ol>
+        <h2><a id="user-content-contributing" class="anchor" aria-hidden="true" href="#contributing"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Contributing</h2>
+        <p><a href="https://www.codetriage.com/rails/rails" rel="nofollow"><img src="https://camo.githubusercontent.com/04e058bfae9e9bbed506f71739e106f703bf41bc/68747470733a2f2f7777772e636f64657472696167652e636f6d2f7261696c732f7261696c732f6261646765732f75736572732e737667" alt="Code Triage Badge" data-canonical-src="https://www.codetriage.com/rails/rails/badges/users.svg" style="max-width:100%;"></a></p>
+        <p>We encourage you to contribute to Ruby on Rails! Please check out the
+        <a href="https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html" rel="nofollow">Contributing to Ruby on Rails guide</a> for guidelines about how to proceed. <a href="https://contributors.rubyonrails.org" rel="nofollow">Join us!</a></p>
+        <p>Trying to report a possible security vulnerability in Rails? Please
+        check out our <a href="https://rubyonrails.org/security/" rel="nofollow">security policy</a> for
+        guidelines about how to proceed.</p>
+        <p>Everyone interacting in Rails and its sub-projects' codebases, issue trackers, chat rooms, and mailing lists is expected to follow the Rails <a href="https://rubyonrails.org/conduct/" rel="nofollow">code of conduct</a>.</p>
+        <h2><a id="user-content-code-status" class="anchor" aria-hidden="true" href="#code-status"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Code Status</h2>
+        <p><a href="https://buildkite.com/rails/rails" rel="nofollow"><img src="https://camo.githubusercontent.com/3bf8e396f8d45a3ead95ff55e0ca1f1c14040211/68747470733a2f2f62616467652e6275696c646b6974652e636f6d2f61623131353262366131663661363164336561346563356233656563653864346332623833303939383435396337353335322e7376673f6272616e63683d6d6173746572" alt="Build Status" data-canonical-src="https://badge.buildkite.com/ab1152b6a1f6a61d3ea4ec5b3eece8d4c2b830998459c75352.svg?branch=master" style="max-width:100%;"></a></p>
+        <h2><a id="user-content-license" class="anchor" aria-hidden="true" href="#license"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>License</h2>
+        <p>Ruby on Rails is released under the <a href="https://opensource.org/licenses/MIT" rel="nofollow">MIT License</a>.</p>
+        </article></div>
+  recorded_at: Sun, 30 Aug 2020 21:08:31 GMT
+recorded_with: VCR 6.0.0

--- a/spec/integration/github_client_spec.rb
+++ b/spec/integration/github_client_spec.rb
@@ -5,75 +5,110 @@ require "rails_helper"
 RSpec.describe GithubClient, :real_http do
   let(:client) { described_class.new }
 
-  describe "for existing repo", vcr: { cassette_name: "graphql/rails" } do
-    let(:expected_attributes) do
-      {
-        archived?:                   false,
-        average_recent_committed_at: a_value > Time.utc(2018, 3, 1),
-        closed_issues_count:         a_value > 10_000,
-        closed_pull_requests_count:  a_value > 6000,
-        code_of_conduct_name:        "Other",
-        code_of_conduct_url:         "https://github.com/rails/rails/blob/master/CODE_OF_CONDUCT.md",
-        created_at:                  Time.zone.parse("2008-04-11T02:19:47Z"),
-        default_branch:              "master",
-        description:                 "Ruby on Rails",
-        fork?:                       false,
-        forks_count:                 a_value > 10_000,
-        homepage_url:                "https://rubyonrails.org",
-        issues?:                     true,
-        license:                     "mit",
-        merged_pull_requests_count:  a_value > 13_000,
-        mirror?:                     false,
-        open_issues_count:           a_value > 10,
-        open_pull_requests_count:    a_value > 50,
-        total_pull_requests_count:   a_value > 100,
-        path:                        "rails/rails",
-        primary_language:            "Ruby",
-        pushed_at:                   a_value >= Time.zone.parse("2018-03-12T19:56:09Z"),
-        stargazers_count:            a_value > 35_000,
-        topics:                      %w[rails mvc html activerecord activejob ruby framework].sort,
-        watchers_count:              a_value > 2500,
-        wiki?:                       false,
-      }
+  describe "#fetch_repository" do
+    describe "for existing repo", vcr: { cassette_name: "graphql/rails" } do
+      let(:expected_attributes) do
+        {
+          archived?:                   false,
+          average_recent_committed_at: a_value > Time.utc(2018, 3, 1),
+          closed_issues_count:         a_value > 10_000,
+          closed_pull_requests_count:  a_value > 6000,
+          code_of_conduct_name:        "Other",
+          code_of_conduct_url:         "https://github.com/rails/rails/blob/master/CODE_OF_CONDUCT.md",
+          created_at:                  Time.zone.parse("2008-04-11T02:19:47Z"),
+          default_branch:              "master",
+          description:                 "Ruby on Rails",
+          fork?:                       false,
+          forks_count:                 a_value > 10_000,
+          homepage_url:                "https://rubyonrails.org",
+          issues?:                     true,
+          license:                     "mit",
+          merged_pull_requests_count:  a_value > 13_000,
+          mirror?:                     false,
+          open_issues_count:           a_value > 10,
+          open_pull_requests_count:    a_value > 50,
+          total_pull_requests_count:   a_value > 100,
+          path:                        "rails/rails",
+          primary_language:            "Ruby",
+          pushed_at:                   a_value >= Time.zone.parse("2018-03-12T19:56:09Z"),
+          stargazers_count:            a_value > 35_000,
+          topics:                      %w[rails mvc html activerecord activejob ruby framework].sort,
+          watchers_count:              a_value > 2500,
+          wiki?:                       false,
+        }
+      end
+
+      it "can fetch a whole bunch of data about the repository in question" do
+        expect(client.fetch_repository("rails/rails")).to have_attributes(expected_attributes)
+      end
     end
 
-    it "can fetch a whole bunch of data about the repository in question" do
-      expect(client.fetch_repository("rails/rails")).to have_attributes(expected_attributes)
+    describe "for invalid reference to an org", vcr: { cassette_name: "github/org_reference" } do
+      it "raises a GithubClient::UnknownRepoError" do
+        expect { client.fetch_repository("orgs/acdcorp") }.to raise_error(
+          GithubClient::UnknownRepoError, /NOT_FOUND/
+        )
+      end
+    end
+
+    describe "for unknown repo", vcr: { cassette_name: "graphql/fails" } do
+      it "raises a GithubClient::UnknownRepoError" do
+        expect { client.fetch_repository("thisverylikely/fails") }.to raise_error(
+          GithubClient::UnknownRepoError, /NOT_FOUND/
+        )
+      end
+    end
+
+    describe "for empty repo", vcr: { cassette_name: "graphql/empty" } do
+      it "successfully fetches the repo" do
+        expected_attributes = {
+          pushed_at: nil,
+        }
+        expect(client.fetch_repository("therabidbanana/eventbright")).to have_attributes(expected_attributes)
+      end
+    end
+
+    # This is currently not possible with Github's GraphQL API :(
+    # https://platform.github.community/t/repository-redirects-in-api-v4-graphql/4417
+    #
+    describe "for a moved repo", vcr: { cassette_name: "jnicklas/carrierwave" } do
+      it "resolves to the real repository path" do
+        response = client.fetch_repository "jnicklas/carrierwave"
+        expect(response.path).to be == "carrierwaveuploader/carrierwave"
+      end
     end
   end
 
-  describe "for invalid reference to an org", vcr: { cassette_name: "github/org_reference" } do
-    it "raises a GithubClient::UnknownRepoError" do
-      expect { client.fetch_repository("orgs/acdcorp") }.to raise_error(
-        GithubClient::UnknownRepoError, /NOT_FOUND/
-      )
+  describe "#fetch_readme" do
+    shared_examples_for "a readme response" do |path|
+      it "returns html content and etag wrapped in a ReadmeData object" do
+        expect(client.fetch_readme(path))
+          .to be_a(described_class::ReadmeData)
+          .and have_attributes(
+            html: kind_of(String),
+            etag: /"[a-f0-9]+"/
+          )
+      end
     end
-  end
 
-  describe "for unknown repo", vcr: { cassette_name: "graphql/fails" } do
-    it "raises a GithubClient::UnknownRepoError" do
-      expect { client.fetch_repository("thisverylikely/fails") }.to raise_error(
-        GithubClient::UnknownRepoError, /NOT_FOUND/
-      )
+    describe "for existing repo", vcr: { cassette_name: "github/readme/existing" } do
+      it_behaves_like "a readme response", "rspec/rspec"
+
+      it "returns nil on etag cache hit" do
+        etag = client.fetch_readme("rspec/rspec").etag
+
+        expect(client.fetch_readme("rspec/rspec", etag: etag)).to be nil
+      end
     end
-  end
 
-  describe "for empty repo", vcr: { cassette_name: "graphql/empty" } do
-    it "successfully fetches the repo" do
-      expected_attributes = {
-        pushed_at: nil,
-      }
-      expect(client.fetch_repository("therabidbanana/eventbright")).to have_attributes(expected_attributes)
+    describe "for permanently moved repo", vcr: { cassette_name: "github/readme/moved" } do
+      it_behaves_like "a readme response", "colszowka/simplecov"
     end
-  end
 
-  # This is currently not possible with Github's GraphQL API :(
-  # https://platform.github.community/t/repository-redirects-in-api-v4-graphql/4417
-  #
-  describe "for a moved repo", vcr: { cassette_name: "jnicklas/carrierwave" } do
-    it "resolves to the real repository path" do
-      response = client.fetch_repository "jnicklas/carrierwave"
-      expect(response.path).to be == "carrierwaveuploader/carrierwave"
+    describe "for unknown repo", vcr: { cassette_name: "github/readme/unknown" } do
+      it "gracefully returns nil" do
+        expect(client.fetch_readme("colszowka/nope")).to be nil
+      end
     end
   end
 end

--- a/spec/integration/github_repo_update_spec.rb
+++ b/spec/integration/github_repo_update_spec.rb
@@ -19,6 +19,17 @@ RSpec.describe GithubRepoUpdateJob, :real_http do
           fetched_at:       be_within(5.seconds).of(Time.current)
         )
       end
+
+      it "stores the README contents" do
+        do_perform
+
+        expect(GithubRepo.find(repo_path).readme)
+          .to be_present
+          .and have_attributes(
+            html: kind_of(String),
+            etag: kind_of(String)
+          )
+      end
     end
 
     describe "which exists locally" do


### PR DESCRIPTION
This PR adds syncing of repository READMEs from Github into the toolbox database. 

Since fetching that via graphql is highly limited when compared to the [v3 api for this](https://docs.github.com/en/rest/reference/repos#get-a-repository-readme) (most notably no automatic default branch + default readme filename detection on generic request) this uses the regular REST API

The READMEs get persisted into a dedicated db table since they can get quite big and for the majority of views there is no need to send this data over the wire from postgres to the app and put it into ruby objects just to toss it away immediately again.

Display will be added later, with this added the syncing of the data can already get going in the background.