### PR TITLE
Bump CI version of Postgres (and update README)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,16 +69,17 @@ jobs:
     # https://docs.github.com/en/free-pro-team@latest/actions/guides/about-service-containers#creating-service-containers
     services:
       redis:
-        image: circleci/redis:latest
+        image: redis:latest
         ports:
           - 6379:6379
       postgres:
-        image: circleci/postgres:12.1-alpine-ram
+        image: postgres:13-alpine
         ports:
           - 5432:5432
         env:
           POSTGRES_USER: postgres
           POSTGRES_DB: test
+          POSTGRES_PASSWORD: secret
 
     steps:
     - uses: actions/checkout@v2
@@ -87,7 +88,7 @@ jobs:
         bundler-cache: true
     - name: Install dependencies and run RSpec
       env:
-        DATABASE_URL: "postgresql://postgres@localhost/test"
+        DATABASE_URL: "postgresql://postgres:secret@localhost/test"
         RAILS_ENV: test
         PERCY_TOKEN: ${{secrets.PERCY_TOKEN}}
       run: |

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The Ruby Toolbox is a catalog of all Rubygems that keeps track of popularity and
 
 The Ruby Toolbox depends on a few utilities which you will need to install before you begin.
 
-#### [PostgreSQL](https://www.postgresql.org/)
+#### [PostgreSQL](https://www.postgresql.org/) (Version 13)
 
 * **Linux:** Use the official postgres repositories for [Apt](https://wiki.postgresql.org/wiki/Apt) or [Yum](https://yum.postgresql.org/)
 * **Mac OS:** Use [HomeBrew](http://brewformulas.org/Postgresql) or [Postgres.app](https://postgresapp.com/)


### PR DESCRIPTION
I upgraded the production db the site runs on to postgres 13, the CI should match that. To prevent surprises for people trying to run locally I also mentioned the version on the README for good measure.