### PR TITLE
Sync gem dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -112,6 +112,7 @@ group :test do
   gem "feedjira"
 
   gem "db-query-matchers"
+  gem "shoulda-matchers"
 
   gem "retriable"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -365,6 +365,8 @@ GEM
     semantic_range (2.3.1)
     sexp_processor (4.15.1)
     shellany (0.0.1)
+    shoulda-matchers (4.5.1)
+      activesupport (>= 4.2.0)
     sidekiq (6.1.3)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
@@ -494,6 +496,7 @@ DEPENDENCIES
   sanitize
   sass-rails (~> 5.0)
   selenium-webdriver
+  shoulda-matchers
   sidekiq
   simplecov
   slim-rails

--- a/app/jobs/rubygem_update_job.rb
+++ b/app/jobs/rubygem_update_job.rb
@@ -88,9 +88,8 @@ class RubygemUpdateJob < ApplicationJob
   def sync_dependencies!
     return unless info["dependencies"]
 
-    known = []
-    info["dependencies"].each do |type, dependencies|
-      known += dependencies.map do
+    known = info["dependencies"].flat_map do |type, dependencies|
+      dependencies.map do
         sync_dependency! dependency_name: _1.fetch("name"),
                          type:            type,
                          requirements:    _1.fetch("requirements")

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -23,9 +23,18 @@ class Rubygem < ApplicationRecord
            inverse_of:  :rubygem,
            dependent:   :destroy
 
-  has_many :rubygem_dependencies, -> { order(dependency_name: :asc) },
+  has_many :rubygem_dependencies,
+           -> { order(dependency_name: :asc) },
            foreign_key: :rubygem_name,
-           inverse_of:  :rubygem
+           inverse_of:  :rubygem,
+           dependent:   :destroy
+
+  has_many :reverse_dependencies,
+           -> { order(rubygem_name: :asc) },
+           class_name:  "RubygemDependency",
+           foreign_key: :dependency_name,
+           inverse_of:  :dependency,
+           dependent:   :destroy
 
   def self.update_batch
     where("updated_at < ? ", 24.hours.ago.utc)

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -23,6 +23,10 @@ class Rubygem < ApplicationRecord
            inverse_of:  :rubygem,
            dependent:   :destroy
 
+  has_many :rubygem_dependencies, -> { order(dependency_name: :asc) },
+           foreign_key: :rubygem_name,
+           inverse_of:  :rubygem
+
   def self.update_batch
     where("updated_at < ? ", 24.hours.ago.utc)
       .order(updated_at: :asc)

--- a/app/models/rubygem_dependency.rb
+++ b/app/models/rubygem_dependency.rb
@@ -8,7 +8,11 @@ class RubygemDependency < ApplicationRecord
   belongs_to :rubygem,
              foreign_key: :rubygem_name,
              inverse_of:  :rubygem_dependencies
-  belongs_to :dependency, class_name: "Rubygem", optional: true
+  belongs_to :dependency,
+             class_name:  "Rubygem",
+             foreign_key: :dependency_name,
+             inverse_of:  :reverse_dependencies,
+             optional:    true
 
   validates :type, inclusion: { in: TYPES }
 

--- a/app/models/rubygem_dependency.rb
+++ b/app/models/rubygem_dependency.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class RubygemDependency < ApplicationRecord
+  self.inheritance_column = nil
+
+  TYPES = %w[runtime development].freeze
+
+  belongs_to :rubygem,
+             foreign_key: :rubygem_name,
+             inverse_of:  :rubygem_dependencies
+  belongs_to :dependency, class_name: "Rubygem", optional: true
+
+  validates :type, inclusion: { in: TYPES }
+
+  TYPES.each do |type|
+    scope type, -> { where(type: type) }
+  end
+end

--- a/db/migrate/20210228234343_create_rubygem_dependencies.rb
+++ b/db/migrate/20210228234343_create_rubygem_dependencies.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CreateRubygemDependencies < ActiveRecord::Migration[6.1]
+  def change
+    create_table :rubygem_dependencies do |t|
+      t.string :rubygem_name, null: false
+      t.foreign_key :rubygems, column: :rubygem_name, primary_key: :name
+
+      t.string :dependency_name, null: false
+
+      t.string :type, null: false
+      t.string :requirements
+
+      t.timestamps
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -10,20 +10,6 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
--- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
-
-
---
--- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
-
-
---
 -- Name: citext; Type: EXTENSION; Schema: -; Owner: -
 --
 
@@ -302,6 +288,40 @@ CREATE TABLE public.projects (
 
 
 --
+-- Name: rubygem_dependencies; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.rubygem_dependencies (
+    id bigint NOT NULL,
+    rubygem_name character varying NOT NULL,
+    dependency_name character varying NOT NULL,
+    type character varying NOT NULL,
+    requirements character varying,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: rubygem_dependencies_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.rubygem_dependencies_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: rubygem_dependencies_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.rubygem_dependencies_id_seq OWNED BY public.rubygem_dependencies.id;
+
+
+--
 -- Name: rubygem_download_stats; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -415,6 +435,13 @@ ALTER TABLE ONLY public.categorizations ALTER COLUMN id SET DEFAULT nextval('pub
 
 
 --
+-- Name: rubygem_dependencies id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.rubygem_dependencies ALTER COLUMN id SET DEFAULT nextval('public.rubygem_dependencies_id_seq'::regclass);
+
+
+--
 -- Name: rubygem_download_stats id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -442,6 +469,14 @@ ALTER TABLE ONLY public.ar_internal_metadata
 
 ALTER TABLE ONLY public.categorizations
     ADD CONSTRAINT categorizations_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: rubygem_dependencies rubygem_dependencies_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.rubygem_dependencies
+    ADD CONSTRAINT rubygem_dependencies_pkey PRIMARY KEY (id);
 
 
 --
@@ -731,6 +766,14 @@ ALTER TABLE ONLY public.categories
 
 
 --
+-- Name: rubygem_dependencies fk_rails_7b157253c8; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.rubygem_dependencies
+    ADD CONSTRAINT fk_rails_7b157253c8 FOREIGN KEY (rubygem_name) REFERENCES public.rubygems(name);
+
+
+--
 -- Name: rubygem_trends fk_rails_8a29c552ee; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -808,6 +851,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190228102103'),
 ('20190508190527'),
 ('20190730194020'),
-('20200830205823');
+('20200830205823'),
+('20210228234343');
 
 

--- a/spec/models/rubygem_dependency_spec.rb
+++ b/spec/models/rubygem_dependency_spec.rb
@@ -3,5 +3,19 @@
 require "rails_helper"
 
 RSpec.describe RubygemDependency, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  subject(:model) { described_class.new }
+
+  describe "associations" do
+    it { is_expected.to belong_to(:rubygem) }
+
+    it "belongs to dependency optionally" do
+      expect(model).to belong_to(:dependency)
+        .class_name("Rubygem")
+        .with_foreign_key(:dependency_name)
+        .optional
+        .inverse_of(:reverse_dependencies)
+    end
+  end
+
+  it { is_expected.to validate_inclusion_of(:type).in_array(described_class::TYPES) }
 end

--- a/spec/models/rubygem_dependency_spec.rb
+++ b/spec/models/rubygem_dependency_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RubygemDependency, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/rubygem_spec.rb
+++ b/spec/models/rubygem_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe Rubygem, type: :model do
   subject(:model) { described_class.new }
 
   describe "associations" do
+    it { is_expected.to have_one(:project) }
+    it { is_expected.to have_many(:download_stats).order(date: :asc) }
     it { is_expected.to have_many(:trends).order(date: :asc) }
     it { is_expected.to have_many(:rubygem_dependencies).order(dependency_name: :asc).dependent(:destroy) }
 

--- a/spec/models/rubygem_spec.rb
+++ b/spec/models/rubygem_spec.rb
@@ -3,6 +3,19 @@
 require "rails_helper"
 
 RSpec.describe Rubygem, type: :model do
+  subject(:model) { described_class.new }
+
+  describe "associations" do
+    it { is_expected.to have_many(:trends).order(date: :asc) }
+    it { is_expected.to have_many(:rubygem_dependencies).order(dependency_name: :asc).dependent(:destroy) }
+
+    it "has_many rubygem_dependencies" do
+      expect(model).to have_many(:reverse_dependencies)
+        .order(rubygem_name: :asc)
+        .dependent(:destroy)
+    end
+  end
+
   describe ".update_batch" do
     before do
       described_class.create! name: "up-to-date", downloads: 50, current_version: "1.0.0", updated_at: 23.hours.ago

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -61,6 +61,13 @@ Capybara.server = :puma, { Silent: true }
 Capybara.javascript_driver = :selenium_chrome_headless
 Capybara.javascript_driver = :selenium_chrome if ENV["CHROME_DEBUG"].present?
 
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"


### PR DESCRIPTION
This PR adds sync of rubygem dependencies (runtime and development) into the database. We used to have this on the old site, it's time to bring it back.

Display of the dependencies, ideally including health metrics indicator, will come in a followup, this is for now just about getting the data into the database.