### PR TITLE
Prevent date drift in UI snapshots for visual regression tests

### DIFF
--- a/app/views/pages/components/landing_hero.html.slim
+++ b/app/views/pages/components/landing_hero.html.slim
@@ -20,10 +20,11 @@
       strong Recent News
 
     ul
+      - base = Date.new(2021, 3, 1)
       - 3.times do |i|
         li
           a href="#"
-            span.date= l (i+1).days.ago.to_date, format: :long
+            span.date= l (base - i.days), format: :long
             | &nbsp;
             strong Some Title
 

--- a/spec/jobs/rubygem_downloads_persistence_job_spec.rb
+++ b/spec/jobs/rubygem_downloads_persistence_job_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe RubygemDownloadsPersistenceJob, type: :job do
 
     it "is false on other days of the week" do
       # Any weekday other than sunday this week
-      date = (Time.zone.today.beginning_of_week(:monday)..Time.zone.today.end_of_week(:sunday)).to_a.sample
+      date = (Time.zone.today.beginning_of_week(:monday)...Time.zone.today.end_of_week(:sunday)).to_a.sample
       Timecop.freeze date do
         expect(job.should_run?).to be false
       end

--- a/spec/jobs/rubygem_trends_job_spec.rb
+++ b/spec/jobs/rubygem_trends_job_spec.rb
@@ -25,9 +25,10 @@ RSpec.describe RubygemTrendsJob, type: :job do
     # It's not perfect this way but at least all of the trends logic is
     # in a single place
     it "persists entries for trending projects" do
-      Factories.project "a"
-      Factories.project "b"
-      Factories.project "c"
+      # Make sure we have a recent release, otherwise it will be ignored
+      %w[a b c].each do |name|
+        Factories.project(name)
+      end
 
       Factories.rubygem_download_stat "a", date: 8.weeks.ago, total_downloads: 10_000
       Factories.rubygem_download_stat "a", date: 4.weeks.ago, total_downloads: 30_000

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -25,7 +25,7 @@ module Factories
                       description: description
     end
 
-    def rubygem(name, downloads: 5000, first_release: 1.year.ago, latest_release: 3.months.ago)
+    def rubygem(name, downloads: 5000, first_release: Date.new(2018, 2, 28), latest_release: Date.new(2021, 1, 2))
       Rubygem.create!(
         name:              name,
         current_version:   "1.0",


### PR DESCRIPTION
We get visual regression checks from Percy on CI runs, which is nice. However, since some of the dates used in the underlying specs that make the screenshots were dynamic every single CI run needed manual approval. This should hopefully resolve that and also not introduce any other issues either :)