### PR TITLE
Fix accidental removal of stored readme on cache hit

### DIFF
--- a/app/jobs/github_repo_update_job.rb
+++ b/app/jobs/github_repo_update_job.rb
@@ -84,7 +84,7 @@ class GithubRepoUpdateJob < ApplicationJob
     nil
   end
 
-  def update_readme_for_repo(repo)
+  def update_readme_for_repo(repo) # rubocop:disable Metrics/MethodLength
     readme = client.fetch_readme repo.path, etag: repo.readme_etag
 
     if readme
@@ -95,6 +95,8 @@ class GithubRepoUpdateJob < ApplicationJob
     else
       Github::Readme.where(path: repo.path).destroy_all
     end
+  rescue GithubClient::CacheHit
+    Rails.logger.info "Hit cache for #{repo.path} README, nothing to do"
   end
 
   def trigger_project_updates(project_permalinks)

--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -4,6 +4,7 @@ class GithubClient
   class InvalidResponse < StandardError; end
   class InvalidResponseStatus < StandardError; end
   class UnknownRepoError < StandardError; end
+  class CacheHit < StandardError; end
 
   # Object for holding readme API data responses
   ReadmeData = Struct.new(:html, :etag)
@@ -39,8 +40,9 @@ class GithubClient
       "If-None-Match" => etag
     ).follow.get("https://api.github.com/repos/#{path}/readme")
 
-    # Ignore cache hits and missing readmes
-    return if [304, 404].include? response.status
+    raise CacheHit if response.status == 304
+    # Ignore missing readmes
+    return if response.status == 404
 
     ensure_success! response.status
 

--- a/spec/integration/github_client_spec.rb
+++ b/spec/integration/github_client_spec.rb
@@ -94,10 +94,10 @@ RSpec.describe GithubClient, :real_http do
     describe "for existing repo", vcr: { cassette_name: "github/readme/existing" } do
       it_behaves_like "a readme response", "rspec/rspec"
 
-      it "returns nil on etag cache hit" do
+      it "raises CacheHit on etag cache hit" do
         etag = client.fetch_readme("rspec/rspec").etag
 
-        expect(client.fetch_readme("rspec/rspec", etag: etag)).to be nil
+        expect { client.fetch_readme("rspec/rspec", etag: etag) }.to raise_error(described_class::CacheHit)
       end
     end
 

--- a/spec/jobs/github_repo_update_job_spec.rb
+++ b/spec/jobs/github_repo_update_job_spec.rb
@@ -117,6 +117,19 @@ RSpec.describe GithubRepoUpdateJob, type: :job do
         expect { do_perform }.to change { Github::Readme.find_by(path: repo_path) }.to(nil)
       end
     end
+
+    describe "when cache is hit" do
+      before do
+        allow(faked_github_client).to receive(:fetch_readme).and_raise GithubClient::CacheHit
+      end
+
+      it "keeps around existing readme record" do
+        do_perform
+        readme = Github::Readme.create! path: repo_path, html: "123", etag: "123"
+
+        expect { do_perform }.not_to change { Github::Readme.find_by(path: repo_path) }.from(readme)
+      end
+    end
   end
 end
 # rubocop:enable RSpec/MultipleMemoizedHelpers


### PR DESCRIPTION
Followup to #731 noticed while doing some checkups before publishing #769 - turns out since 404 and 304 cache hit were both returning `nil` when a readme was stored fine but didn't change until next sync it was removed accidentally again from the database :facepalm: 

This should fix that. Not very proud about the use of exceptions for control flow here, but after evaluating a bit my options honestly I could not be bothered coming up with something more elegant right now, iet's just get it back to full function for now...