### PR TITLE
Rename github webhook receiver to correct webhook payload

### DIFF
--- a/app/controllers/webhooks/github_controller.rb
+++ b/app/controllers/webhooks/github_controller.rb
@@ -4,7 +4,7 @@ class Webhooks::GithubController < ApplicationController
   skip_before_action :verify_authenticity_token
   include GithubWebhook::Processor
 
-  def github_status(payload)
+  def github_page_build(payload)
     return unless build_deployed? payload
 
     CatalogImportJob.perform_in 30.seconds

--- a/spec/controllers/webhooks/github_controller_spec.rb
+++ b/spec/controllers/webhooks/github_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Webhooks::GithubController, type: :controller do
     let(:state) { :success }
     let(:branch) { "main" }
 
-    let(:event_name) { "status" }
+    let(:event_name) { "page_build" }
     let(:secret) { ENV.fetch("GITHUB_WEBHOOK_SECRET") }
 
     def signature


### PR DESCRIPTION
As part of some general upkeep I'm currently doing as part of https://github.com/rubytoolbox/rubytoolbox/issues/872 I noticed that the github page build notifications were no longer correctly delivered (when the catalog repo is built it's pushed to github pages, and then a webhook should notify the actual rails app to update the catalog). Somewhere along the way this must have gotten lost or misconfigured, and the actual event sent was wrong now. This should make it work again by listening to the correct event