### PR TITLE
Add syntax highlighting for readme code blocks

### DIFF
--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -54,6 +54,8 @@ $navbar-breakpoint: $widescreen
 @import "bulma-tooltip/dist/css/bulma-tooltip"
 @import "components/**/*"
 
+@import "github-syntax-light/lib/github-light.css"
+
 .border-bottom
   border-bottom: 1px solid $light
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "bulma": "^0.7.0",
     "bulma-tooltip": "^2.0.2",
     "chart.js": "^2.7.3",
+    "github-syntax-light": "^0.5.0",
     "headroom.js": "^0.9.4",
     "javascript-autocomplete": "^1.0.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1056,6 +1056,11 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
+github-syntax-light@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/github-syntax-light/-/github-syntax-light-0.5.0.tgz#17466fdd3c08d756ce3f016ed18a2a1343ce0729"
+  integrity sha1-F0Zv3TwI11bOPwFu0YoqE0POByk=
+
 glob-parent@^5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"


### PR DESCRIPTION
Followup to #731, this adds syntax highlighting to code blocks in README display:

![Screenshot from 2020-10-30 17-28-00](https://user-images.githubusercontent.com/13972/97731497-7c422d00-1ad5-11eb-9f24-bbb55792b623.png)

The code blocks fall out of GitHub's api properly wrapped in highlight classes, however the actual css schema seems to from some custom / internal highlighter called "prettylights", see https://github.com/github/pages-gem/issues/160 and uses it's own css classes that are not compatible with common CSS classes from rouge or pygments. Luckily I found [this](https://github.com/primer/github-syntax-light) helpful npm package that ships the neccessary CSS classes, so things look a bit nicer now