### PR TITLE
Fix chrome scroll jump issue

### DIFF
--- a/app/assets/stylesheets/components/readme.sass
+++ b/app/assets/stylesheets/components/readme.sass
@@ -1,13 +1,14 @@
 .readme
   .label
     @extend .column, .is-full, .is-2-widescreen
-    span
+    div
       @extend .is-size-5
       position: sticky
       top: 90px
       padding-bottom: 12px
       border-bottom: 3px solid $primary
       margin-bottom: 24px
+      display: inline-block
 
     i.fa
       @extend .has-text-grey-light

--- a/app/views/components/project/_readme.html.slim
+++ b/app/views/components/project/_readme.html.slim
@@ -1,7 +1,7 @@
 - if readme
   section.readme.section: .container: .columns.is-multiline
     .label
-      span
+      div
         i.fa.fa-book &nbsp;
         strong Project Readme
 


### PR DESCRIPTION
Fixes scroll jump issue in chrome when viewing readme and hovering sponsor logo #757

This is very weird. Doesn't happen on firefox. Change from span to div fixed it. I actually tried to reproduce this in an isolated codepen, but no idea. It definetely has to do with the sticky positioning of the "Project Readme" label, if I take that out it goes away. Maybe it has to do with the headroom-js-driven hiding main nav bar together. Regardless, with a div it works fine so ¯\_(ツ)_/¯