### PR TITLE
Allow to actually search against new search index

### DIFF
--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -49,7 +49,7 @@ class Search
     # class properly as pg search itself gets removed from the codebase.
     #
     if order.sql == Project::Order::PG_SEARCH_RANK_DIRECTION.sql
-      mapped = permalinks.map { "'#{_1}'" }.join(",")
+      mapped = permalinks.map { Project.connection.quote _1 }.join(",")
       Arel.sql("array_position(ARRAY[#{mapped}], projects.permalink::text)")
     else
       order.sql

--- a/app/services/meili_search.rb
+++ b/app/services/meili_search.rb
@@ -27,6 +27,13 @@ class MeiliSearch
     self.http = prepare_http_client URI.parse(url)
   end
 
+  def search(index, query)
+    response = http.post "/indexes/#{index}/search", json: { q: query, limit: 1000 }
+    raise UnknownResponseStatus, response unless response.status == 200
+
+    Oj.load(response).fetch("hits").map { _1.fetch("permalink") }
+  end
+
   def ranking_rules(index)
     settings(index).fetch("rankingRules")
   end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,37 +1,6 @@
 {
   "ignored_warnings": [
     {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 2,
-      "fingerprint": "23cd32092623ef25b4bb35fcbbf1b909627100d506bef0b6bde96192ffc1afae",
-      "check_name": "CrossSiteScripting",
-      "message": "Unescaped model attribute",
-      "file": "app/views/blog/show.html.slim",
-      "line": 18,
-      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "Blog.new(:root => Rails.root.join(\"app\", \"blog_posts\"), :cache => Rails.env.production?).find(params[:id]).body_html",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "BlogController",
-          "method": "show",
-          "line": 16,
-          "file": "app/controllers/blog_controller.rb",
-          "rendered": {
-            "name": "blog/show",
-            "file": "app/views/blog/show.html.slim"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "blog/show"
-      },
-      "user_input": null,
-      "confidence": "High",
-      "note": "The content injected unescaped here is from markdown blog posts hosted in the repo itself"
-    },
-    {
       "warning_type": "SQL Injection",
       "warning_code": 0,
       "fingerprint": "3b30c684464ba27e92f7cfaddc9fb2e37ed5d1f0be6e8d7e3adf5ed48b4cf537",
@@ -49,6 +18,26 @@
       },
       "user_input": "date",
       "confidence": "Medium",
+      "note": ""
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "5064a7c6abdc26594864aa9e12af582c0d859b3c6222624bd22ed7f3d893eeb1",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/models/search.rb",
+      "line": 53,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "Arel.sql(\"array_position(ARRAY[#{permalinks.map do\n Project.connection.quote(_1)\n end.join(\",\")}], projects.permalink::text)\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Search",
+        "method": "meili_order_sql"
+      },
+      "user_input": "Project.connection.quote(_1)",
+      "confidence": "High",
       "note": ""
     },
     {
@@ -112,6 +101,6 @@
       "note": "It's shielded by categories in the db, not random user input"
     }
   ],
-  "updated": "2020-09-29 21:00:22 +0200",
-  "brakeman_version": "4.9.1"
+  "updated": "2021-02-27 22:30:21 +0100",
+  "brakeman_version": "5.0.0"
 }

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -72,7 +72,20 @@ RSpec.describe Search, type: :model do
         ]
         Factories.project("not-returned")
 
-        expect(described_class.new("hello world").projects).to be == expected
+        expect(described_class.new("hello world").projects.to_a).to be == expected
+      end
+
+      it "respects custom order when given" do
+        expected = [
+          Factories.project("project", score: 40),
+          Factories.project("world", score: 30),
+          Factories.project("hello", score: 20),
+        ]
+        Factories.project("not-returned")
+
+        order = Project::Order.new order: "score", directions: Project::Order::SEARCH_DIRECTIONS
+
+        expect(described_class.new("hello world", order: order).projects.to_a).to be == expected
       end
     end
   end

--- a/spec/services/meili_search_spec.rb
+++ b/spec/services/meili_search_spec.rb
@@ -120,4 +120,26 @@ RSpec.describe MeiliSearch, type: :service do
   it_behaves_like "queued index update",
                   :update_displayed_attributes,
                   "settings/displayed-attributes"
+
+  describe "#search" do
+    before do
+      stub_request(:post, "https://example.com/indexes/my_index/search")
+        .with(
+          body: { q: "my query", limit: 1000 }.to_json
+        )
+        .to_return(
+          status: 200,
+          body:   {
+            hits: [
+              { permalink: "one" },
+              { permalink: "two" },
+            ],
+          }.to_json
+        )
+    end
+
+    it "returns matching permalinks for given index and query" do
+      expect(search.search(:my_index, "my query")).to be == %w[one two]
+    end
+  end
 end


### PR DESCRIPTION
This is a followup to #831 which adds logic to perform project search queries against the external MeiliSearch index instead of using Postgres search. 

When results are received in the shape of permalinks from the search index, subsequently the corresponding projects are fetched once again from postgres, which in my tests was much much quicker.

As I'm still experimenting with this and I'd like to verify that my prior performance tests actually hold true this ships this feature behind a feature flag to enable some additional testing of this before I then hopefully move on to fully replace the existing search code with this (and throwing in some additional specs and refactoring the not-yet-optimal order query stuff)