### PR TITLE
Fix more false positives in visual regression tests

### DIFF
--- a/spec/features/category_display_spec.rb
+++ b/spec/features/category_display_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe "Categories Display", type: :feature, js: true do
   before do
     group = CategoryGroup.create! permalink: "group1", name: "Group"
     category = Category.create! permalink: "widgets", name: "Widgets", category_group: group
-    category.projects << Factories.project("acme", score: 25, downloads: 25_000, first_release: 3.years.ago)
-    category.projects << Factories.project("widget", score: 20, downloads: 50_000, first_release: 2.years.ago)
-    category.projects << Factories.project("toolkit", score: 22, downloads: 10_000, first_release: 5.years.ago)
+    category.projects << Factories.project("acme", score: 25, downloads: 25_000, first_release: Date.new(2018, 3, 1))
+    category.projects << Factories.project("widget", score: 20, downloads: 50_000, first_release: Date.new(2019, 3, 1))
+    category.projects << Factories.project("toolkit", score: 22, downloads: 10_000, first_release: Date.new(2016, 3, 1))
   end
 
   it "can display projects of a category" do

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe "Search", type: :feature, js: true do
     group = CategoryGroup.create! permalink: "group1", name: "Group"
     Category.create! permalink: "widgets", name: "Widgets", category_group: group
 
-    Factories.project "widgets", score: 50, downloads: 125_000, first_release: 3.years.ago
+    Factories.project "widgets", score: 50, downloads: 125_000, first_release: Date.new(2018, 3, 1)
     Factories.project "more widgets",
                       score:         50,
                       description:   "widgets widgets",
                       downloads:     50_000,
                       first_release: 5.years.ago
-    Factories.project "other", score: 22, downloads: 10_000, first_release: 5.years.ago
+    Factories.project "other", score: 22, downloads: 10_000, first_release: Date.new(2016, 3, 1)
   end
 
   let(:halt_form_submission_js) do

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -6,7 +6,7 @@ module Factories
     def project(name,
                 score: 25,
                 downloads: 5000,
-                first_release: 1.year.ago,
+                first_release: Date.new(2020, 3, 12),
                 description: nil)
 
       rubygem = self.rubygem name, downloads: downloads, first_release: first_release


### PR DESCRIPTION
Didn't catch all of them in https://github.com/rubytoolbox/rubytoolbox/pull/847 it seems. Again, some dynamic dates from factories led to this, i.e. see https://percy.io/rubytoolbox/rubytoolbox/builds/9650228 for the build of https://github.com/rubytoolbox/rubytoolbox/pull/855

Hopefully I managed to catch all of them now.