### PR TITLE
Add display of rubygem dependencies to projects

### DIFF
--- a/app/assets/stylesheets/components/project.sass
+++ b/app/assets/stylesheets/components/project.sass
@@ -10,6 +10,7 @@
 .metrics
   @extend .columns, .is-multiline
   display: flex
+
   strong
     @extend .is-size-5
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -2,7 +2,9 @@
 
 class ProjectsController < ApplicationController
   def show
-    @project = Project.find_for_show! params[:id]
+    @project = Project.strict_loading.find_for_show! params[:id]
     redirect_to "/projects/#{@project.permalink}" if @project.permalink != params[:id]
+
+    @dependencies = RubygemDependency.for_project @project
   end
 end

--- a/app/models/rubygem_dependency.rb
+++ b/app/models/rubygem_dependency.rb
@@ -1,9 +1,23 @@
 # frozen_string_literal: true
 
 class RubygemDependency < ApplicationRecord
+  class Collection
+    attr_reader :development, :runtime
+    private attr_writer :development, :runtime
+
+    def initialize(development:, runtime:)
+      self.development = development
+      self.runtime = runtime
+    end
+
+    def present?
+      development.any? || runtime.any?
+    end
+  end
+
   self.inheritance_column = nil
 
-  TYPES = %w[runtime development].freeze
+  TYPES = %w[development runtime].freeze
 
   belongs_to :rubygem,
              foreign_key: :rubygem_name,
@@ -12,11 +26,41 @@ class RubygemDependency < ApplicationRecord
              class_name:  "Rubygem",
              foreign_key: :dependency_name,
              inverse_of:  :reverse_dependencies,
+             # Optional because we might not know about this gem
              optional:    true
+
+  belongs_to :dependency_project,
+             class_name:  "Project",
+             optional:    true,
+             foreign_key: :dependency_name,
+             primary_key: :rubygem_name,
+             inverse_of:  false
 
   validates :type, inclusion: { in: TYPES }
 
   TYPES.each do |type|
     scope type, -> { where(type: type) }
+  end
+
+  scope :preloaded_for_health_status, lambda {
+    # We have to preload the associated records to report the health status
+    # badges alongside it in the UI
+    includes(dependency_project: %i[rubygem github_repo])
+  }
+
+  #
+  # Retrieves the sets of dependencies for the given project wrapped in
+  # a RubygemDependency::Collection with associations preloaded to
+  # easily assess project health status based on the returned data
+  #
+  def self.for_project(project)
+    return Collection.new(development: [], runtime: []) if project.rubygem_name.blank?
+
+    base_scope = where(rubygem_name: project.rubygem_name).strict_loading.preloaded_for_health_status
+
+    Collection.new(
+      development: base_scope.development,
+      runtime:     base_scope.runtime
+    )
   end
 end

--- a/app/views/projects/show.html.slim
+++ b/app/views/projects/show.html.slim
@@ -37,4 +37,26 @@
 section.section: .container: .project
   = project_metrics @project, expanded_view: true
 
+section.readme.section: .container: .columns.is-multiline
+  .label
+    div
+      i.fa.fa-link &nbsp;
+      strong Dependencies
+
+  .column
+    - RubygemDependency::TYPES.each do |type|
+      .columns: .column
+        h4.is-size-5: strong= type.humanize
+
+      .columns.is-multiline
+        - @dependencies.public_send(type).each do |dependency|
+          .column.is-one-quarter: .columns.is-mobile
+            .column
+              .dependency-name
+                = link_to project_path(dependency.dependency_project.permalink) do
+                  strong= dependency.dependency_project.permalink
+              .has-text-grey: small= "#{dependency.requirements}"
+            .column.is-narrow
+              = small_health_indicator dependency.dependency_project
+
 = project_readme @project.github_repo_readme

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -63,26 +63,6 @@
     {
       "warning_type": "Redirect",
       "warning_code": 18,
-      "fingerprint": "cda1b712fdb49d265db5723c680071fbf1e39be9485da99692e1b834bb51c035",
-      "check_name": "Redirect",
-      "message": "Possible unprotected redirect",
-      "file": "app/controllers/projects_controller.rb",
-      "line": 6,
-      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
-      "code": "redirect_to(\"/projects/#{Project.find_for_show!(params[:id]).permalink}\")",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "ProjectsController",
-        "method": "show"
-      },
-      "user_input": "Project.find_for_show!(params[:id]).permalink",
-      "confidence": "High",
-      "note": "It's shielded by projects in the db, not random user input"
-    },
-    {
-      "warning_type": "Redirect",
-      "warning_code": 18,
       "fingerprint": "d97a1e1c0d455e1c36c99d03c57ebb2864e179204eb85027acbe366f39767e40",
       "check_name": "Redirect",
       "message": "Possible unprotected redirect",
@@ -99,8 +79,28 @@
       "user_input": "Category.find_for_show!(params[:id], :order => current_order)",
       "confidence": "High",
       "note": "It's shielded by categories in the db, not random user input"
+    },
+    {
+      "warning_type": "Redirect",
+      "warning_code": 18,
+      "fingerprint": "ed22db20a4f142a7a02c42d900289a3a66370249a1e438397eefe4e18119f656",
+      "check_name": "Redirect",
+      "message": "Possible unprotected redirect",
+      "file": "app/controllers/projects_controller.rb",
+      "line": 6,
+      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
+      "code": "redirect_to(\"/projects/#{Project.strict_loading.find_for_show!(params[:id]).permalink}\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "ProjectsController",
+        "method": "show"
+      },
+      "user_input": "Project.strict_loading.find_for_show!(params[:id]).permalink",
+      "confidence": "High",
+      "note": ""
     }
   ],
-  "updated": "2021-02-27 22:30:21 +0100",
-  "brakeman_version": "5.0.0"
+  "updated": "2021-05-30 23:26:35 +0200",
+  "brakeman_version": "5.0.1"
 }

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -32,6 +32,13 @@ RSpec.describe ProjectsController, type: :controller do
         do_request
         expect(assigns(:project)).to be == project
       end
+
+      it "assigns Rubygem Dependencies" do
+        allow(Project).to receive(:find_for_show!).and_return(project)
+        allow(RubygemDependency).to receive(:for_project).with(project).and_return("the value")
+        do_request
+        expect(assigns(:dependencies)).to be == "the value"
+      end
     end
 
     describe "for known github project" do

--- a/spec/features/project_spec.rb
+++ b/spec/features/project_spec.rb
@@ -9,14 +9,14 @@ RSpec.describe "Project Display", type: :feature do
 
   it "can display Project README" do
     visit project_path(project)
-    expect(page).not_to have_selector(".readme")
+    expect(page).not_to have_selector(".readme .content")
 
     project.github_repo.create_readme! html: "<strong>some content</strong>", etag: "1234"
     visit project_path(project)
 
-    expect(page).to have_selector(".readme")
+    expect(page).to have_selector(".readme .content")
 
-    within ".readme" do
+    within ".readme .content" do
       expect(page).to have_text("some content")
     end
   end

--- a/spec/models/rubygem_dependency_spec.rb
+++ b/spec/models/rubygem_dependency_spec.rb
@@ -5,6 +5,22 @@ require "rails_helper"
 RSpec.describe RubygemDependency, type: :model do
   subject(:model) { described_class.new }
 
+  describe described_class::Collection do
+    describe "#present?" do
+      it "is true when a development dependency is there" do
+        expect(described_class.new(development: [1], runtime: [])).to be_present
+      end
+
+      it "is true when a runtime dependency is there" do
+        expect(described_class.new(development: [], runtime: [1])).to be_present
+      end
+
+      it "is false when no dependencies are reported" do
+        expect(described_class.new(development: [], runtime: [])).not_to be_present
+      end
+    end
+  end
+
   describe "associations" do
     it { is_expected.to belong_to(:rubygem) }
 
@@ -15,7 +31,51 @@ RSpec.describe RubygemDependency, type: :model do
         .optional
         .inverse_of(:reverse_dependencies)
     end
+
+    it "belongs to dependency_project" do
+      expect(model).to belong_to(:dependency_project)
+        .class_name("Project")
+        .with_foreign_key(:dependency_name)
+        .inverse_of(false)
+        .optional
+    end
   end
 
   it { is_expected.to validate_inclusion_of(:type).in_array(described_class::TYPES) }
+
+  describe ".for_project" do
+    let(:project) { instance_double Project }
+
+    it "is an empty RubygemDependency::Collection when project has no rubygem name" do
+      allow(project).to receive(:rubygem_name)
+      expect(described_class.for_project(project))
+        .to be_a(described_class::Collection)
+        .and have_attributes(development: [], runtime: [])
+    end
+
+    describe "when the project has a rubygem_name" do
+      let(:base_scope) do
+        described_class.where(rubygem_name: project.rubygem_name).preloaded_for_health_status
+      end
+
+      before do
+        allow(project).to receive(:rubygem_name).and_return(SecureRandom.hex(8))
+      end
+
+      it "is a Collection" do
+        expect(described_class.for_project(project))
+          .to be_a(described_class::Collection)
+      end
+
+      it "contains expected development dependencies query" do
+        expect(described_class.for_project(project).development.to_sql)
+          .to be == base_scope.development.to_sql
+      end
+
+      it "contains expected runtime dependencies query" do
+        expect(described_class.for_project(project).runtime.to_sql)
+          .to be == base_scope.runtime.to_sql
+      end
+    end
+  end
 end


### PR DESCRIPTION
Based upon the data we started syncing via https://github.com/rubytoolbox/rubytoolbox/pull/854 this adds display of rubygem dependencies to project details pages, including a health badge:

![Screenshot from 2021-05-30 23-08-04](https://user-images.githubusercontent.com/13972/120120367-10c05b00-c19d-11eb-8eb8-0e387b2c2abd.png)

Some followups should take place:

* This uses the layout introduced for the project README a few months ago, however it did not fully fit the use case because that one wraps the main column in a bulma `.content` block, meant for formatted / markdown content. This should be broken out into a dedicated meta thingy for this emerging layout pattern we have here with a section title on the side and the main content next to it, which should also not be named `readme` anymore (and then the change here to the readme feature spec can be rolled back properly too again :)
* Handle the no dependencies for this type case more nicely
* Add some view or feature specs for the dependencies display
* Some kind of popover when hovering the project would probably be nice
* Announcement blog post