### PR TITLE
Handle gracefully requests for unknown docs pages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,12 @@ class ApplicationController < ActionController::Base
   # investigation
   rescue_from ActionController::UnknownFormat do
     logger.info "Unknown path/format requested #{request.path} / #{request.format}"
-    raise ActionController::RoutingError, "Unknown path #{request.path} / format #{request.format}"
+    render_not_found
+  end
+
+  private
+
+  def render_not_found
+    render file: Rails.root.join("public", "404.html"), layout: false, status: 404
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+#
+# Controller for hosting static pages (mostly) for documentation via the HighVoltage gem
+#
+class PagesController < ApplicationController
+  include HighVoltage::StaticPage
+
+  private
+
+  # See https://github.com/thoughtbot/high_voltage/issues/23#issuecomment-245631978
+  def invalid_page
+    render_not_found
+  end
+end

--- a/config/initializers/high_voltage.rb
+++ b/config/initializers/high_voltage.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+HighVoltage.configure do |config|
+  config.routes = false
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,10 @@ Rails.application.routes.draw do
   end
 
   resources :blog, only: %i[index show], constraints: { id: /[^.]+/ }
+
+  # Routes for documentation via HighVoltage gem
+  get "/pages/*id" => "pages#show", as: :page, format: false
+
   resources :categories, only: %i[index show]
 
   resources :projects, only: %i[show], constraints: { id: Patterns::ROUTE_PATTERN }

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -16,8 +16,13 @@ RSpec.describe ApplicationController, type: :controller do
       get :index, format: :json
     end
 
-    it "raises a routing error, which will show 404 page on production" do
-      expect { do_request }.to raise_error(ActionController::RoutingError, %r{Unknown path /anonymous.json})
+    it "renders 404 page" do
+      do_request
+
+      expect(response).to have_http_status(:not_found)
+        .and have_attributes(
+          body: Rails.root.join("public", "404.html").read
+        )
     end
   end
 end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PagesController, type: :controller do
+  describe "for valid page" do
+    before do
+      get :show, params: { id: "docs/index" }
+    end
+
+    it "responds with success" do
+      expect(response).to have_http_status(:success)
+    end
+
+    it "renders expected page template" do
+      expect(response).to render_template("docs/index")
+    end
+  end
+
+  describe "for unknown page" do
+    before do
+      get :show, params: { id: "WAT" }
+    end
+
+    it "responds with 404" do
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/features/docs_spec.rb
+++ b/spec/features/docs_spec.rb
@@ -30,6 +30,12 @@ RSpec.describe "Documentation Display", type: :feature, js: true do
     end
   end
 
+  it "renders the default 404 when an unknown page is accessed", js: false do
+    visit "/pages/unknown"
+
+    expect(page).to have_text("The page you were looking for doesn't exist")
+  end
+
   private
 
   def expect_can_visit(doc_title)


### PR DESCRIPTION
Since HighVoltage raises a routing error by default and this causes a bit of noise on our Appsignal exception tracking this PR ramps up the high voltage integration to use an explicitly declared controller (instead of the implicit one) and adds an explicit rendering of 404 pages as per https://github.com/thoughtbot/high_voltage/issues/23#issuecomment-245631978