### PR TITLE
Scope performance fix when bugfix forks are included

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -33,7 +33,7 @@ class Project < ApplicationRecord
   scope :with_score, -> { where.not(score: nil) }
 
   def self.with_bugfix_forks(include_forks)
-    include_forks ? self : where(is_bugfix_fork: false)
+    include_forks ? all : where(is_bugfix_fork: false)
   end
 
   def self.for_display(forks: false)


### PR DESCRIPTION
Followup to https://github.com/rubytoolbox/rubytoolbox/pull/845#issuecomment-787196925, the previous code led to all things on the scope being loaded when using pagination, instead of only the current page