### PR TITLE
Add integration with MeiliSearch

### DIFF
--- a/app/jobs/project_search_index_job.rb
+++ b/app/jobs/project_search_index_job.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class ProjectSearchIndexJob < ApplicationJob
+  private attr_accessor :project, :client
+
+  # Converts given project records into documents suitable for
+  # the search index. This takes arbitrary sets of projects
+  # to aid with bulk imports too.
+  def self.index_payload(*projects)
+    projects.map do |project|
+      {
+        # Some gem names fail to work as IDs on meilisearch,
+        # so we construct a reliable one
+        id:          Digest::SHA256.hexdigest(project.permalink),
+        permalink:   project.permalink,
+        description: project.description,
+        score:       project.score,
+      }
+    end
+  end
+
+  delegate :index_payload, to: :class
+
+  def perform(permalink)
+    self.client = MeiliSearch.client
+    return unless client
+
+    self.project = Project.includes_associations.find permalink
+    return unless project.score
+
+    client.store_documents :projects, index_payload(project)
+  end
+end

--- a/app/jobs/project_update_job.rb
+++ b/app/jobs/project_update_job.rb
@@ -34,6 +34,7 @@ class ProjectUpdateJob < ApplicationJob
       project.description = project.rubygem_description || project.github_repo_description
       project.save!
       ProjectScoreJob.perform_async permalink
+      ProjectSearchIndexJob.perform_async permalink
       enqueue_github_repo_sync project.github_repo_path
     end
   end

--- a/app/services/meili_search.rb
+++ b/app/services/meili_search.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+#
+# A simple HTTP client for interacting with [MeiliSearch](https://www.meilisearch.com/)
+#
+class MeiliSearch
+  class UnknownResponseStatus < StandardError
+    def initialize(response)
+      super "Received unexpected response status #{response.status}"
+    end
+  end
+
+  attr_accessor :http
+  private :http=
+
+  def initialize(url: ENV["MEILI_SEARCH_URL"])
+    self.http = prepare_http_client URI.parse(url)
+  end
+
+  def ranking_rules(index)
+    settings(index).fetch("rankingRules")
+  end
+
+  def searchable_attributes(index)
+    settings(index).fetch("searchableAttributes")
+  end
+
+  def store_documents(index, documents)
+    queue_index_update index, :documents, documents
+  end
+
+  def update_ranking_rules(index, rules)
+    queue_index_update index, "settings/ranking-rules", rules
+  end
+
+  def update_searchable_attributes(index, attributes)
+    queue_index_update index, "settings/searchable-attributes", attributes
+  end
+
+  private
+
+  def settings(index)
+    response = http.get "/indexes/#{index}/settings"
+    raise UnknownResponseStatus, response unless response.status == 200
+
+    Oj.load response.body
+  end
+
+  def prepare_http_client(uri)
+    client = HTTP
+             .persistent("#{uri.scheme}://#{uri.host}")
+             .timeout(connect: 2.seconds, write: 2.seconds, read: 2.seconds)
+
+    if [uri.user, uri.password].any?
+      client.basic_auth user: uri.user, pass: uri.password
+    else
+      client
+    end
+  end
+
+  def queue_index_update(index, path, data)
+    response = http.post "/indexes/#{index}/#{path}", json: data
+    response.body.to_s
+    raise UnknownResponseStatus, response unless response.status == 202
+
+    true
+  end
+end

--- a/app/services/meili_search.rb
+++ b/app/services/meili_search.rb
@@ -10,10 +10,20 @@ class MeiliSearch
     end
   end
 
+  #
+  # Returns an instance configured from MEILI_SEARCH_URL
+  # environment variable, or nil if that is not set.
+  #
+  def self.client
+    return if ENV["MEILI_SEARCH_URL"].blank?
+
+    new url: ENV["MEILI_SEARCH_URL"].presence
+  end
+
   attr_accessor :http
   private :http=
 
-  def initialize(url: ENV["MEILI_SEARCH_URL"])
+  def initialize(url:)
     self.http = prepare_http_client URI.parse(url)
   end
 

--- a/app/services/meili_search.rb
+++ b/app/services/meili_search.rb
@@ -35,6 +35,10 @@ class MeiliSearch
     settings(index).fetch("searchableAttributes")
   end
 
+  def displayed_attributes(index)
+    settings(index).fetch("displayedAttributes")
+  end
+
   def store_documents(index, documents)
     queue_index_update index, :documents, documents
   end
@@ -45,6 +49,10 @@ class MeiliSearch
 
   def update_searchable_attributes(index, attributes)
     queue_index_update index, "settings/searchable-attributes", attributes
+  end
+
+  def update_displayed_attributes(index, attributes)
+    queue_index_update index, "settings/displayed-attributes", attributes
   end
 
   private

--- a/spec/jobs/project_search_index_job_spec.rb
+++ b/spec/jobs/project_search_index_job_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ProjectSearchIndexJob, type: :job do
+  let(:job) do
+    described_class.new
+  end
+
+  let(:project) { Factories.project "example_gem", description: "Hello World" }
+
+  let(:client) do
+    instance_double MeiliSearch
+  end
+
+  before do
+    allow(MeiliSearch).to receive(:client).and_return(client)
+  end
+
+  describe "#perform" do
+    it "sends project data to the search index" do
+      expect(client).to receive(:store_documents)
+        .with(:projects, [
+                {
+                  id:          Digest::SHA256.hexdigest(project.permalink),
+                  permalink:   project.permalink,
+                  description: project.description,
+                  score:       project.score,
+                },
+              ])
+
+      job.perform project.permalink
+    end
+
+    it "does not send data if the project has no score" do
+      expect(client).not_to receive(:store_documents)
+      project.update! score: nil
+
+      job.perform project.permalink
+    end
+
+    it "does not send data if the client is not configured" do
+      allow(MeiliSearch).to receive(:client).and_return(nil)
+
+      job.perform project.permalink
+    end
+  end
+end

--- a/spec/jobs/project_update_job_spec.rb
+++ b/spec/jobs/project_update_job_spec.rb
@@ -25,9 +25,11 @@ RSpec.describe ProjectUpdateJob, type: :job do
       expect { do_perform }.to change { project.reload.rubygem }.from(nil).to(rubygem)
     end
 
-    it "enqueues a ProjectScoreJob" do
-      expect(ProjectScoreJob).to receive(:perform_async).with(permalink)
-      do_perform
+    [ProjectScoreJob, ProjectSearchIndexJob].each do |job_type|
+      it "enqueues a #{job_type}" do
+        expect(job_type).to receive(:perform_async).with(permalink)
+        do_perform
+      end
     end
 
     describe "github repo detection" do

--- a/spec/services/meili_search_spec.rb
+++ b/spec/services/meili_search_spec.rb
@@ -7,6 +7,38 @@ RSpec.describe MeiliSearch, type: :service do
     described_class.new(url: "https://example.com")
   end
 
+  describe ".client" do
+    around do |example|
+      original_value = ENV["MEILI_SEARCH_URL"]
+      ENV["MEILI_SEARCH_URL"] = configured_url
+      example.run
+    ensure
+      ENV["MEILI_SEARCH_URL"] = original_value
+    end
+
+    describe "when MEILI_SEARCH_URL is not configured" do
+      let(:configured_url) { nil }
+
+      it "returns nil" do
+        expect(described_class.client).to be nil
+      end
+    end
+
+    describe "when MEILI_SEARCH_URL is configured" do
+      let(:configured_url) { "https://search.ruby-toolbox.com" }
+
+      it "returns client instance configured with the URL" do
+        the_instance = instance_double described_class
+
+        allow(described_class).to receive(:new)
+          .with(url: configured_url)
+          .and_return(the_instance)
+
+        expect(described_class.client).to be the_instance
+      end
+    end
+  end
+
   describe "initialize" do
     it "configures HTTP client for basic_auth when configured" do
       search = described_class.new(url: "https://foo:bar@example.com")

--- a/spec/services/meili_search_spec.rb
+++ b/spec/services/meili_search_spec.rb
@@ -66,6 +66,7 @@ RSpec.describe MeiliSearch, type: :service do
         .to_return(status: 200, body: {
           rankingRules:         %w[hello world],
           searchableAttributes: %w[foo bar],
+          displayedAttributes:  %w[one two],
         }.to_json)
     end
 
@@ -75,6 +76,10 @@ RSpec.describe MeiliSearch, type: :service do
 
     it "returns searchable attributes as reported by server" do
       expect(search.searchable_attributes("my_index")).to be == %w[foo bar]
+    end
+
+    it "returns displayed attributes as reported by server" do
+      expect(search.displayed_attributes("my_index")).to be == %w[one two]
     end
   end
 
@@ -111,4 +116,8 @@ RSpec.describe MeiliSearch, type: :service do
   it_behaves_like "queued index update",
                   :update_ranking_rules,
                   "settings/ranking-rules"
+
+  it_behaves_like "queued index update",
+                  :update_displayed_attributes,
+                  "settings/displayed-attributes"
 end

--- a/spec/services/meili_search_spec.rb
+++ b/spec/services/meili_search_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe MeiliSearch, type: :service do
+  let(:search) do
+    described_class.new(url: "https://example.com")
+  end
+
+  describe "initialize" do
+    it "configures HTTP client for basic_auth when configured" do
+      search = described_class.new(url: "https://foo:bar@example.com")
+
+      authorization = search.http.default_options.headers["Authorization"]
+      expect(authorization).to be == "Basic Zm9vOmJhcg=="
+    end
+
+    it "skips basic_auth when not configured" do
+      search = described_class.new(url: "https://example.com")
+
+      expect(search.http.default_options.headers.keys).to be_empty
+    end
+
+    it "configures persistent connection for host and scheme" do
+      search = described_class.new(url: "https://example.com")
+
+      expect(search.http.default_options.persistent).to be == "https://example.com"
+    end
+  end
+
+  describe "index settings" do
+    before do
+      stub_request(:get, "https://example.com/indexes/my_index/settings")
+        .to_return(status: 200, body: {
+          rankingRules:         %w[hello world],
+          searchableAttributes: %w[foo bar],
+        }.to_json)
+    end
+
+    it "returns ranking rules as reported by server" do
+      expect(search.ranking_rules("my_index")).to be == %w[hello world]
+    end
+
+    it "returns searchable attributes as reported by server" do
+      expect(search.searchable_attributes("my_index")).to be == %w[foo bar]
+    end
+  end
+
+  shared_examples_for "queued index update" do |method_name, path|
+    describe "##{method_name}" do
+      it "queues updated #{path} for given index" do
+        stub_request(:post, "https://example.com/indexes/my_index/#{path}")
+          .with(
+            body: %w[foo bar baz].to_json
+          )
+          .to_return(status: 202)
+
+        expect(search.public_send(method_name, :my_index, %w[foo bar baz])).to be true
+      end
+
+      it "raises an UnknownResponseStatus exception when an error occurs" do
+        stub_request(:post, "https://example.com/indexes/my_index/#{path}")
+          .to_return(status: 500)
+
+        expect { search.public_send(method_name, :my_index, %w[foo bar baz]) }
+          .to raise_error(described_class::UnknownResponseStatus, /unexpected response status 500/)
+      end
+    end
+  end
+
+  it_behaves_like "queued index update",
+                  :store_documents,
+                  "documents"
+
+  it_behaves_like "queued index update",
+                  :update_searchable_attributes,
+                  "settings/searchable-attributes"
+
+  it_behaves_like "queued index update",
+                  :update_ranking_rules,
+                  "settings/ranking-rules"
+end


### PR DESCRIPTION
The current search on the site is rather slow and I'm currently in the process of speeding it up by converting the search indexing to [MeiliSearch](https://www.meilisearch.com/). I've done some initial prototyping on this recently and the results using that for the search and then fetching the resulting projects from Postgres looked very promising, and this code is the beginning of porting the prototype code into actually converting this over.