### PR TITLE
Loosen pinned gem version constraints and bump related gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,18 +18,18 @@ gem "pg_search"
 gem "kaminari"
 
 # Use Puma as the app server
-gem "puma", "~> 3.11"
+gem "puma"
 # Use SCSS for stylesheets
-gem "sass-rails", "~> 5.0"
+gem "sass-rails"
 # Use Uglifier as compressor for JavaScript assets
-gem "uglifier", ">= 1.3.0"
+gem "uglifier"
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'mini_racer', platforms: :ruby
 
 # Heroku ruby buildpack installs yarn only when webpacker gem is detected...
 gem "webpacker", require: false
 
-gem "font-awesome-rails", ">= 4.7", github: "bokmann/font-awesome-rails", branch: "master"
+gem "font-awesome-rails"
 
 gem "addressable"
 
@@ -39,7 +39,7 @@ gem "blueprinter"
 # gem 'mini_magick', '~> 4.8'
 
 # Reduces boot times through caching; required in config/boot.rb
-gem "bootsnap", ">= 1.1.0", require: false
+gem "bootsnap", require: false
 
 gem "foreman", require: false
 
@@ -97,12 +97,12 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: %i[mri mingw x64_mingw]
   gem "pry-rails"
-  gem "rspec-rails", ">= 4.0"
+  gem "rspec-rails"
 end
 
 group :test do
   # Adds support for Capybara system testing and selenium driver
-  gem "capybara", ">= 2.15", "< 4.0"
+  gem "capybara"
   gem "launchy"
   gem "selenium-webdriver"
   # Easy installation and use of selenium webdriver browsers to run system tests
@@ -135,12 +135,12 @@ group :development do
 
   gem "pghero"
 
+  gem "listen"
   # Access an IRB console on exception pages or by using <%= console %> anywhere in the code.
-  gem "listen", ">= 3.0.5", "< 3.2"
-  gem "web-console", ">= 3.3.0"
+  gem "web-console"
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem "spring"
-  gem "spring-watcher-listen", "~> 2.0.0"
+  gem "spring-watcher-listen"
 
   gem "guard-bundler", require: false
   gem "guard-rspec", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/bokmann/font-awesome-rails.git
-  revision: 4fef48e4db3be79ce47a01480f2dab5be5d2b15e
-  branch: master
-  specs:
-    font-awesome-rails (4.7.0.7)
-      railties (>= 3.2, < 7)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -119,6 +111,8 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
+    font-awesome-rails (4.7.0.7)
+      railties (>= 3.2, < 7)
     foreman (0.87.2)
     forgery (0.8.1)
     formatador (0.2.5)
@@ -183,9 +177,9 @@ GEM
     kaminari-core (1.2.1)
     launchy (2.5.0)
       addressable (~> 2.7)
-    listen (3.0.8)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
+    listen (3.5.1)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
     lograge (0.11.2)
       actionpack (>= 4)
       activesupport (>= 4)
@@ -234,7 +228,8 @@ GEM
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (4.0.6)
-    puma (3.12.6)
+    puma (5.2.2)
+      nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
     rack-canonical-host (1.0.0)
@@ -347,17 +342,16 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.8.0)
       nokogumbo (~> 2.0)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (5.1.0)
-      railties (>= 5.2.0)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
+    sass-rails (6.0.0)
+      sassc-rails (~> 2.1, >= 2.1.1)
+    sassc (2.4.0)
+      ffi (~> 1.9)
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     sax-machine (1.3.2)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
@@ -388,7 +382,7 @@ GEM
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
-    sprockets (3.7.2)
+    sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.2)
@@ -446,16 +440,16 @@ DEPENDENCIES
   addressable
   appsignal
   blueprinter
-  bootsnap (>= 1.1.0)
+  bootsnap
   brakeman
   browser
   bundler-audit
   byebug
-  capybara (>= 2.15, < 4.0)
+  capybara
   db-query-matchers
   dotenv-rails
   feedjira
-  font-awesome-rails (>= 4.7)!
+  font-awesome-rails
   foreman
   forgery
   github_webhook
@@ -467,7 +461,7 @@ DEPENDENCIES
   http
   kaminari
   launchy
-  listen (>= 3.0.5, < 3.2)
+  listen
   lograge
   logstash-event
   oj
@@ -477,7 +471,7 @@ DEPENDENCIES
   pg_search
   pghero
   pry-rails
-  puma (~> 3.11)
+  puma
   rack-canonical-host
   rack-cors
   rack-ssl-enforcer
@@ -486,7 +480,7 @@ DEPENDENCIES
   redcarpet
   retriable
   rouge
-  rspec-rails (>= 4.0)
+  rspec-rails
   rspec-retry
   rspec_junit_formatter
   rubocop
@@ -494,21 +488,21 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec
   sanitize
-  sass-rails (~> 5.0)
+  sass-rails
   selenium-webdriver
   shoulda-matchers
   sidekiq
   simplecov
   slim-rails
   spring
-  spring-watcher-listen (~> 2.0.0)
+  spring-watcher-listen
   timecop
   truncato
   turbolinks (~> 5)
   tzinfo-data
-  uglifier (>= 1.3.0)
+  uglifier
   vcr
-  web-console (>= 3.3.0)
+  web-console
   webdrivers
   webmock
   webpacker


### PR DESCRIPTION
While going through the depfu dashboard I noticed some dependencies had upgrades available but could not be upgraded due to Gemfile version constraints. I loosened (or rather dropped) those and upgraded all the things