### PR TITLE
Add missing indices to rubygem dependencies table

### DIFF
--- a/db/migrate/20210531193907_add_missing_indices_to_rubygem_dependencies.rb
+++ b/db/migrate/20210531193907_add_missing_indices_to_rubygem_dependencies.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddMissingIndicesToRubygemDependencies < ActiveRecord::Migration[6.1]
+  def change
+    add_index :rubygem_dependencies, :rubygem_name
+    add_index :rubygem_dependencies, :dependency_name
+  end
+end

--- a/db/migrate/20210531194507_add_missing_index_on_projects_github_repo_path.rb
+++ b/db/migrate/20210531194507_add_missing_index_on_projects_github_repo_path.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddMissingIndexOnProjectsGithubRepoPath < ActiveRecord::Migration[6.1]
+  def change
+    add_index :projects, :github_repo_path
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -637,6 +637,20 @@ CREATE UNIQUE INDEX index_projects_on_rubygem_name ON public.projects USING btre
 
 
 --
+-- Name: index_rubygem_dependencies_on_dependency_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_rubygem_dependencies_on_dependency_name ON public.rubygem_dependencies USING btree (dependency_name);
+
+
+--
+-- Name: index_rubygem_dependencies_on_rubygem_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_rubygem_dependencies_on_rubygem_name ON public.rubygem_dependencies USING btree (rubygem_name);
+
+
+--
 -- Name: index_rubygem_download_stats_on_absolute_change_month; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -852,6 +866,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190508190527'),
 ('20190730194020'),
 ('20200830205823'),
-('20210228234343');
+('20210228234343'),
+('20210531193907');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -609,6 +609,13 @@ CREATE INDEX index_projects_on_description_tsvector ON public.projects USING gin
 
 
 --
+-- Name: index_projects_on_github_repo_path; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_projects_on_github_repo_path ON public.projects USING btree (github_repo_path);
+
+
+--
 -- Name: index_projects_on_is_bugfix_fork; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -867,6 +874,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190730194020'),
 ('20200830205823'),
 ('20210228234343'),
-('20210531193907');
+('20210531193907'),
+('20210531194507');
 
 


### PR DESCRIPTION
🔗 Follows #854 and #891

This adds missing indices on the two gem name reference columns which apparently I forgot the first time around 😊 🤦

Also adds an index on `projects.github_repo_path` because according to Heroku postgres stats we're calling this a bunch but didn't have the index in place yet.