### PR TITLE
Fallback if a gem declared as dependency doesn't exist

### DIFF
--- a/app/views/projects/show.html.slim
+++ b/app/views/projects/show.html.slim
@@ -45,18 +45,27 @@ section.readme.section: .container: .columns.is-multiline
 
   .column
     - RubygemDependency::TYPES.each do |type|
-      .columns: .column
-        h4.is-size-5: strong= type.humanize
+      - dependencies = @dependencies.public_send(type)
+      - if dependencies.present?
+        .columns: .column
+          h4.is-size-5: strong= type.humanize
 
-      .columns.is-multiline
-        - @dependencies.public_send(type).each do |dependency|
-          .column.is-one-quarter: .columns.is-mobile
-            .column
-              .dependency-name
-                = link_to project_path(dependency.dependency_project.permalink) do
-                  strong= dependency.dependency_project.permalink
-              .has-text-grey: small= "#{dependency.requirements}"
-            .column.is-narrow
-              = small_health_indicator dependency.dependency_project
+        .columns.is-multiline
+          - @dependencies.public_send(type).each do |dependency|
+            .column.is-one-quarter: .columns.is-mobile
+              .column
+                .dependency-name
+                  - if dependency.dependency_project
+                    = link_to project_path(dependency.dependency_project.permalink) do
+                      strong= dependency.dependency_project.permalink
+                  - else
+                    / This happens if a gem has all it's versions yanked (or never existed)
+                    strong= dependency.dependency_name
+                .has-text-grey: small= "#{dependency.requirements}"
+
+              - if dependency.dependency_project
+                .column.is-narrow
+                  = small_health_indicator dependency.dependency_project
+
 
 = project_readme @project.github_repo_readme


### PR DESCRIPTION
Small followup to #891 - when a gem is yanked (or never existed) yet is declared as a dependency, the view code crashed before.

This small adjustment adds a fallback to the template that ensures the dependency is still rendered:

![Screenshot from 2021-05-31 20-27-08](https://user-images.githubusercontent.com/13972/120230020-b8e22c80-c24e-11eb-97d0-048bb9007e70.png)
