### PR TITLE
Fix more visual regression test drift

### DIFF
--- a/spec/features/comparisons_spec.rb
+++ b/spec/features/comparisons_spec.rb
@@ -4,9 +4,9 @@ require "rails_helper"
 
 RSpec.describe "Project Comparisons", type: :feature, js: true do
   before do
-    Factories.project("acme", score: 25, downloads: 25_000, first_release: 3.years.ago)
-    Factories.project("widget", score: 20, downloads: 50_000, first_release: 2.years.ago)
-    Factories.project("toolkit", score: 22, downloads: 10_000, first_release: 5.years.ago)
+    Factories.project("acme", score: 25, downloads: 25_000, first_release: Date.new(2018, 5, 6))
+    Factories.project("widget", score: 20, downloads: 50_000, first_release: Date.new(2019, 5, 6))
+    Factories.project("toolkit", score: 22, downloads: 10_000, first_release: Date.new(2016, 5, 6))
   end
 
   it "allows to compare arbitrary projects" do

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Search", type: :feature, js: true do
                       score:         50,
                       description:   "widgets widgets",
                       downloads:     50_000,
-                      first_release: 5.years.ago
+                      first_release: Date.new(2016, 3, 1)
     Factories.project "other", score: 22, downloads: 10_000, first_release: Date.new(2016, 3, 1)
   end
 


### PR DESCRIPTION
Another round of fixing moving dates in visual regression test screenshots that are being captured following https://github.com/rubytoolbox/rubytoolbox/pull/856 and https://github.com/rubytoolbox/rubytoolbox/pull/847, again it's due to some relative dates being defined (and then rendered) in the test setups. Gotta catch 'em all...