### PR TITLE
Add fixtures

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -3,4 +3,6 @@
 SimpleCov.start :rails do
   enable_coverage :branch
   minimum_coverage line: 100, branch: 94.5 unless ENV["SKIP_COVERAGE"]
+
+  add_filter "/lib/make_fixtures.rb"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -115,6 +115,8 @@ group :test do
   gem "db-query-matchers"
   gem "shoulda-matchers"
 
+  gem "database_cleaner-active_record"
+
   gem "retriable"
 
   gem "timecop"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,10 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
+    database_cleaner-active_record (2.0.1)
+      activerecord (>= 5.a)
+      database_cleaner-core (~> 2.0.0)
+    database_cleaner-core (2.0.1)
     db-query-matchers (0.10.0)
       activesupport (>= 4.0, < 7)
       rspec (~> 3.0)
@@ -446,6 +450,7 @@ DEPENDENCIES
   bundler-audit
   byebug
   capybara
+  database_cleaner-active_record
   db-query-matchers
   dotenv-rails
   feedjira

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Yarn is used to manage frontend dependencies for the project. It can be installe
 
 1. Start postgres and redis
 1. Install the project's dependencies and prepare the database with `bin/setup`
-1. *Optional but recommended*: Import a [production database dump](https://data.ruby-toolbox.com) using `bin/pull_database`
+1. *Optional but recommended*: Import a [production database dump](https://data.ruby-toolbox.com) using `bin/pull_database`. You can also load some test data quickly by running `rake db:fixtures:load`
 1. In order to access the GitHub GraphQL API for pulling repo data, you need to [create a OAuth token as per GitHub's documentation](https://developer.github.com/v4/guides/forming-calls/#authenticating-with-graphql). No auth scopes are needed. Place the token as `GITHUB_TOKEN=yourtoken` in `.env.local` and `.env.local.test`.
 1. Run the services with `foreman start`. You can access the site at `http://localhost:5000`
 

--- a/app/jobs/remote_update_scheduler_job.rb
+++ b/app/jobs/remote_update_scheduler_job.rb
@@ -14,11 +14,11 @@ class RemoteUpdateSchedulerJob < ApplicationJob
     # anymore
     GithubRepo.without_projects.destroy_all
 
-    Rubygem.update_batch.each do |name|
+    Rubygem.update_batch.pluck(:name).each do |name|
       RubygemUpdateJob.perform_async name
     end
 
-    GithubRepo.update_batch.each do |path|
+    GithubRepo.update_batch.pluck(:path).each do |path|
       GithubRepoUpdateJob.perform_async path
     end
   end

--- a/app/models/github_repo.rb
+++ b/app/models/github_repo.rb
@@ -25,12 +25,11 @@ class GithubRepo < ApplicationRecord
            allow_nil: true,
            prefix:    :readme
 
-  def self.update_batch
-    where("updated_at < ? ", 24.hours.ago.utc)
-      .order(updated_at: :asc)
+  scope :update_batch, lambda {
+    where("fetched_at < ? ", 24.hours.ago.utc)
+      .order(fetched_at: :asc)
       .limit((count / 24.0).ceil)
-      .pluck(:path)
-  end
+  }
 
   def self.without_projects
     joins("LEFT JOIN projects ON projects.github_repo_path = github_repos.path")

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -36,12 +36,11 @@ class Rubygem < ApplicationRecord
            inverse_of:  :dependency,
            dependent:   :destroy
 
-  def self.update_batch
-    where("updated_at < ? ", 24.hours.ago.utc)
-      .order(updated_at: :asc)
+  scope :update_batch, lambda {
+    where("fetched_at < ? ", 24.hours.ago.utc)
+      .order(fetched_at: :asc)
       .limit((count / 24.0).ceil)
-      .pluck(:name)
-  end
+  }
 
   def url
     File.join "https://rubygems.org/gems", name

--- a/app/views/pages/components/project.html.slim
+++ b/app/views/pages/components/project.html.slim
@@ -3,7 +3,7 @@
     p.heading= link_to "Ruby Toolbox UI Components Styleguide", "/pages/components"
     h2= current_page.split("/").last.humanize
 
-- full = Project.find('rspec')
+- full = Project.find('simplecov')
 - github = Project.find('imathis/octopress')
 
 = component_example "Project box" do

--- a/app/views/pages/components/project.html.slim
+++ b/app/views/pages/components/project.html.slim
@@ -3,20 +3,20 @@
     p.heading= link_to "Ruby Toolbox UI Components Styleguide", "/pages/components"
     h2= current_page.split("/").last.humanize
 
-- full = Project.for_display.joins(:categories, :github_repo, :rubygem).order(score: :desc).limit(25)
-- github = Project.for_display.joins(:categories, :github_repo).order(score: :desc).where(rubygem_name: nil).limit(25).sample
+- full = Project.find('rspec')
+- github = Project.find('imathis/octopress')
 
 = component_example "Project box" do
   .notification: .content
     markdown:
       A box to display an individual project's data in an overview
 
-  = render_project full.sample
+  = render_project full
 
   .notification: .content
     markdown:
       Includes links to referenced categories when given `show_categories: true`
-  = render_project full.sample, show_categories: true
+  = render_project full, show_categories: true
 
 
 = component_example "Project links" do
@@ -24,19 +24,18 @@
     markdown:
       Display an inline list of all available links for this project
 
-  - 3.times do
-    = project_links full.sample
+  = project_links full
 
 = component_example "Project metrics" do
   .notification: .content
     markdown:
       Renders a subset of project metrics and a link to the project page by default
-  = project_metrics full.sample
+  = project_metrics full
 
   .notification: .content
     markdown:
       With `expanded_view: true`, used for full individual project display
-  = project_metrics full.sample, expanded_view: true
+  = project_metrics full, expanded_view: true
 
   - if github
     .notification: .content
@@ -48,4 +47,4 @@
 = component_example "Compact card" do
   .project-compact-cards
     - 4.times do
-      .column= render_project full.sample, compact: true
+      .column= render_project full, compact: true

--- a/app/views/pages/components/project_readme.html.slim
+++ b/app/views/pages/components/project_readme.html.slim
@@ -3,7 +3,7 @@
     p.heading= link_to "Ruby Toolbox UI Components Styleguide", "/pages/components"
     h2= current_page.split("/").last.humanize
 
-- readme = Github::Readme.new(html: "<h1>Hello World!</h1><p>Hello World</p>")
+- readme = Project.find("simplecov").github_repo_readme
 
 = component_example "Project README" do
   = project_readme readme

--- a/app/views/pages/components/project_release_history.html.slim
+++ b/app/views/pages/components/project_release_history.html.slim
@@ -3,7 +3,7 @@
     p.heading= link_to "Ruby Toolbox UI Components Styleguide", "/pages/components"
     h2= current_page.split("/").last.humanize
 
-- project = Project.find("rspec")
+- project = Project.find("simplecov")
 - data = { "2018-3" => 1, "2018-4" => 3, "2019-1" => 12 }
 
 = component_example "Quarterly release counts for a project" do

--- a/lib/make_fixtures.rb
+++ b/lib/make_fixtures.rb
@@ -13,7 +13,6 @@ PROJECTS = %w[
   bundler
   simplecov
   rubocop
-  rspec
   minitest
   imathis/octopress
 ].freeze
@@ -59,5 +58,8 @@ PROJECTS.each do |project_name|
 end
 
 RESULTS.each do |name, data|
-  Rails.root.join("spec", "fixtures", "#{name}.yml").open("w+") { _1.puts data.to_yaml }
+  Rails.root.join("spec", "fixtures", "#{name}.yml").open("w+") do
+    _1.puts "# Generated from realistic dataset using lib/make_fixtures.rb, please don't modify manually"
+    _1.puts data.to_yaml
+  end
 end

--- a/lib/make_fixtures.rb
+++ b/lib/make_fixtures.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require File.join(__dir__, "..", "config", "environment")
+
+#
+# This little script can be used to help with building new fixtures for the specs.
+# You will need to have a production database dump loaded locally so realistic data
+# to build the fixtures from is available.
+#
+
+PROJECTS = %w[
+  nokogiri
+  bundler
+  simplecov
+  rubocop
+  rspec
+  minitest
+  imathis/octopress
+].freeze
+
+EXCLUDED_COLUMNS = %w[
+  fetched_at
+  permalink_tsvector
+  description_tsvector
+  bugfix_fork_of
+  bugfix_fork_criteria
+  is_bugfix_fork
+  name_tsvector
+  description_tsvector
+].freeze
+
+def fixturify(model)
+  model.attributes.as_json.except(*EXCLUDED_COLUMNS)
+end
+
+RESULTS = Hash.new { _1[_2] = {} }
+PROJECTS.each do |project_name|
+  project = Project.find project_name
+
+  RESULTS[:projects][project_name] = fixturify project
+
+  if project.rubygem
+    RESULTS[:rubygems][project.rubygem_name] = fixturify project.rubygem
+    project.rubygem.rubygem_dependencies.each do |dependency|
+      RESULTS[:rubygem_dependencies]["#{dependency.rubygem_name}_#{dependency.dependency_name}"] = fixturify dependency
+    end
+  end
+  RESULTS[:github_repos][project.github_repo_path] = fixturify project.github_repo if project.github_repo
+
+  if project.permalink == "simplecov"
+    RESULTS[:github_readmes][project.github_repo_path] =
+      fixturify project.github_repo_readme
+  end
+
+  project.categories.each do |category|
+    RESULTS[:categories][category.permalink] = fixturify category
+    RESULTS[:category_groups][category.category_group.permalink] = fixturify category.category_group
+  end
+end
+
+RESULTS.each do |name, data|
+  Rails.root.join("spec", "fixtures", "#{name}.yml").open("w+") { _1.puts data.to_yaml }
+end

--- a/spec/blueprints/github_repo_blueprint_spec.rb
+++ b/spec/blueprints/github_repo_blueprint_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe GithubRepoBlueprint, type: :blueprint do
+  fixtures :all
+
   let(:repo) do
     GithubRepo.new path: "foo/bar"
   end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe ApplicationController, type: :controller do
+  fixtures :all
+
   controller do
     def index
       respond_to do |f|

--- a/spec/controllers/blog_controller_spec.rb
+++ b/spec/controllers/blog_controller_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe BlogController, type: :controller do
+  fixtures :all
+
   render_views
 
   let(:posts) { described_class::BLOG.posts }

--- a/spec/controllers/categories_controller_spec.rb
+++ b/spec/controllers/categories_controller_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe CategoriesController, type: :controller do
+  fixtures :all
+
   describe "GET index" do
     let(:do_request) { get :index }
 

--- a/spec/controllers/comparisons_controller_spec.rb
+++ b/spec/controllers/comparisons_controller_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe ComparisonsController, type: :controller do
+  fixtures :all
+
   before do
     Factories.project "a", score: 30, downloads: 5000
     Factories.project "b", score: 25, downloads: 40_000

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe PagesController, type: :controller do
+  fixtures :all
+
   describe "for valid page" do
     before do
       get :show, params: { id: "docs/index" }

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe ProjectsController, type: :controller do
+  fixtures :all
+
   describe "GET show" do
     describe "for unknown project" do
       let(:do_request) { get :show, params: { id: "foobar" } }

--- a/spec/controllers/searches_controller_spec.rb
+++ b/spec/controllers/searches_controller_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe SearchesController, type: :controller do
+  fixtures :all
+
   describe "GET #show" do
     def do_request(query: "foobar", order: nil, show_forks: nil, display: nil)
       get :show, params: { q: query, order: order, show_forks: show_forks, display: display }

--- a/spec/controllers/stats_spec.rb
+++ b/spec/controllers/stats_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Stats, type: :model do
+  fixtures :all
+
   let(:stats) { described_class.new }
   let(:count) { rand(20_000) }
 

--- a/spec/controllers/trends_controller_spec.rb
+++ b/spec/controllers/trends_controller_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe TrendsController, type: :controller do
+  fixtures :all
+
   render_views
 
   describe "GET index" do

--- a/spec/controllers/webhooks/github_controller_spec.rb
+++ b/spec/controllers/webhooks/github_controller_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Webhooks::GithubController, type: :controller do
+  fixtures :all
+
   describe "POST create" do
     let(:state) { :success }
     let(:branch) { "main" }

--- a/spec/controllers/welcome_controller_spec.rb
+++ b/spec/controllers/welcome_controller_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe WelcomeController, type: :controller do
+  fixtures :all
+
   render_views
 
   describe "GET home" do

--- a/spec/features/category_display_spec.rb
+++ b/spec/features/category_display_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe "Categories Display", type: :feature, js: true do
+  fixtures :all
+
   before do
     group = CategoryGroup.create! permalink: "group1", name: "Group"
     category = Category.create! permalink: "widgets", name: "Widgets", category_group: group

--- a/spec/features/comparisons_spec.rb
+++ b/spec/features/comparisons_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe "Project Comparisons", type: :feature, js: true do
+  fixtures :all
+
   before do
     Factories.project("acme", score: 25, downloads: 25_000, first_release: Date.new(2018, 5, 6))
     Factories.project("widget", score: 20, downloads: 50_000, first_release: Date.new(2019, 5, 6))

--- a/spec/features/docs_spec.rb
+++ b/spec/features/docs_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe "Documentation Display", type: :feature, js: true do
+  fixtures :all
+
   it "can display all documentation pages" do
     visit_docs
     take_snapshots! "Documentation"

--- a/spec/features/mobile_navigation_spec.rb
+++ b/spec/features/mobile_navigation_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe "Mobile Navigation", type: :feature, js: true, viewport: :mobile do
+  fixtures :all
+
   it "has a toggle-able hamburger navigation on mobile" do
     visit "/"
 

--- a/spec/features/project_spec.rb
+++ b/spec/features/project_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe "Project Display", type: :feature do
+  fixtures :all
+
   let(:project) do
     Factories.project "widgets"
   end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe "Search", type: :feature, js: true do
+  fixtures :all
+
   before do
     group = CategoryGroup.create! permalink: "group1", name: "Group"
     Category.create! permalink: "widgets", name: "Widgets", category_group: group

--- a/spec/features/sidekiq_web_spec.rb
+++ b/spec/features/sidekiq_web_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe "Sidekiq Web", type: :feature do
+  fixtures :all
+
   shared_examples_for "an unauthenticated response" do
     it "returns an empty body" do
       expect(page.body).to be_empty

--- a/spec/features/styleguide_spec.rb
+++ b/spec/features/styleguide_spec.rb
@@ -3,11 +3,9 @@
 require "rails_helper"
 
 RSpec.describe "Styleguide Display", type: :feature, js: true do
-  it "can display all pages of the styleguide" do
-    group = CategoryGroup.create! permalink: "group1", name: "Group"
-    category = Category.create! permalink: "widgets", name: "Widgets", category_group: group
-    category.projects << Factories.project("rspec", score: 25)
+  fixtures :all
 
+  it "can display all pages of the styleguide" do
     visit "/pages/components"
     expect(page).to have_text "Ruby Toolbox UI Components Styleguide".upcase
     expect(page).to have_text "Components Overview"

--- a/spec/features/trending_spec.rb
+++ b/spec/features/trending_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe "Trending Projects", type: :feature, js: true do
+  fixtures :all
+
   before do
     Factories.project "foobar"
     Factories.project "widget"

--- a/spec/fixtures/categories.yml
+++ b/spec/fixtures/categories.yml
@@ -1,0 +1,60 @@
+---
+html_parsing:
+  permalink: html_parsing
+  name: HTML parsing
+  description:
+  created_at: '2017-11-01T22:39:56.302Z'
+  updated_at: '2017-11-01T22:39:56.302Z'
+  category_group_permalink: Web_Apps_Services_Interaction
+  rank:
+dependency_management:
+  permalink: dependency_management
+  name: Dependency Management
+  description:
+  created_at: '2017-11-01T22:39:50.108Z'
+  updated_at: '2017-11-01T22:39:50.108Z'
+  category_group_permalink: Package_Dependency_Management
+  rank:
+gem_creation:
+  permalink: gem_creation
+  name: Gem Creation
+  description: Tools that aid in creating, maintaining and publishing Rubygems
+  created_at: '2017-11-01T22:39:45.888Z'
+  updated_at: '2019-01-07T13:46:25.120Z'
+  category_group_permalink: Developer_Tools
+  rank:
+code_coverage:
+  permalink: code_coverage
+  name: Code Coverage
+  description: Utilities that report which code is being run. Most commonly this is
+    used as test coverage which reports what parts of your code are not tested, but
+    there are also tools to find dead production code
+  created_at: '2018-12-16T15:43:36.171Z'
+  updated_at: '2018-12-16T15:43:36.171Z'
+  category_group_permalink: Code_Quality
+  rank:
+code_metrics:
+  permalink: code_metrics
+  name: Code Metrics
+  description: Utilities to improve code quality by reporting common code smells like
+    complexity, unsafe defaults, unused variables or stylistic inconsistencies
+  created_at: '2017-11-01T22:39:42.736Z'
+  updated_at: '2018-12-16T15:43:36.190Z'
+  category_group_permalink: Code_Quality
+  rank:
+testing_frameworks:
+  permalink: testing_frameworks
+  name: Test Frameworks
+  description: Frameworks for writing automated tests for your software
+  created_at: '2017-11-01T22:39:53.925Z'
+  updated_at: '2021-05-31T10:53:28.756Z'
+  category_group_permalink: Testing
+  rank: 4
+Blog_Engines:
+  permalink: Blog_Engines
+  name: Blog Engines
+  description:
+  created_at: '2017-11-01T22:39:43.599Z'
+  updated_at: '2017-11-01T22:39:43.599Z'
+  category_group_permalink: Content_Management_Blogging
+  rank:

--- a/spec/fixtures/categories.yml
+++ b/spec/fixtures/categories.yml
@@ -1,3 +1,4 @@
+# Generated from realistic dataset using lib/make_fixtures.rb, please don't modify manually
 ---
 html_parsing:
   permalink: html_parsing

--- a/spec/fixtures/category_groups.yml
+++ b/spec/fixtures/category_groups.yml
@@ -1,3 +1,4 @@
+# Generated from realistic dataset using lib/make_fixtures.rb, please don't modify manually
 ---
 Web_Apps_Services_Interaction:
   permalink: Web_Apps_Services_Interaction

--- a/spec/fixtures/category_groups.yml
+++ b/spec/fixtures/category_groups.yml
@@ -1,0 +1,37 @@
+---
+Web_Apps_Services_Interaction:
+  permalink: Web_Apps_Services_Interaction
+  name: Web Apps, Services & Interaction
+  description:
+  created_at: '2017-11-01T22:39:54.863Z'
+  updated_at: '2017-11-01T22:39:54.863Z'
+Package_Dependency_Management:
+  permalink: Package_Dependency_Management
+  name: Package & Dependency Management
+  description:
+  created_at: '2017-11-01T22:39:49.992Z'
+  updated_at: '2017-11-01T22:39:49.992Z'
+Developer_Tools:
+  permalink: Developer_Tools
+  name: Developer Tools
+  description:
+  created_at: '2017-11-01T22:39:44.856Z'
+  updated_at: '2017-11-01T22:39:44.856Z'
+Code_Quality:
+  permalink: Code_Quality
+  name: Code Quality
+  description:
+  created_at: '2017-11-01T22:39:42.728Z'
+  updated_at: '2017-11-01T22:39:42.728Z'
+Testing:
+  permalink: Testing
+  name: Testing
+  description:
+  created_at: '2017-11-01T22:39:52.719Z'
+  updated_at: '2017-11-01T22:39:52.719Z'
+Content_Management_Blogging:
+  permalink: Content_Management_Blogging
+  name: Content Management & Blogging
+  description:
+  created_at: '2017-11-01T22:39:43.591Z'
+  updated_at: '2017-11-01T22:39:43.591Z'

--- a/spec/fixtures/github_readmes.yml
+++ b/spec/fixtures/github_readmes.yml
@@ -1,3 +1,4 @@
+# Generated from realistic dataset using lib/make_fixtures.rb, please don't modify manually
 ---
 simplecov-ruby/simplecov:
   path: simplecov-ruby/simplecov

--- a/spec/fixtures/github_readmes.yml
+++ b/spec/fixtures/github_readmes.yml
@@ -1,0 +1,681 @@
+---
+simplecov-ruby/simplecov:
+  path: simplecov-ruby/simplecov
+  html: |-
+    <div id="readme" class="md"><article class="markdown-body entry-content container-lg"><h1>SimpleCov <a href="https://badge.fury.io/rb/simplecov" rel="nofollow"><img src="https://camo.githubusercontent.com/f7c89c24156a508194c9347b2d0847073a6bd4f280fb41c18767907391061664/68747470733a2f2f62616467652e667572792e696f2f72622f73696d706c65636f762e737667" alt="Gem Version" style="max-width:100%;"></a> <a href="https://github.com/simplecov-ruby/simplecov/actions?query=workflow%3Astable" title="SimpleCov is built around the clock by github.com"><img src="https://github.com/simplecov-ruby/simplecov/workflows/stable/badge.svg?branch=main" alt="Build Status" style="max-width:100%;"></a> <a href="https://codeclimate.com/github/simplecov-ruby/simplecov/maintainability" rel="nofollow"><img src="https://camo.githubusercontent.com/50f44caab1b05ca3d2db4b4ac345851b508fbf18cbb061c426c595b3b1f6d674/68747470733a2f2f6170692e636f6465636c696d6174652e636f6d2f76312f6261646765732f63303731643139376436313935336137653438322f6d61696e7461696e6162696c697479" alt="Maintainability" style="max-width:100%;"></a> <a href="http://inch-ci.org/github/simplecov-ruby/simplecov" rel="nofollow"><img src="https://camo.githubusercontent.com/96cf2d19902032c2f7d5f273e60b296ba6ecbd8c276c307fa2f2ab0599f075bf/687474703a2f2f696e63682d63692e6f72672f6769746875622f73696d706c65636f762d727562792f73696d706c65636f762e7376673f6272616e63683d6d61696e" alt="Inline docs" style="max-width:100%;"></a>
+    </h1>
+    <p><strong>Code coverage for Ruby</strong></p>
+    <ul>
+    <li><a href="https://github.com/simplecov-ruby/simplecov" title="Source Code @ GitHub">Source Code</a></li>
+    <li><a href="http://rubydoc.info/gems/simplecov/frames" title="RDoc API Documentation at Rubydoc.info" rel="nofollow">API documentation</a></li>
+    <li><a href="https://github.com/simplecov-ruby/simplecov/blob/main/CHANGELOG.md" title="Project Changelog">Changelog</a></li>
+    <li><a href="http://rubygems.org/gems/simplecov" title="SimpleCov @ rubygems.org" rel="nofollow">Rubygem</a></li>
+    <li><a href="https://github.com/simplecov-ruby/simplecov/actions?query=workflow%3Astable" title="SimpleCov is built around the clock by github.com">Continuous Integration</a></li>
+    </ul>
+    <p>SimpleCov is a code coverage analysis tool for Ruby. It uses <a href="https://ruby-doc.org/stdlib/libdoc/coverage/rdoc/Coverage.html" title="API doc for Ruby's Coverage library" rel="nofollow">Ruby's built-in Coverage</a> library to gather code
+    coverage data, but makes processing its results much easier by providing a clean API to filter, group, merge, format,
+    and display those results, giving you a complete code coverage suite that can be set up with just a couple lines of
+    code.
+    SimpleCov/Coverage track covered ruby code, gathering coverage for common templating solutions like erb, slim and haml is not supported.</p>
+    <p>In most cases, you'll want overall coverage results for your projects, including all types of tests, Cucumber features,
+    etc. SimpleCov automatically takes care of this by caching and merging results when generating reports, so your
+    report actually includes coverage across your test suites and thereby gives you a better picture of blank spots.</p>
+    <p>The official formatter of SimpleCov is packaged as a separate gem called <a href="https://github.com/simplecov-ruby/simplecov-html" title="SimpleCov HTML Formatter Source Code @ GitHub">simplecov-html</a>, but will be installed and
+    configured automatically when you launch SimpleCov. If you're curious, you can find it <a href="https://github.com/simplecov-ruby/simplecov-html" title="SimpleCov HTML Formatter Source Code @ GitHub">on GitHub, too</a>.</p>
+    <h2>Contact</h2>
+    <p><em>Code and Bug Reports</em></p>
+    <ul>
+    <li><a href="https://github.com/simplecov-ruby/simplecov/issues">Issue Tracker</a></li>
+    <li>See <a href="https://github.com/simplecov-ruby/simplecov/blob/main/CONTRIBUTING.md">CONTRIBUTING</a> for how to contribute along
+    with some common problems to check out before creating an issue.</li>
+    </ul>
+    <p><em>Questions, Problems, Suggestions, etc.</em></p>
+    <ul>
+    <li>
+    <a href="https://groups.google.com/forum/#!forum/simplecov" rel="nofollow">Mailing List</a> "Open mailing list for discussion and announcements
+    on Google Groups"</li>
+    </ul>
+    <h2>Getting started</h2>
+    <ol>
+    <li>
+    <p>Add SimpleCov to your <code>Gemfile</code> and <code>bundle install</code>:</p>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-en">gem</span> <span class="pl-s">'simplecov'</span><span class="pl-kos">,</span> <span class="pl-pds">require</span>: <span class="pl-c1">false</span><span class="pl-kos">,</span> <span class="pl-pds">group</span>: <span class="pl-pds">:test</span></pre></div>
+    </li>
+    <li>
+    <p>Load and launch SimpleCov <strong>at the very top</strong> of your <code>test/test_helper.rb</code>
+    (<em>or <code>spec_helper.rb</code>, <code>rails_helper</code>, cucumber <code>env.rb</code>, or whatever your preferred test
+    framework uses</em>):</p>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-en">require</span> <span class="pl-s">'simplecov'</span>
+    <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span>
+
+    <span class="pl-c"># Previous content of test helper now starts here</span></pre></div>
+    <p><strong>Note:</strong> If SimpleCov starts after your application code is already loaded
+    (via <code>require</code>), it won't be able to track your files and their coverage!
+    The <code>SimpleCov.start</code> <strong>must</strong> be issued <strong>before any of your application
+    code is required!</strong></p>
+    <p>SimpleCov must be running in the process that you want the code coverage
+    analysis to happen on. When testing a server process (e.g. a JSON API
+    endpoint) via a separate test process (e.g. when using Selenium) where you
+    want to see all code executed by the <code>rails server</code>, and not just code
+    executed in your actual test files, you need to require SimpleCov in the
+    server process. For rails for instance, you'll want to add something like this
+    to the top of <code>bin/rails</code>, but below the "shebang" line (<code>#! /usr/bin/env ruby</code>) and after config/boot is required:</p>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-k">if</span> <span class="pl-c1">ENV</span><span class="pl-kos">[</span><span class="pl-s">'RAILS_ENV'</span><span class="pl-kos">]</span> == <span class="pl-s">'test'</span>
+      <span class="pl-en">require</span> <span class="pl-s">'simplecov'</span>
+      <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span> <span class="pl-s">'rails'</span>
+      <span class="pl-en">puts</span> <span class="pl-s">"required simplecov"</span>
+    <span class="pl-k">end</span></pre></div>
+    </li>
+    <li>
+    <p>Run your full test suite to see the percent coverage that your application has.</p>
+    </li>
+    <li>
+    <p>After running your tests, open <code>coverage/index.html</code> in the browser of your choice. For example, in a Mac Terminal,
+    run the following command from your application's root directory:</p>
+    <div class="snippet-clipboard-content position-relative"><pre><code>open coverage/index.html
+    </code></pre></div>
+    <p>in a debian/ubuntu Terminal,</p>
+    <div class="snippet-clipboard-content position-relative"><pre><code>xdg-open coverage/index.html
+    </code></pre></div>
+    <p><strong>Note:</strong> <a href="https://dwheeler.com/essays/open-files-urls.html" rel="nofollow">This guide</a> can help if you're unsure which command your particular
+    operating system requires.</p>
+    </li>
+    <li>
+    <p>Add the following to your <code>.gitignore</code> file to ensure that coverage results
+    are not tracked by Git (optional):</p>
+    <div class="snippet-clipboard-content position-relative"><pre><code>echo "coverage" &gt;&gt; .gitignore
+    </code></pre></div>
+    <p>Or if you use Windows:</p>
+    <div class="snippet-clipboard-content position-relative"><pre><code>echo coverage &gt;&gt; .gitignore
+    </code></pre></div>
+    <p>If you're making a Rails application, SimpleCov comes with built-in configurations (see below for information on
+    profiles) that will get you started with groups for your Controllers, Models and Helpers. To use it, the
+    first two lines of your test_helper should be like this:</p>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-en">require</span> <span class="pl-s">'simplecov'</span>
+    <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span> <span class="pl-s">'rails'</span></pre></div>
+    </li>
+    </ol>
+    <h2>Example output</h2>
+    <p><strong>Coverage results report, fully browsable locally with sorting and much more:</strong></p>
+    <p><a rel="noopener noreferrer" href="https://cloud.githubusercontent.com/assets/137793/17071162/db6f253e-502d-11e6-9d84-e40c3d75f333.png"><img src="https://cloud.githubusercontent.com/assets/137793/17071162/db6f253e-502d-11e6-9d84-e40c3d75f333.png" alt="SimpleCov coverage report" style="max-width:100%;"></a></p>
+    <p><strong>Source file coverage details view:</strong></p>
+    <p><a rel="noopener noreferrer" href="https://cloud.githubusercontent.com/assets/137793/17071163/db6f9f0a-502d-11e6-816c-edb2c66fad8d.png"><img src="https://cloud.githubusercontent.com/assets/137793/17071163/db6f9f0a-502d-11e6-816c-edb2c66fad8d.png" alt="SimpleCov source file detail view" style="max-width:100%;"></a></p>
+    <h2>Use it with any framework!</h2>
+    <p>Similarly to the usage with Test::Unit described above, the only thing you have to do is to add the SimpleCov
+    config to the very top of your Cucumber/RSpec/whatever setup file.</p>
+    <p>Add the setup code to the <strong>top</strong> of <code>features/support/env.rb</code> (for Cucumber) or <code>spec/spec_helper.rb</code> (for RSpec).
+    Other test frameworks should work accordingly, whatever their setup file may be:</p>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-en">require</span> <span class="pl-s">'simplecov'</span>
+    <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span> <span class="pl-s">'rails'</span></pre></div>
+    <p>You could even track what kind of code your UI testers are touching if you want to go overboard with things. SimpleCov
+    does not care what kind of framework it is running in; it just looks at what code is being executed and generates a
+    report about it.</p>
+    <h3>Notes on specific frameworks and test utilities</h3>
+    <p>For some frameworks and testing tools there are quirks and problems you might want to know about if you want
+    to use SimpleCov with them. Here's an overview of the known ones:</p>
+    <table>
+      <tbody>
+    <tr>
+    <th>Framework</th>
+    <th>Notes</th>
+    <th>Issue</th>
+    </tr>
+      <tr>
+        <th>
+          parallel_tests
+        </th>
+        <td>
+          As of 0.8.0, SimpleCov should correctly recognize parallel_tests and
+          supplement your test suite names with their corresponding test env
+          numbers. SimpleCov locks the resultset cache while merging, ensuring no
+          race conditions occur when results are merged.
+        </td>
+        <td>
+          <a href="https://github.com/simplecov-ruby/simplecov/issues/64">#64</a> &amp;
+          <a href="https://github.com/simplecov-ruby/simplecov/pull/185">#185</a>
+        </td>
+      </tr>
+      <tr>
+        <th>
+          knapsack_pro
+        </th>
+        <td>
+          To make SimpleCov work with Knapsack Pro Queue Mode to split tests in parallel on CI jobs you need to provide CI node index number to the <code>SimpleCov.command_name</code> in <code>KnapsackPro::Hooks::Queue.before_queue</code> hook.
+        </td>
+        <td>
+          <a href="https://knapsackpro.com/faq/question/how-to-use-simplecov-in-queue-mode" rel="nofollow">Tip</a>
+        </td>
+      </tr>
+      <tr>
+        <th>
+          RubyMine
+        </th>
+        <td>
+          The <a href="https://www.jetbrains.com/ruby/" rel="nofollow">RubyMine IDE</a> has
+          built-in support for SimpleCov's coverage reports, though you might need
+          to explicitly set the output root using `SimpleCov.root('foo/bar/baz')`
+        </td>
+        <td>
+          <a href="https://github.com/simplecov-ruby/simplecov/issues/95">#95</a>
+        </td>
+      </tr>
+      <tr>
+        <th>
+          Spork
+        </th>
+        <td>
+          Because of how Spork works internally (using preforking), there used to
+          be trouble when using SimpleCov with it, but that has apparently been
+          resolved with a specific configuration strategy. See <a href="https://github.com/simplecov-ruby/simplecov/issues/42#issuecomment-4440284">this</a>
+          comment.
+        </td>
+        <td>
+          <a href="https://github.com/simplecov-ruby/simplecov/issues/42#issuecomment-4440284">#42</a>
+        </td>
+      </tr>
+      <tr>
+        <th>
+          Spring
+        </th>
+        <td>
+          See section below.
+        </td>
+        <td>
+          <a href="https://github.com/simplecov-ruby/simplecov/issues/381">#381</a>
+        </td>
+      </tr>
+      <tr>
+        <th>
+          Test/Unit
+        </th>
+        <td>
+          Test Unit 2 used to mess with ARGV, leading to a failure to detect the
+          test process name in SimpleCov. <code>test-unit</code> releases 2.4.3+
+          (Dec 11th, 2011) should have this problem resolved.
+        </td>
+        <td>
+          <a href="https://github.com/simplecov-ruby/simplecov/issues/45">#45</a> &amp;
+          <a href="https://github.com/test-unit/test-unit/pull/12">test-unit/test-unit#12</a>
+        </td>
+      </tr>
+    </tbody>
+    </table>
+    <h2>Configuring SimpleCov</h2>
+    <p><a href="http://rubydoc.info/gems/simplecov/SimpleCov/Configuration" title="Configuration options API documentation" rel="nofollow">Configuration</a> settings can be applied in three formats, which are completely equivalent:</p>
+    <ul>
+    <li>
+    <p>The most common way is to configure it directly in your start block:</p>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span> <span class="pl-k">do</span>
+      <span class="pl-en">some_config_option</span> <span class="pl-s">'foo'</span>
+    <span class="pl-k">end</span></pre></div>
+    </li>
+    <li>
+    <p>You can also set all configuration options directly:</p>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">some_config_option</span> <span class="pl-s">'foo'</span></pre></div>
+    </li>
+    <li>
+    <p>If you do not want to start coverage immediately after launch or want to add additional configuration later on in a
+    concise way, use:</p>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">configure</span> <span class="pl-k">do</span>
+      <span class="pl-en">some_config_option</span> <span class="pl-s">'foo'</span>
+    <span class="pl-k">end</span></pre></div>
+    </li>
+    </ul>
+    <p>Please check out the <a href="http://rubydoc.info/gems/simplecov/SimpleCov/Configuration" title="Configuration options API documentation" rel="nofollow">Configuration</a> API documentation to find out what you can customize.</p>
+    <h2>Using .simplecov for centralized config</h2>
+    <p>If you use SimpleCov to merge multiple test suite results (e.g. Test/Unit and Cucumber) into a single report, you'd
+    normally have to set up all your config options twice, once in <code>test_helper.rb</code> and once in <code>env.rb</code>.</p>
+    <p>To avoid this, you can place a file called <code>.simplecov</code> in your project root. You can then just leave the
+    <code>require 'simplecov'</code> in each test setup helper (<strong>at the top</strong>) and move the <code>SimpleCov.start</code> code with all your
+    custom config options into <code>.simplecov</code>:</p>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-c"># test/test_helper.rb</span>
+    <span class="pl-en">require</span> <span class="pl-s">'simplecov'</span>
+
+    <span class="pl-c"># features/support/env.rb</span>
+    <span class="pl-en">require</span> <span class="pl-s">'simplecov'</span>
+
+    <span class="pl-c"># .simplecov</span>
+    <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span> <span class="pl-s">'rails'</span> <span class="pl-k">do</span>
+      <span class="pl-c"># any custom configs like groups and filters can be here at a central place</span>
+    <span class="pl-k">end</span></pre></div>
+    <p>Using <code>.simplecov</code> rather than separately requiring SimpleCov multiple times is recommended if you are merging multiple
+    test frameworks like Cucumber and RSpec that rely on each other, as invoking SimpleCov multiple times can cause coverage
+    information to be lost.</p>
+    <h2>Branch coverage (ruby "~&gt; 2.5")</h2>
+    <p>Add branch coverage measurement statistics to your results. Supported in CRuby versions 2.5+.</p>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span> <span class="pl-k">do</span>
+      <span class="pl-en">enable_coverage</span> <span class="pl-pds">:branch</span>
+    <span class="pl-k">end</span></pre></div>
+    <p>Branch coverage is a feature introduced in Ruby 2.5 concerning itself with whether a
+    particular branch of a condition had been executed. Line coverage on the other hand
+    is only interested in whether a line of code has been executed.</p>
+    <p>This comes in handy for instance for one line conditionals:</p>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-en">number</span><span class="pl-kos">.</span><span class="pl-en">odd?</span> ? <span class="pl-s">"odd"</span> : <span class="pl-s">"even"</span></pre></div>
+    <p>In line coverage this line would always be marked as executed but you'd never know if both
+    conditions were met. Guard clauses have a similar story:</p>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-k">return</span> <span class="pl-k">if</span> <span class="pl-en">number</span><span class="pl-kos">.</span><span class="pl-en">odd?</span>
+
+    <span class="pl-c"># more code</span></pre></div>
+    <p>If all the code in that method was covered you'd never know if the guard clause was ever
+    triggered! With line coverage as just evaluating the condition marks it as covered.</p>
+    <p>In the HTML report the lines of code will be annotated like <code>branch_type: hit_count</code>:</p>
+    <ul>
+    <li>
+    <code>then: 2</code> - the then branch (of an <code>if</code>) was executed twice</li>
+    <li>
+    <code>else: 0</code> - the else branch (of an <code>if</code> or <code>case</code>) was never executed</li>
+    </ul>
+    <p>Not that even if you don't declare an <code>else</code> branch it will still show up in the coverage
+    reports meaning that the condition of the <code>if</code> was not hit or that no <code>when</code> of <code>case</code>
+    was hit during the test runs.</p>
+    <p><strong>Is branch coverage strictly better?</strong> No. Branch coverage really only concerns itself with
+    conditionals - meaning coverage of sequential code is of no interest to it. A file without
+    conditional logic will have no branch coverage data and SimpleCov will report 0 of 0
+    branches covered as 100% (as everything that can be covered was covered).</p>
+    <p>Hence, we recommend looking at both metrics together. Branch coverage might also be a good
+    overall metric to look at - while you might be missing only 10% of your lines that might
+    account for 50% of your branches for instance.</p>
+    <h2>Primary Coverage</h2>
+    <p>By default, the primary coverage type is <code>line</code>. To set the primary coverage to something else, use the following:</p>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-c"># or in configure SimpleCov.primary_coverage :branch</span>
+    <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span> <span class="pl-k">do</span>
+      <span class="pl-en">enable_coverage</span> <span class="pl-pds">:branch</span>
+      <span class="pl-en">primary_coverage</span> <span class="pl-pds">:branch</span>
+    <span class="pl-k">end</span></pre></div>
+    <p>Primary coverage determines what will come in first all output, and the type of coverage to check if you don't specify the type of coverage when customizing exit behavior (<code>SimpleCov.minimum_coverage 90</code>).</p>
+    <p>Note that coverage must first be enabled for non-default coverage types.</p>
+    <h2>Filters</h2>
+    <p>Filters can be used to remove selected files from your coverage data. By default, a filter is applied that removes all
+    files OUTSIDE of your project's root directory - otherwise you'd end up with billions of coverage reports for source
+    files in the gems you are using.</p>
+    <p>You can define your own to remove things like configuration files, tests or whatever you don't need in your coverage
+    report.</p>
+    <h3>Defining custom filters</h3>
+    <p>You can currently define a filter using either a String or Regexp (that will then be Regexp-matched against each source
+    file's path), a block or by passing in your own Filter class.</p>
+    <h4>String filter</h4>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span> <span class="pl-k">do</span>
+      <span class="pl-en">add_filter</span> <span class="pl-s">"/test/"</span>
+    <span class="pl-k">end</span></pre></div>
+    <p>This simple string filter will remove all files that match "/test/" in their path.</p>
+    <h4>Regex filter</h4>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span> <span class="pl-k">do</span>
+      <span class="pl-en">add_filter</span> <span class="pl-pds">%r{^/test/}</span>
+    <span class="pl-k">end</span></pre></div>
+    <p>This simple regex filter will remove all files that start with /test/ in their path.</p>
+    <h4>Block filter</h4>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span> <span class="pl-k">do</span>
+      <span class="pl-en">add_filter</span> <span class="pl-k">do</span> |<span class="pl-s1">source_file</span>|
+        <span class="pl-s1">source_file</span><span class="pl-kos">.</span><span class="pl-en">lines</span><span class="pl-kos">.</span><span class="pl-en">count</span> &lt; <span class="pl-c1">5</span>
+      <span class="pl-k">end</span>
+    <span class="pl-k">end</span></pre></div>
+    <p>Block filters receive a SimpleCov::SourceFile instance and expect your block to return either true (if the file is to be
+    removed from the result) or false (if the result should be kept). Please check out the RDoc for SimpleCov::SourceFile to
+    learn about the methods available to you. In the above example, the filter will remove all files that have less than 5
+    lines of code.</p>
+    <h4>Custom filter class</h4>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-k">class</span> <span class="pl-v">LineFilter</span> &lt; <span class="pl-v">SimpleCov</span>::<span class="pl-v">Filter</span>
+      <span class="pl-k">def</span> <span class="pl-en">matches?</span><span class="pl-kos">(</span><span class="pl-s1">source_file</span><span class="pl-kos">)</span>
+        <span class="pl-s1">source_file</span><span class="pl-kos">.</span><span class="pl-en">lines</span><span class="pl-kos">.</span><span class="pl-en">count</span> &lt; <span class="pl-en">filter_argument</span>
+      <span class="pl-k">end</span>
+    <span class="pl-k">end</span>
+
+    <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">add_filter</span> <span class="pl-v">LineFilter</span><span class="pl-kos">.</span><span class="pl-en">new</span><span class="pl-kos">(</span><span class="pl-c1">5</span><span class="pl-kos">)</span></pre></div>
+    <p>Defining your own filters is pretty easy: Just inherit from SimpleCov::Filter and define a method
+    'matches?(source_file)'. When running the filter, a true return value from this method will result in the removal of the
+    given source_file. The filter_argument method is being set in the SimpleCov::Filter initialize method and thus is set to
+    5 in this example.</p>
+    <h4>Array filter</h4>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span> <span class="pl-k">do</span>
+      <span class="pl-s1">proc</span> <span class="pl-c1">=</span> <span class="pl-v">Proc</span><span class="pl-kos">.</span><span class="pl-en">new</span> <span class="pl-kos">{</span> |<span class="pl-s1">source_file</span>| <span class="pl-c1">false</span> <span class="pl-kos">}</span>
+      <span class="pl-en">add_filter</span> <span class="pl-kos">[</span><span class="pl-s">"string"</span><span class="pl-kos">,</span> <span class="pl-pds">/regex/</span><span class="pl-kos">,</span> <span class="pl-s1">proc</span><span class="pl-kos">,</span> <span class="pl-v">LineFilter</span><span class="pl-kos">.</span><span class="pl-en">new</span><span class="pl-kos">(</span><span class="pl-c1">5</span><span class="pl-kos">)</span><span class="pl-kos">]</span>
+    <span class="pl-k">end</span></pre></div>
+    <p>You can pass in an array containing any of the other filter types.</p>
+    <h4>Ignoring/skipping code</h4>
+    <p>You can exclude code from the coverage report by wrapping it in <code># :nocov:</code>.</p>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-c"># :nocov:</span>
+    <span class="pl-k">def</span> <span class="pl-en">skip_this_method</span>
+      <span class="pl-en">never_reached</span>
+    <span class="pl-k">end</span>
+    <span class="pl-c"># :nocov:</span></pre></div>
+    <p>The name of the token can be changed to your liking. <a href="https://github.com/simplecov-ruby/simplecov/blob/main/features/config_nocov_token.feature">Learn more about the nocov feature.</a></p>
+    <p><strong>Note:</strong> You shouldn't have to use the nocov token to skip private methods that are being included in your coverage. If
+    you appropriately test the public interface of your classes and objects you should automatically get full coverage of
+    your private methods.</p>
+    <h2>Default root filter and coverage for things outside of it</h2>
+    <p>By default, SimpleCov filters everything outside of the <code>SimpleCov.root</code> directory. However, sometimes you may want
+    to include coverage reports for things you include as a gem, for example a Rails Engine.</p>
+    <p>Here's an example by <a href="https://github.com/lsaffie">@lsaffie</a> from <a href="https://github.com/simplecov-ruby/simplecov/issues/221">#221</a>
+    that shows how you can achieve just that:</p>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span> <span class="pl-pds">:rails</span> <span class="pl-k">do</span>
+      <span class="pl-en">filters</span><span class="pl-kos">.</span><span class="pl-en">clear</span> <span class="pl-c"># This will remove the :root_filter and :bundler_filter that come via simplecov's defaults</span>
+      <span class="pl-en">add_filter</span> <span class="pl-k">do</span> |<span class="pl-s1">src</span>|
+        !<span class="pl-kos">(</span><span class="pl-s1">src</span><span class="pl-kos">.</span><span class="pl-en">filename</span> =~ <span class="pl-pds">/^<span class="pl-s1"><span class="pl-kos">#{</span><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">root</span><span class="pl-kos">}</span></span>/</span><span class="pl-kos">)</span> <span class="pl-k">unless</span> <span class="pl-s1">src</span><span class="pl-kos">.</span><span class="pl-en">filename</span> =~ <span class="pl-pds">/my_engine/</span>
+      <span class="pl-k">end</span>
+    <span class="pl-k">end</span></pre></div>
+    <h2>Groups</h2>
+    <p>You can separate your source files into groups. For example, in a Rails app, you'll want to have separate listings for
+    Models, Controllers, Helpers, and Libs. Group definition works similarly to Filters (and also accepts custom
+    filter classes), but source files end up in a group when the filter passes (returns true), as opposed to filtering
+    results, which exclude files from results when the filter results in a true value.</p>
+    <p>Add your groups with:</p>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span> <span class="pl-k">do</span>
+      <span class="pl-en">add_group</span> <span class="pl-s">"Models"</span><span class="pl-kos">,</span> <span class="pl-s">"app/models"</span>
+      <span class="pl-en">add_group</span> <span class="pl-s">"Controllers"</span><span class="pl-kos">,</span> <span class="pl-s">"app/controllers"</span>
+      <span class="pl-en">add_group</span> <span class="pl-s">"Long files"</span> <span class="pl-k">do</span> |<span class="pl-s1">src_file</span>|
+        <span class="pl-s1">src_file</span><span class="pl-kos">.</span><span class="pl-en">lines</span><span class="pl-kos">.</span><span class="pl-en">count</span> &gt; <span class="pl-c1">100</span>
+      <span class="pl-k">end</span>
+      <span class="pl-en">add_group</span> <span class="pl-s">"Multiple Files"</span><span class="pl-kos">,</span> <span class="pl-kos">[</span><span class="pl-s">"app/models"</span><span class="pl-kos">,</span> <span class="pl-s">"app/controllers"</span><span class="pl-kos">]</span> <span class="pl-c"># You can also pass in an array</span>
+      <span class="pl-en">add_group</span> <span class="pl-s">"Short files"</span><span class="pl-kos">,</span> <span class="pl-v">LineFilter</span><span class="pl-kos">.</span><span class="pl-en">new</span><span class="pl-kos">(</span><span class="pl-c1">5</span><span class="pl-kos">)</span> <span class="pl-c"># Using the LineFilter class defined in Filters section above</span>
+    <span class="pl-k">end</span></pre></div>
+    <h2>Merging results</h2>
+    <p>You normally want to have your coverage analyzed across ALL of your test suites, right?</p>
+    <p>Simplecov automatically caches coverage results in your
+    (coverage_path)/.resultset.json, and will merge or override those with
+    subsequent runs, depending on whether simplecov considers those subsequent runs
+    as different test suites or as the same test suite as the cached results. To
+    make this distinction, simplecov has the concept of "test suite names".</p>
+    <h3>Test suite names</h3>
+    <p>SimpleCov tries to guess the name of the currently running test suite based upon the shell command the tests
+    are running on. This should work fine for Unit Tests, RSpec, and Cucumber. If it fails, it will use the shell
+    command that invoked the test suite as a command name.</p>
+    <p>If you have some non-standard setup and still want nicely labeled test suites, you have to give Simplecov a
+    cue as to what the name of the currently running test suite is. You can do so by specifying
+    <code>SimpleCov.command_name</code> in one test file that is part of your specific suite.</p>
+    <p>To customize the suite names on a Rails app (yeah, sorry for being Rails-biased, but everyone knows what
+    the structure of those projects is. You can apply this accordingly to the RSpecs in your
+    Outlook-WebDAV-Calendar-Sync gem), you could do something like this:</p>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-c"># test/unit/some_test.rb</span>
+    <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">command_name</span> <span class="pl-s">'test:units'</span>
+
+    <span class="pl-c"># test/functionals/some_controller_test.rb</span>
+    <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">command_name</span> <span class="pl-s">"test:functionals"</span>
+
+    <span class="pl-c"># test/integration/some_integration_test.rb</span>
+    <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">command_name</span> <span class="pl-s">"test:integration"</span>
+
+    <span class="pl-c"># features/support/env.rb</span>
+    <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">command_name</span> <span class="pl-s">"features"</span></pre></div>
+    <p>Note that this only has to be invoked ONCE PER TEST SUITE, so even if you have 200 unit test files,
+    specifying it in <code>some_test.rb</code> is enough.</p>
+    <p>Last but not least <strong>if multiple suites resolve to the same <code>command_name</code></strong> be aware that the coverage results <strong>will
+    clobber each other instead of being merged</strong>.  SimpleCov is smart enough to detect unique names for the most common
+    setups, but if you have more than one test suite that doesn't follow a common pattern then you will want to manually
+    ensure that each suite gets a unique <code>command_name</code>.</p>
+    <p>If you are running tests in parallel each process has the potential to clobber results from the other test processes.
+    If you are relying on the default <code>command_name</code> then SimpleCov will attempt to detect and avoid parallel test suite
+    <code>command_name</code> collisions based on the presence of <code>ENV['PARALLEL_TEST_GROUPS']</code> and <code>ENV['TEST_ENV_NUMBER']</code>.  If your
+    parallel test runner does not set one or both of these then <em>you must</em> set a <code>command_name</code> and ensure that it is unique
+    per process (eg. <code>command_name "Unit Tests PID #{$$}"</code>).</p>
+    <p>If you are using parallel_tests, you must incorporate <code>TEST_ENV_NUMBER</code> into the command name yourself, in
+    order for SimpleCov to merge the results correctly. For example:</p>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-c"># spec/spec_helper.rb</span>
+    <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">command_name</span> <span class="pl-s">"features"</span> + <span class="pl-kos">(</span><span class="pl-c1">ENV</span><span class="pl-kos">[</span><span class="pl-s">'TEST_ENV_NUMBER'</span><span class="pl-kos">]</span> || <span class="pl-s">''</span><span class="pl-kos">)</span></pre></div>
+    <p><a href="https://github.com/simplecov-ruby/simplecov-html" title="SimpleCov HTML Formatter Source Code @ GitHub">simplecov-html</a> prints the used test suites in the footer of the generated coverage report.</p>
+    <h3>Merging test runs under the same execution environment</h3>
+    <p>Test results are automatically merged with previous runs in the same execution
+    environment when generating the result, so when coverage is set up properly for
+    Cucumber and your unit / functional / integration tests, all of those test
+    suites will be taken into account when building the coverage report.</p>
+    <h4>Timeout for merge</h4>
+    <p>Of course, your cached coverage data is likely to become invalid at some point. Thus, when automatically merging
+    subsequent test runs, result sets that are older than <code>SimpleCov.merge_timeout</code> will not be used any more. By default,
+    the timeout is 600 seconds (10 minutes), and you can raise (or lower) it by specifying <code>SimpleCov.merge_timeout 3600</code>
+    (1 hour), or, inside a configure/start block, with just <code>merge_timeout 3600</code>.</p>
+    <p>You can deactivate this automatic merging altogether with <code>SimpleCov.use_merging false</code>.</p>
+    <h3>Merging test runs under different execution environments</h3>
+    <p>If your tests are done in parallel across multiple build machines, you can fetch them all and merge them into a single
+    result set using the <code>SimpleCov.collate</code> method. This can be added to a Rakefile or script file, having downloaded a set of
+    <code>.resultset.json</code> files from each parallel test run.</p>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-c"># lib/tasks/coverage_report.rake</span>
+    <span class="pl-en">namespace</span> <span class="pl-pds">:coverage</span> <span class="pl-k">do</span>
+      <span class="pl-en">desc</span> <span class="pl-s">"Collates all result sets generated by the different test runners"</span>
+      <span class="pl-en">task</span> <span class="pl-pds">:report</span> <span class="pl-k">do</span>
+        <span class="pl-en">require</span> <span class="pl-s">'simplecov'</span>
+
+        <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">collate</span> <span class="pl-v">Dir</span><span class="pl-kos">[</span><span class="pl-s">"simplecov-resultset-*/.resultset.json"</span><span class="pl-kos">]</span>
+      <span class="pl-k">end</span>
+    <span class="pl-k">end</span></pre></div>
+    <p><code>SimpleCov.collate</code> also takes an optional simplecov profile and an optional
+    block for configuration, just the same as <code>SimpleCov.start</code> or
+    <code>SimpleCov.configure</code>.  This means you can configure a separate formatter for
+    the collated output. For instance, you can make the formatter in
+    <code>SimpleCov.start</code> the <code>SimpleCov::Formatter::SimpleFormatter</code>, and only use more
+    complex formatters in the final <code>SimpleCov.collate</code> run.</p>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-c"># spec/spec_helper.rb</span>
+    <span class="pl-en">require</span> <span class="pl-s">'simplecov'</span>
+
+    <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span> <span class="pl-s">'rails'</span> <span class="pl-k">do</span>
+      <span class="pl-c"># Disambiguates individual test runs</span>
+      <span class="pl-en">command_name</span> <span class="pl-s">"Job <span class="pl-s1"><span class="pl-kos">#{</span><span class="pl-c1">ENV</span><span class="pl-kos">[</span><span class="pl-s">"TEST_ENV_NUMBER"</span><span class="pl-kos">]</span><span class="pl-kos">}</span></span>"</span> <span class="pl-k">if</span> <span class="pl-c1">ENV</span><span class="pl-kos">[</span><span class="pl-s">"TEST_ENV_NUMBER"</span><span class="pl-kos">]</span>
+
+      <span class="pl-k">if</span> <span class="pl-c1">ENV</span><span class="pl-kos">[</span><span class="pl-s">'CI'</span><span class="pl-kos">]</span>
+        <span class="pl-en">formatter</span> <span class="pl-v">SimpleCov</span>::<span class="pl-v">Formatter</span>::<span class="pl-v">SimpleFormatter</span>
+      <span class="pl-k">else</span>
+        <span class="pl-en">formatter</span> <span class="pl-v">SimpleCov</span>::<span class="pl-v">Formatter</span>::<span class="pl-v">MultiFormatter</span><span class="pl-kos">.</span><span class="pl-en">new</span><span class="pl-kos">(</span><span class="pl-kos">[</span>
+          <span class="pl-v">SimpleCov</span>::<span class="pl-v">Formatter</span>::<span class="pl-v">SimpleFormatter</span><span class="pl-kos">,</span>
+          <span class="pl-v">SimpleCov</span>::<span class="pl-v">Formatter</span>::<span class="pl-v">HTMLFormatter</span>
+        <span class="pl-kos">]</span><span class="pl-kos">)</span>
+      <span class="pl-k">end</span>
+
+      <span class="pl-en">track_files</span> <span class="pl-s">"**/*.rb"</span>
+    <span class="pl-k">end</span></pre></div>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-c"># lib/tasks/coverage_report.rake</span>
+    <span class="pl-en">namespace</span> <span class="pl-pds">:coverage</span> <span class="pl-k">do</span>
+      <span class="pl-en">task</span> <span class="pl-pds">:report</span> <span class="pl-k">do</span>
+        <span class="pl-en">require</span> <span class="pl-s">'simplecov'</span>
+
+        <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">collate</span> <span class="pl-v">Dir</span><span class="pl-kos">[</span><span class="pl-s">"simplecov-resultset-*/.resultset.json"</span><span class="pl-kos">]</span><span class="pl-kos">,</span> <span class="pl-s">'rails'</span> <span class="pl-k">do</span>
+          <span class="pl-en">formatter</span> <span class="pl-v">SimpleCov</span>::<span class="pl-v">Formatter</span>::<span class="pl-v">MultiFormatter</span><span class="pl-kos">.</span><span class="pl-en">new</span><span class="pl-kos">(</span><span class="pl-kos">[</span>
+            <span class="pl-v">SimpleCov</span>::<span class="pl-v">Formatter</span>::<span class="pl-v">SimpleFormatter</span><span class="pl-kos">,</span>
+            <span class="pl-v">SimpleCov</span>::<span class="pl-v">Formatter</span>::<span class="pl-v">HTMLFormatter</span>
+          <span class="pl-kos">]</span><span class="pl-kos">)</span>
+        <span class="pl-k">end</span>
+      <span class="pl-k">end</span>
+    <span class="pl-k">end</span></pre></div>
+    <h2>Running simplecov against subprocesses</h2>
+    <p><code>SimpleCov.enable_for_subprocesses</code> will allow SimpleCov to observe subprocesses starting using <code>Process.fork</code>.
+    This modifies ruby's core Process.fork method so that SimpleCov can see into it, appending <code>" (subprocess #{pid})"</code>
+    to the <code>SimpleCov.command_name</code>, with results that can be merged together using SimpleCov's merging feature.</p>
+    <p>To configure this, use <code>.at_fork</code>.</p>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">enable_for_subprocesses</span> <span class="pl-c1">true</span>
+    <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">at_fork</span> <span class="pl-k">do</span> |<span class="pl-s1">pid</span>|
+      <span class="pl-c"># This needs a unique name so it won't be ovewritten</span>
+      <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">command_name</span> <span class="pl-s">"<span class="pl-s1"><span class="pl-kos">#{</span><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">command_name</span><span class="pl-kos">}</span></span> (subprocess: <span class="pl-s1"><span class="pl-kos">#{</span><span class="pl-s1">pid</span><span class="pl-kos">}</span></span>)"</span>
+      <span class="pl-c"># be quiet, the parent process will be in charge of output and checking coverage totals</span>
+      <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">print_error_status</span> <span class="pl-c1">=</span> <span class="pl-c1">false</span>
+      <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">formatter</span> <span class="pl-v">SimpleCov</span>::<span class="pl-v">Formatter</span>::<span class="pl-v">SimpleFormatter</span>
+      <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">minimum_coverage</span> <span class="pl-c1">0</span>
+      <span class="pl-c"># start</span>
+      <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span>
+    <span class="pl-k">end</span></pre></div>
+    <p>NOTE: SimpleCov must have already been started before <code>Process.fork</code> was called.</p>
+    <h3>Running simplecov against spawned subprocesses</h3>
+    <p>Perhaps you're testing a ruby script with <code>PTY.spawn</code> or <code>Open3.popen</code>, or <code>Process.spawn</code> or etc.
+    SimpleCov can cover this too.</p>
+    <p>Add a .simplecov_spawn.rb file to your project root</p>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-c"># .simplecov_spawn.rb</span>
+    <span class="pl-en">require</span> <span class="pl-s">'simplecov'</span> <span class="pl-c"># this will also pick up whatever config is in .simplecov</span>
+                        <span class="pl-c"># so ensure it just contains configuration, and doesn't call SimpleCov.start.</span>
+    <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">command_name</span> <span class="pl-s">'spawn'</span> <span class="pl-c"># As this is not for a test runner directly, script doesn't have a pre-defined base command_name</span>
+    <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">at_fork</span><span class="pl-kos">.</span><span class="pl-en">call</span><span class="pl-kos">(</span><span class="pl-v">Process</span><span class="pl-kos">.</span><span class="pl-en">pid</span><span class="pl-kos">)</span> <span class="pl-c"># Use the per-process setup described previously</span>
+    <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span> <span class="pl-c"># only now can we start.</span></pre></div>
+    <p>Then, instead of calling your script directly, like:</p>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-c1">PTY</span><span class="pl-kos">.</span><span class="pl-en">spawn</span><span class="pl-kos">(</span><span class="pl-s">'my_script.rb'</span><span class="pl-kos">)</span> <span class="pl-k">do</span> <span class="pl-c"># ...</span><span class="pl-k"></span></pre></div>
+    <p>Use bin/ruby to require the new .simplecov_spawn file, then your script</p>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-c1">PTY</span><span class="pl-kos">.</span><span class="pl-en">spawn</span><span class="pl-kos">(</span><span class="pl-s">'ruby -r./.simplecov_spawn my_script.rb'</span><span class="pl-kos">)</span> <span class="pl-k">do</span> <span class="pl-c"># ...</span><span class="pl-k"></span></pre></div>
+    <h2>Running coverage only on demand</h2>
+    <p>The Ruby STDLIB Coverage library that SimpleCov builds upon is <em>very</em> fast (on a ~10 min Rails test suite, the speed
+    drop was only a couple seconds for me), and therefore it's SimpleCov's policy to just generate coverage every time you
+    run your tests because it doesn't do your test speed any harm and you're always equipped with the latest and greatest
+    coverage results.</p>
+    <p>Because of this, SimpleCov has no explicit built-in mechanism to run coverage only on demand.</p>
+    <p>However, you can still accomplish this very easily by introducing an ENV variable conditional into your SimpleCov setup
+    block, like this:</p>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span> <span class="pl-k">if</span> <span class="pl-c1">ENV</span><span class="pl-kos">[</span><span class="pl-s">"COVERAGE"</span><span class="pl-kos">]</span></pre></div>
+    <p>Then, SimpleCov will only run if you execute your tests like this:</p>
+    <div class="highlight highlight-source-shell position-relative"><pre>COVERAGE=true rake <span class="pl-c1">test</span></pre></div>
+    <h2>Errors and exit statuses</h2>
+    <p>To aid in debugging issues, if an error is raised, SimpleCov will print a message to <code>STDERR</code>
+    with the exit status of the error, like:</p>
+    <div class="snippet-clipboard-content position-relative"><pre><code>SimpleCov failed with exit 1
+    </code></pre></div>
+    <p>This <code>STDERR</code> message can be disabled with:</p>
+    <div class="snippet-clipboard-content position-relative"><pre><code>SimpleCov.print_error_status = false
+    </code></pre></div>
+    <h2>Profiles</h2>
+    <p>By default, SimpleCov's only config assumption is that you only want coverage reports for files inside your project
+    root. To save yourself from repetitive configuration, you can use predefined blocks of configuration, called 'profiles',
+    or define your own.</p>
+    <p>You can then pass the name of the profile to be used as the first argument to SimpleCov.start. For example, simplecov
+    comes bundled with a 'rails' profile. It looks somewhat like this:</p>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">profiles</span><span class="pl-kos">.</span><span class="pl-en">define</span> <span class="pl-s">'rails'</span> <span class="pl-k">do</span>
+      <span class="pl-en">add_filter</span> <span class="pl-s">'/test/'</span>
+      <span class="pl-en">add_filter</span> <span class="pl-s">'/config/'</span>
+
+      <span class="pl-en">add_group</span> <span class="pl-s">'Controllers'</span><span class="pl-kos">,</span> <span class="pl-s">'app/controllers'</span>
+      <span class="pl-en">add_group</span> <span class="pl-s">'Models'</span><span class="pl-kos">,</span> <span class="pl-s">'app/models'</span>
+      <span class="pl-en">add_group</span> <span class="pl-s">'Helpers'</span><span class="pl-kos">,</span> <span class="pl-s">'app/helpers'</span>
+      <span class="pl-en">add_group</span> <span class="pl-s">'Libraries'</span><span class="pl-kos">,</span> <span class="pl-s">'lib'</span>
+    <span class="pl-k">end</span></pre></div>
+    <p>As you can see, it's just a SimpleCov.configure block. In your test_helper.rb, launch SimpleCov with:</p>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span> <span class="pl-s">'rails'</span></pre></div>
+    <p>or</p>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span> <span class="pl-s">'rails'</span> <span class="pl-k">do</span>
+      <span class="pl-c"># additional config here</span>
+    <span class="pl-k">end</span></pre></div>
+    <h3>Custom profiles</h3>
+    <p>You can load additional profiles with the SimpleCov.load_profile('xyz') method. This allows you to build upon an
+    existing profile and customize it so you can reuse it in unit tests and Cucumber features. For example:</p>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-c"># lib/simplecov_custom_profile.rb</span>
+    <span class="pl-en">require</span> <span class="pl-s">'simplecov'</span>
+    <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">profiles</span><span class="pl-kos">.</span><span class="pl-en">define</span> <span class="pl-s">'myprofile'</span> <span class="pl-k">do</span>
+      <span class="pl-en">load_profile</span> <span class="pl-s">'rails'</span>
+      <span class="pl-en">add_filter</span> <span class="pl-s">'vendor'</span> <span class="pl-c"># Don't include vendored stuff</span>
+    <span class="pl-k">end</span>
+
+    <span class="pl-c"># features/support/env.rb</span>
+    <span class="pl-en">require</span> <span class="pl-s">'simplecov_custom_profile'</span>
+    <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span> <span class="pl-s">'myprofile'</span>
+
+    <span class="pl-c"># test/test_helper.rb</span>
+    <span class="pl-en">require</span> <span class="pl-s">'simplecov_custom_profile'</span>
+    <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span> <span class="pl-s">'myprofile'</span></pre></div>
+    <h2>Customizing exit behaviour</h2>
+    <p>You can define what SimpleCov should do when your test suite finishes by customizing the at_exit hook:</p>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">at_exit</span> <span class="pl-k">do</span>
+      <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">result</span><span class="pl-kos">.</span><span class="pl-en">format!</span>
+    <span class="pl-k">end</span></pre></div>
+    <p>Above is the default behaviour. Do whatever you like instead!</p>
+    <h3>Minimum coverage</h3>
+    <p>You can define the minimum coverage percentage expected. SimpleCov will return non-zero if unmet.</p>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">minimum_coverage</span> <span class="pl-c1">90</span>
+    <span class="pl-c"># same as above (the default is to check line coverage)</span>
+    <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">minimum_coverage</span> <span class="pl-pds">line</span>: <span class="pl-c1">90</span>
+    <span class="pl-c"># check for a minimum line coverage of 90% and minimum 80% branch coverage</span>
+    <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">minimum_coverage</span> <span class="pl-pds">line</span>: <span class="pl-c1">90</span><span class="pl-kos">,</span> <span class="pl-pds">branch</span>: <span class="pl-c1">80</span></pre></div>
+    <h3>Minimum coverage by file</h3>
+    <p>You can define the minimum coverage by file percentage expected. SimpleCov will return non-zero if unmet. This is useful
+    to help ensure coverage is relatively consistent, rather than being skewed by particularly good or bad areas of the code.</p>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">minimum_coverage_by_file</span> <span class="pl-c1">80</span>
+    <span class="pl-c"># same as above (the default is to check line coverage by file)</span>
+    <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">minimum_coverage_by_file</span> <span class="pl-pds">line</span>: <span class="pl-c1">80</span>
+    <span class="pl-c"># check for a minimum line coverage by file of 90% and minimum 80% branch coverage</span>
+    <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">minimum_coverage_by_file</span> <span class="pl-pds">line</span>: <span class="pl-c1">90</span><span class="pl-kos">,</span> <span class="pl-pds">branch</span>: <span class="pl-c1">80</span></pre></div>
+    <h3>Maximum coverage drop</h3>
+    <p>You can define the maximum coverage drop percentage at once. SimpleCov will return non-zero if exceeded.</p>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">maximum_coverage_drop</span> <span class="pl-c1">5</span>
+    <span class="pl-c"># same as above (the default is to check line drop)</span>
+    <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">maximum_coverage_drop</span> <span class="pl-pds">line</span>: <span class="pl-c1">5</span>
+    <span class="pl-c"># check for a maximum line drop of 5% and maximum 10% branch drop</span>
+    <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">maximum_coverage_drop</span> <span class="pl-pds">line</span>: <span class="pl-c1">5</span><span class="pl-kos">,</span> <span class="pl-pds">branch</span>: <span class="pl-c1">10</span></pre></div>
+    <h3>Refuse dropping coverage</h3>
+    <p>You can also entirely refuse dropping coverage between test runs:</p>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">refuse_coverage_drop</span>
+    <span class="pl-c"># same as above (the default is to only refuse line drop)</span>
+    <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">refuse_coverage_drop</span> <span class="pl-pds">:line</span>
+    <span class="pl-c"># refuse drop for line and branch</span>
+    <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">refuse_coverage_drop</span> <span class="pl-pds">:line</span><span class="pl-kos">,</span> <span class="pl-pds">:branch</span></pre></div>
+    <h2>Using your own formatter</h2>
+    <p>You can use your own formatter with:</p>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">formatter</span> <span class="pl-c1">=</span> <span class="pl-v">SimpleCov</span>::<span class="pl-v">Formatter</span>::<span class="pl-v">HTMLFormatter</span></pre></div>
+    <p>When calling SimpleCov.result.format!, it will be invoked with SimpleCov::Formatter::YourFormatter.new.format(result),
+    "result" being an instance of SimpleCov::Result. Do whatever your wish with that!</p>
+    <h2>Using multiple formatters</h2>
+    <p>As of SimpleCov 0.9, you can specify multiple result formats:</p>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">formatters</span> <span class="pl-c1">=</span> <span class="pl-v">SimpleCov</span>::<span class="pl-v">Formatter</span>::<span class="pl-v">MultiFormatter</span><span class="pl-kos">.</span><span class="pl-en">new</span><span class="pl-kos">(</span><span class="pl-kos">[</span>
+      <span class="pl-v">SimpleCov</span>::<span class="pl-v">Formatter</span>::<span class="pl-v">HTMLFormatter</span><span class="pl-kos">,</span>
+      <span class="pl-v">SimpleCov</span>::<span class="pl-v">Formatter</span>::<span class="pl-v">CSVFormatter</span><span class="pl-kos">,</span>
+    <span class="pl-kos">]</span><span class="pl-kos">)</span></pre></div>
+    <h2>JSON formatter</h2>
+    <p>SimpleCov is packaged with a separate gem called <a href="https://github.com/codeclimate-community/simplecov_json_formatter">simplecov_json_formatter</a> that provides you with a JSON formatter, this formatter could be useful for different use cases, such as for CI consumption or for reporting to external services.</p>
+    <p>In order to use it you will need to manually load the installed gem like so:</p>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-en">require</span> <span class="pl-s">"simplecov_json_formatter"</span>
+    <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">formatter</span> <span class="pl-c1">=</span> <span class="pl-v">SimpleCov</span>::<span class="pl-v">Formatter</span>::<span class="pl-v">JSONFormatter</span></pre></div>
+    <blockquote>
+    <p><em>Note:</em> In case you plan to report your coverage results to CodeClimate services, know that SimpleCov will automatically use the
+    JSON formatter along with the HTML formatter when the <code>CC_TEST_REPORTER_ID</code> variable is present in the environment.</p>
+    </blockquote>
+    <h2>Available formatters, editor integrations and hosted services</h2>
+    <ul>
+    <li><a href="https://github.com/simplecov-ruby/simplecov/blob/main/doc/alternate-formatters.md">Open Source formatter and integration plugins for SimpleCov</a></li>
+    <li><a href="https://github.com/simplecov-ruby/simplecov/blob/main/doc/editor-integration.md">Editor Integration</a></li>
+    <li><a href="https://github.com/simplecov-ruby/simplecov/blob/main/doc/commercial-services.md">Hosted (commercial) services</a></li>
+    </ul>
+    <h2>Ruby version compatibility</h2>
+    <p>SimpleCov is built in <a href="https://github.com/simplecov-ruby/simplecov/actions?query=workflow%3Astable" title="SimpleCov is built around the clock by github.com">Continuous Integration</a> on Ruby 2.5+ as well as JRuby 9.2+.</p>
+    <p>Note for JRuby =&gt; You need to pass JRUBY_OPTS="--debug" or create .jrubyrc and add debug.fullTrace=true</p>
+    <h2>Want to find dead code in production?</h2>
+    <p>Try <a href="https://github.com/danmayer/coverband">Coverband</a>.</p>
+    <h2>Want to use Spring with SimpleCov?</h2>
+    <p>If you're using <a href="https://github.com/rails/spring">Spring</a> to speed up test suite runs and want to run SimpleCov along
+    with them, you'll find that it often misreports coverage with the default config due to some sort of eager loading
+    issue. Don't despair!</p>
+    <p>One solution is to <a href="https://github.com/simplecov-ruby/simplecov/issues/381#issuecomment-347651728">explicitly call eager
+    load</a>
+    in your <code>test_helper.rb</code> / <code>spec_helper.rb</code> after calling <code>SimpleCov.start</code>.</p>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-en">require</span> <span class="pl-s">'simplecov'</span>
+    <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span> <span class="pl-s">'rails'</span>
+    <span class="pl-v">Rails</span><span class="pl-kos">.</span><span class="pl-en">application</span><span class="pl-kos">.</span><span class="pl-en">eager_load!</span></pre></div>
+    <p>Alternatively, you could disable Spring while running SimpleCov:</p>
+    <div class="snippet-clipboard-content position-relative"><pre><code>DISABLE_SPRING=1 rake test
+    </code></pre></div>
+    <p>Or you could remove <code>gem 'spring'</code> from your <code>Gemfile</code>.</p>
+    <h2>Troubleshooting</h2>
+    <p>The <strong>most common problem is that simplecov isn't required and started before everything else</strong>. In order to track
+    coverage for your whole application <strong>simplecov needs to be the first one</strong> so that it (and the underlying coverage
+    library) can subsequently track loaded files and their usage.</p>
+    <p>If you are missing coverage for some code a simple trick is to put a puts statement in there and right after
+    <code>SimpleCov.start</code> so you can see if the file really was loaded after simplecov was started.</p>
+    <div class="highlight highlight-source-ruby position-relative"><pre><span class="pl-c"># my_code.rb</span>
+    <span class="pl-k">class</span> <span class="pl-v">MyCode</span>
+
+      <span class="pl-en">puts</span> <span class="pl-s">"MyCode is being loaded!"</span>
+
+      <span class="pl-k">def</span> <span class="pl-en">my_method</span>
+        <span class="pl-c"># ...</span>
+      <span class="pl-k">end</span>
+    <span class="pl-k">end</span>
+
+    <span class="pl-c"># spec_helper.rb/rails_helper.rb/test_helper.rb/.simplecov whatever</span>
+
+    <span class="pl-v">SimpleCov</span><span class="pl-kos">.</span><span class="pl-en">start</span>
+    <span class="pl-en">puts</span> <span class="pl-s">"SimpleCov started successfully!"</span></pre></div>
+    <p>Now when you run your test suite and you see:</p>
+    <div class="snippet-clipboard-content position-relative"><pre><code>SimpleCov started successfully!
+    MyCode is being loaded!
+    </code></pre></div>
+    <p>then it's good otherwise you likely have a problem :)</p>
+    <h2>Code of Conduct</h2>
+    <p>Everyone participating in this project's development, issue trackers and other channels is expected to follow our
+    <a href="https://github.com/simplecov-ruby/simplecov/blob/main/./CODE_OF_CONDUCT.md">Code of Conduct</a></p>
+    <h2>Contributing</h2>
+    <p>See the <a href="https://github.com/simplecov-ruby/simplecov/blob/main/CONTRIBUTING.md">contributing guide</a>.</p>
+    <h2>Kudos</h2>
+    <p>Thanks to Aaron Patterson for the original idea for this!</p>
+    <h2>Copyright</h2>
+    <p>Copyright (c) 2010-2017 Christoph Olszowka. See MIT-LICENSE for details.</p>
+    </article></div>
+  etag: '"8c5b89f1c0fb752a97a1c3eba820f8e451ec9d129e804e8291ec5bf5408b58e2"'
+  created_at: '2020-10-24T17:30:02.290Z'
+  updated_at: '2021-05-21T11:15:31.366Z'

--- a/spec/fixtures/github_repos.yml
+++ b/spec/fixtures/github_repos.yml
@@ -1,0 +1,259 @@
+---
+sparklemotion/nokogiri:
+  path: sparklemotion/nokogiri
+  stargazers_count: 5629
+  forks_count: 745
+  watchers_count: 149
+  description: Nokogiri (鋸) makes it easy and painless to work with XML and HTML from
+    Ruby.
+  homepage_url: https://nokogiri.org/
+  repo_created_at: '2008-07-14T15:34:32.000Z'
+  repo_pushed_at: '2021-05-21T11:18:28.000Z'
+  has_issues: true
+  has_wiki: true
+  archived: false
+  created_at: '2020-04-18T20:19:24.210Z'
+  updated_at: '2021-05-23T11:59:53.485Z'
+  primary_language: C
+  license: other
+  default_branch: main
+  is_fork: false
+  is_mirror: false
+  open_issues_count: 149
+  closed_issues_count: 1532
+  open_pull_requests_count: 9
+  merged_pull_requests_count: 320
+  closed_pull_requests_count: 212
+  average_recent_committed_at: '2021-05-15T20:14:31.000Z'
+  code_of_conduct_url: https://github.com/sparklemotion/nokogiri/blob/main/CODE_OF_CONDUCT.md
+  code_of_conduct_name: Contributor Covenant
+  topics:
+  - libxml2
+  - libxslt
+  - nokogiri
+  - ruby
+  - ruby-gem
+  - sax
+  - xerces
+  - xml
+  - xslt
+  total_issues_count: 1681
+  total_pull_requests_count: 541
+  issue_closure_rate: '91.14'
+  pull_request_acceptance_rate: '59.15'
+rubygems/rubygems:
+  path: rubygems/rubygems
+  stargazers_count: 2725
+  forks_count: 1225
+  watchers_count: 157
+  description: Library packaging and distribution for Ruby.
+  homepage_url: https://rubygems.org/
+  repo_created_at: '2010-04-16T19:02:44.000Z'
+  repo_pushed_at: '2021-05-29T11:38:26.000Z'
+  has_issues: true
+  has_wiki: false
+  archived: false
+  created_at: '2020-12-15T16:55:21.817Z'
+  updated_at: '2021-05-30T22:16:56.447Z'
+  primary_language: Ruby
+  license: other
+  default_branch: master
+  is_fork: false
+  is_mirror: false
+  open_issues_count: 259
+  closed_issues_count: 1976
+  open_pull_requests_count: 47
+  merged_pull_requests_count: 1921
+  closed_pull_requests_count: 385
+  average_recent_committed_at: '2021-05-23T03:51:25.000Z'
+  code_of_conduct_url: https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md
+  code_of_conduct_name: Contributor Covenant
+  topics:
+  - package-manager
+  - ruby
+  - rubygems
+  total_issues_count: 2235
+  total_pull_requests_count: 2353
+  issue_closure_rate: '88.41'
+  pull_request_acceptance_rate: '81.64'
+simplecov-ruby/simplecov:
+  path: simplecov-ruby/simplecov
+  stargazers_count: 4250
+  forks_count: 472
+  watchers_count: 68
+  description: Code coverage for Ruby with a powerful configuration library and automatic
+    merging of coverage across test suites
+  homepage_url:
+  repo_created_at: '2010-08-15T15:28:56.000Z'
+  repo_pushed_at: '2021-04-30T17:07:48.000Z'
+  has_issues: true
+  has_wiki: false
+  archived: false
+  created_at: '2020-08-20T19:10:32.453Z'
+  updated_at: '2021-05-21T23:55:33.943Z'
+  primary_language: Ruby
+  license: mit
+  default_branch: main
+  is_fork: false
+  is_mirror: false
+  open_issues_count: 66
+  closed_issues_count: 438
+  open_pull_requests_count: 6
+  merged_pull_requests_count: 384
+  closed_pull_requests_count: 94
+  average_recent_committed_at: '2020-12-11T07:27:58.000Z'
+  code_of_conduct_url: https://github.com/simplecov-ruby/simplecov/blob/main/CODE_OF_CONDUCT.md
+  code_of_conduct_name: Contributor Covenant
+  topics:
+  - code-quality
+  - coverage
+  - coverage-library
+  - coverage-report
+  - rails
+  - ruby
+  - test-coverage
+  total_issues_count: 504
+  total_pull_requests_count: 484
+  issue_closure_rate: '86.9'
+  pull_request_acceptance_rate: '79.34'
+rubocop/rubocop:
+  path: rubocop/rubocop
+  stargazers_count: 11414
+  forks_count: 2603
+  watchers_count: 191
+  description: A Ruby static code analyzer and formatter, based on the community Ruby
+    style guide.
+  homepage_url: https://docs.rubocop.org
+  repo_created_at: '2012-04-21T10:09:58.000Z'
+  repo_pushed_at: '2021-05-10T06:29:06.000Z'
+  has_issues: true
+  has_wiki: false
+  archived: false
+  created_at: '2021-03-03T23:12:14.045Z'
+  updated_at: '2021-05-10T08:47:15.681Z'
+  primary_language: Ruby
+  license: mit
+  default_branch: master
+  is_fork: false
+  is_mirror: false
+  open_issues_count: 200
+  closed_issues_count: 4078
+  open_pull_requests_count: 19
+  merged_pull_requests_count: 4846
+  closed_pull_requests_count: 539
+  average_recent_committed_at: '2021-05-01T10:27:56.000Z'
+  code_of_conduct_url: https://github.com/rubocop/rubocop/blob/master/CODE_OF_CONDUCT.md
+  code_of_conduct_name: Other
+  topics:
+  - code-formatter
+  - linter
+  - rubocop
+  - ruby
+  - static-code-analysis
+  total_issues_count: 4278
+  total_pull_requests_count: 5404
+  issue_closure_rate: '95.32'
+  pull_request_acceptance_rate: '89.67'
+rspec/rspec:
+  path: rspec/rspec
+  stargazers_count: 2788
+  forks_count: 229
+  watchers_count: 98
+  description: RSpec meta-gem that depends on the other components
+  homepage_url:
+  repo_created_at: '2009-06-29T16:13:38.000Z'
+  repo_pushed_at: '2020-12-27T12:00:30.000Z'
+  has_issues: true
+  has_wiki: true
+  archived: false
+  created_at: '2020-04-18T20:18:57.581Z'
+  updated_at: '2021-05-22T22:00:54.089Z'
+  primary_language: Ruby
+  license: mit
+  default_branch: main
+  is_fork: false
+  is_mirror: false
+  open_issues_count: 2
+  closed_issues_count: 19
+  open_pull_requests_count: 1
+  merged_pull_requests_count: 21
+  closed_pull_requests_count: 12
+  average_recent_committed_at: '2017-10-10T16:54:09.000Z'
+  code_of_conduct_url: https://github.com/rspec/rspec/blob/main/code_of_conduct.md
+  code_of_conduct_name: Other
+  topics: []
+  total_issues_count: 21
+  total_pull_requests_count: 34
+  issue_closure_rate: '90.48'
+  pull_request_acceptance_rate: '61.76'
+seattlerb/minitest:
+  path: seattlerb/minitest
+  stargazers_count: 2908
+  forks_count: 461
+  watchers_count: 62
+  description: minitest provides a complete suite of testing facilities supporting
+    TDD, BDD, mocking, and benchmarking.
+  homepage_url: http://docs.seattlerb.org/minitest/
+  repo_created_at: '2009-02-18T07:40:21.000Z'
+  repo_pushed_at: '2021-05-23T08:15:58.000Z'
+  has_issues: true
+  has_wiki: false
+  archived: false
+  created_at: '2020-04-18T20:18:57.538Z'
+  updated_at: '2021-05-25T15:40:19.606Z'
+  primary_language: Ruby
+  license:
+  default_branch: master
+  is_fork: false
+  is_mirror: false
+  open_issues_count: 30
+  closed_issues_count: 424
+  open_pull_requests_count: 27
+  merged_pull_requests_count: 1
+  closed_pull_requests_count: 392
+  average_recent_committed_at: '2020-03-16T03:13:05.000Z'
+  code_of_conduct_url:
+  code_of_conduct_name:
+  topics:
+  - minitest
+  - ruby
+  - seattlerb
+  - test
+  - testing
+  total_issues_count: 454
+  total_pull_requests_count: 420
+  issue_closure_rate: '93.39'
+  pull_request_acceptance_rate: '0.24'
+imathis/octopress:
+  path: imathis/octopress
+  stargazers_count: 9407
+  forks_count: 2617
+  watchers_count: 336
+  description: Octopress is an obsessively designed framework for Jekyll blogging.
+    It’s easy to configure and easy to deploy. Sweet huh?
+  homepage_url: http://github.com/imathis/octopress
+  repo_created_at: '2009-10-18T21:41:32.000Z'
+  repo_pushed_at: '2017-02-04T22:34:23.000Z'
+  has_issues: true
+  has_wiki: true
+  archived: false
+  created_at: '2020-04-18T20:17:10.921Z'
+  updated_at: '2021-05-23T11:56:36.844Z'
+  primary_language: Ruby
+  license:
+  default_branch: master
+  is_fork: false
+  is_mirror: false
+  open_issues_count: 176
+  closed_issues_count: 811
+  open_pull_requests_count: 77
+  merged_pull_requests_count: 249
+  closed_pull_requests_count: 473
+  average_recent_committed_at: '2014-11-28T10:12:15.000Z'
+  code_of_conduct_url:
+  code_of_conduct_name:
+  topics: []
+  total_issues_count: 987
+  total_pull_requests_count: 799
+  issue_closure_rate: '82.17'
+  pull_request_acceptance_rate: '31.16'

--- a/spec/fixtures/github_repos.yml
+++ b/spec/fixtures/github_repos.yml
@@ -1,3 +1,4 @@
+# Generated from realistic dataset using lib/make_fixtures.rb, please don't modify manually
 ---
 sparklemotion/nokogiri:
   path: sparklemotion/nokogiri
@@ -154,38 +155,6 @@ rubocop/rubocop:
   total_pull_requests_count: 5404
   issue_closure_rate: '95.32'
   pull_request_acceptance_rate: '89.67'
-rspec/rspec:
-  path: rspec/rspec
-  stargazers_count: 2788
-  forks_count: 229
-  watchers_count: 98
-  description: RSpec meta-gem that depends on the other components
-  homepage_url:
-  repo_created_at: '2009-06-29T16:13:38.000Z'
-  repo_pushed_at: '2020-12-27T12:00:30.000Z'
-  has_issues: true
-  has_wiki: true
-  archived: false
-  created_at: '2020-04-18T20:18:57.581Z'
-  updated_at: '2021-05-22T22:00:54.089Z'
-  primary_language: Ruby
-  license: mit
-  default_branch: main
-  is_fork: false
-  is_mirror: false
-  open_issues_count: 2
-  closed_issues_count: 19
-  open_pull_requests_count: 1
-  merged_pull_requests_count: 21
-  closed_pull_requests_count: 12
-  average_recent_committed_at: '2017-10-10T16:54:09.000Z'
-  code_of_conduct_url: https://github.com/rspec/rspec/blob/main/code_of_conduct.md
-  code_of_conduct_name: Other
-  topics: []
-  total_issues_count: 21
-  total_pull_requests_count: 34
-  issue_closure_rate: '90.48'
-  pull_request_acceptance_rate: '61.76'
 seattlerb/minitest:
   path: seattlerb/minitest
   stargazers_count: 2908

--- a/spec/fixtures/projects.yml
+++ b/spec/fixtures/projects.yml
@@ -1,3 +1,4 @@
+# Generated from realistic dataset using lib/make_fixtures.rb, please don't modify manually
 ---
 nokogiri:
   permalink: nokogiri
@@ -38,14 +39,6 @@ rubocop:
   description: |2
         RuboCop is a Ruby code style checking and code formatting tool.
         It aims to enforce the community-driven Ruby Style Guide.
-rspec:
-  permalink: rspec
-  created_at: '2017-11-01T22:39:53.996Z'
-  updated_at: '2021-05-27T15:15:16.771Z'
-  rubygem_name: rspec
-  github_repo_path: rspec/rspec
-  score: '42.25'
-  description: BDD for Ruby
 minitest:
   permalink: minitest
   created_at: '2017-11-01T22:39:53.981Z'

--- a/spec/fixtures/projects.yml
+++ b/spec/fixtures/projects.yml
@@ -1,0 +1,118 @@
+---
+nokogiri:
+  permalink: nokogiri
+  created_at: '2017-11-01T22:39:56.327Z'
+  updated_at: '2021-05-23T12:30:14.031Z'
+  rubygem_name: nokogiri
+  github_repo_path: sparklemotion/nokogiri
+  score: '34.52'
+  description: |
+    Nokogiri (鋸) makes it easy and painless to work with XML and HTML from Ruby. It provides a
+    sensible, easy-to-understand API for reading, writing, modifying, and querying documents. It is
+    fast and standards-compliant by relying on native parsers like libxml2 (C) and xerces (Java).
+bundler:
+  permalink: bundler
+  created_at: '2017-11-01T22:39:50.157Z'
+  updated_at: '2021-05-30T11:43:39.115Z'
+  rubygem_name: bundler
+  github_repo_path: rubygems/rubygems
+  score: '53.12'
+  description: Bundler manages an application's dependencies through its entire life,
+    across many machines, systematically and repeatably
+simplecov:
+  permalink: simplecov
+  created_at: '2017-11-01T22:39:42.944Z'
+  updated_at: '2021-05-23T02:37:43.291Z'
+  rubygem_name: simplecov
+  github_repo_path: simplecov-ruby/simplecov
+  score: '13.38'
+  description: Code coverage for Ruby with a powerful configuration library and automatic
+    merging of coverage across test suites
+rubocop:
+  permalink: rubocop
+  created_at: '2017-11-01T22:39:42.913Z'
+  updated_at: '2021-05-23T07:02:11.541Z'
+  rubygem_name: rubocop
+  github_repo_path: rubocop/rubocop
+  score: '21.05'
+  description: |2
+        RuboCop is a Ruby code style checking and code formatting tool.
+        It aims to enforce the community-driven Ruby Style Guide.
+rspec:
+  permalink: rspec
+  created_at: '2017-11-01T22:39:53.996Z'
+  updated_at: '2021-05-27T15:15:16.771Z'
+  rubygem_name: rspec
+  github_repo_path: rspec/rspec
+  score: '42.25'
+  description: BDD for Ruby
+minitest:
+  permalink: minitest
+  created_at: '2017-11-01T22:39:53.981Z'
+  updated_at: '2021-05-27T10:47:55.794Z'
+  rubygem_name: minitest
+  github_repo_path: seattlerb/minitest
+  score: '30.61'
+  description: |-
+    minitest provides a complete suite of testing facilities supporting
+    TDD, BDD, mocking, and benchmarking.
+
+        "I had a class with Jim Weirich on testing last week and we were
+         allowed to choose our testing frameworks. Kirk Haines and I were
+         paired up and we cracked open the code for a few test
+         frameworks...
+
+         I MUST say that minitest is *very* readable / understandable
+         compared to the 'other two' options we looked at. Nicely done and
+         thank you for helping us keep our mental sanity."
+
+        -- Wayne E. Seguin
+
+    minitest/test is a small and incredibly fast unit testing framework.
+    It provides a rich set of assertions to make your tests clean and
+    readable.
+
+    minitest/spec is a functionally complete spec engine. It hooks onto
+    minitest/test and seamlessly bridges test assertions over to spec
+    expectations.
+
+    minitest/benchmark is an awesome way to assert the performance of your
+    algorithms in a repeatable manner. Now you can assert that your newb
+    co-worker doesn't replace your linear algorithm with an exponential
+    one!
+
+    minitest/mock by Steven Baker, is a beautifully tiny mock (and stub)
+    object framework.
+
+    minitest/pride shows pride in testing and adds coloring to your test
+    output. I guess it is an example of how to write IO pipes too. :P
+
+    minitest/test is meant to have a clean implementation for language
+    implementors that need a minimal set of methods to bootstrap a working
+    test suite. For example, there is no magic involved for test-case
+    discovery.
+
+        "Again, I can't praise enough the idea of a testing/specing
+         framework that I can actually read in full in one sitting!"
+
+        -- Piotr Szotkowski
+
+    Comparing to rspec:
+
+        rspec is a testing DSL. minitest is ruby.
+
+        -- Adam Hawkins, "Bow Before MiniTest"
+
+    minitest doesn't reinvent anything that ruby already provides, like:
+    classes, modules, inheritance, methods. This means you only have to
+    learn ruby to use minitest and all of your regular OO practices like
+    extract-method refactorings still apply.
+imathis/octopress:
+  permalink: imathis/octopress
+  created_at: '2017-11-01T22:39:43.622Z'
+  updated_at: '2021-05-23T23:56:17.451Z'
+  rubygem_name:
+  github_repo_path: imathis/octopress
+  score: '15.85'
+  description: Octopress is an obsessively designed framework for Jekyll blogging.
+    It’s easy to configure and easy to deploy. Sweet huh?

--- a/spec/fixtures/rubygem_dependencies.yml
+++ b/spec/fixtures/rubygem_dependencies.yml
@@ -1,3 +1,4 @@
+# Generated from realistic dataset using lib/make_fixtures.rb, please don't modify manually
 ---
 nokogiri_bundler:
   id: 464766
@@ -207,30 +208,6 @@ rubocop_unicode-display_width:
   requirements: ">= 1.4.0, < 3.0"
   created_at: '2021-04-07T11:43:47.929Z'
   updated_at: '2021-04-07T11:43:47.929Z'
-rspec_rspec-core:
-  id: 527518
-  rubygem_name: rspec
-  dependency_name: rspec-core
-  type: runtime
-  requirements: "~> 3.10.0"
-  created_at: '2021-04-09T14:15:15.043Z'
-  updated_at: '2021-04-09T14:15:15.043Z'
-rspec_rspec-expectations:
-  id: 527519
-  rubygem_name: rspec
-  dependency_name: rspec-expectations
-  type: runtime
-  requirements: "~> 3.10.0"
-  created_at: '2021-04-09T14:15:15.120Z'
-  updated_at: '2021-04-09T14:15:15.120Z'
-rspec_rspec-mocks:
-  id: 527522
-  rubygem_name: rspec
-  dependency_name: rspec-mocks
-  type: runtime
-  requirements: "~> 3.10.0"
-  created_at: '2021-04-09T14:15:15.199Z'
-  updated_at: '2021-04-09T14:15:15.199Z'
 minitest_hoe:
   id: 488283
   rubygem_name: minitest

--- a/spec/fixtures/rubygem_dependencies.yml
+++ b/spec/fixtures/rubygem_dependencies.yml
@@ -1,0 +1,249 @@
+---
+nokogiri_bundler:
+  id: 464766
+  rubygem_name: nokogiri
+  dependency_name: bundler
+  type: development
+  requirements: "~> 2.2"
+  created_at: '2021-04-08T02:49:25.081Z'
+  updated_at: '2021-04-08T02:49:25.081Z'
+nokogiri_concourse:
+  id: 464776
+  rubygem_name: nokogiri
+  dependency_name: concourse
+  type: development
+  requirements: "~> 0.41"
+  created_at: '2021-04-08T02:49:26.559Z'
+  updated_at: '2021-04-08T02:49:26.559Z'
+nokogiri_hoe-markdown:
+  id: 464783
+  rubygem_name: nokogiri
+  dependency_name: hoe-markdown
+  type: development
+  requirements: "~> 1.4"
+  created_at: '2021-04-08T02:49:27.869Z'
+  updated_at: '2021-04-08T02:49:27.869Z'
+nokogiri_mini_portile2:
+  id: 464857
+  rubygem_name: nokogiri
+  dependency_name: mini_portile2
+  type: runtime
+  requirements: "~> 2.5.0"
+  created_at: '2021-04-08T02:49:40.333Z'
+  updated_at: '2021-04-08T02:49:40.333Z'
+nokogiri_minitest:
+  id: 464791
+  rubygem_name: nokogiri
+  dependency_name: minitest
+  type: development
+  requirements: "~> 5.8"
+  created_at: '2021-04-08T02:49:29.000Z'
+  updated_at: '2021-04-08T02:49:29.000Z'
+nokogiri_minitest-reporters:
+  id: 464798
+  rubygem_name: nokogiri
+  dependency_name: minitest-reporters
+  type: development
+  requirements: "~> 1.4"
+  created_at: '2021-04-08T02:49:30.023Z'
+  updated_at: '2021-04-08T02:49:30.023Z'
+nokogiri_racc:
+  id: 464863
+  rubygem_name: nokogiri
+  dependency_name: racc
+  type: runtime
+  requirements: "~> 1.4"
+  created_at: '2021-04-08T02:49:41.497Z'
+  updated_at: '2021-04-08T02:49:41.497Z'
+nokogiri_rake:
+  id: 464806
+  rubygem_name: nokogiri
+  dependency_name: rake
+  type: development
+  requirements: "~> 13.0"
+  created_at: '2021-04-08T02:49:31.478Z'
+  updated_at: '2021-04-08T02:49:31.478Z'
+nokogiri_rake-compiler:
+  id: 464814
+  rubygem_name: nokogiri
+  dependency_name: rake-compiler
+  type: development
+  requirements: "~> 1.1"
+  created_at: '2021-04-08T02:49:32.952Z'
+  updated_at: '2021-04-08T02:49:32.952Z'
+nokogiri_rake-compiler-dock:
+  id: 464821
+  rubygem_name: nokogiri
+  dependency_name: rake-compiler-dock
+  type: development
+  requirements: "~> 1.1"
+  created_at: '2021-04-08T02:49:34.160Z'
+  updated_at: '2021-04-08T02:49:34.160Z'
+nokogiri_rexical:
+  id: 464829
+  rubygem_name: nokogiri
+  dependency_name: rexical
+  type: development
+  requirements: "~> 1.0.5"
+  created_at: '2021-04-08T02:49:35.507Z'
+  updated_at: '2021-04-08T02:49:35.507Z'
+nokogiri_rubocop:
+  id: 464834
+  rubygem_name: nokogiri
+  dependency_name: rubocop
+  type: development
+  requirements: "~> 1.7"
+  created_at: '2021-04-08T02:49:36.512Z'
+  updated_at: '2021-04-08T02:49:36.512Z'
+nokogiri_simplecov:
+  id: 464842
+  rubygem_name: nokogiri
+  dependency_name: simplecov
+  type: development
+  requirements: "~> 0.20"
+  created_at: '2021-04-08T02:49:38.008Z'
+  updated_at: '2021-04-08T02:49:38.008Z'
+nokogiri_yard:
+  id: 464849
+  rubygem_name: nokogiri
+  dependency_name: yard
+  type: development
+  requirements: "~> 0.9"
+  created_at: '2021-04-08T02:49:39.262Z'
+  updated_at: '2021-04-08T02:49:39.262Z'
+simplecov_docile:
+  id: 451769
+  rubygem_name: simplecov
+  dependency_name: docile
+  type: runtime
+  requirements: "~> 1.1"
+  created_at: '2021-04-07T11:40:35.729Z'
+  updated_at: '2021-04-07T11:40:35.729Z'
+simplecov_simplecov-html:
+  id: 451773
+  rubygem_name: simplecov
+  dependency_name: simplecov-html
+  type: runtime
+  requirements: "~> 0.11"
+  created_at: '2021-04-07T11:40:35.840Z'
+  updated_at: '2021-04-07T11:40:35.840Z'
+simplecov_simplecov_json_formatter:
+  id: 451775
+  rubygem_name: simplecov
+  dependency_name: simplecov_json_formatter
+  type: runtime
+  requirements: "~> 0.1"
+  created_at: '2021-04-07T11:40:35.913Z'
+  updated_at: '2021-04-07T11:40:35.913Z'
+rubocop_bundler:
+  id: 453274
+  rubygem_name: rubocop
+  dependency_name: bundler
+  type: development
+  requirements: ">= 1.15.0, < 3.0"
+  created_at: '2021-04-07T11:43:38.768Z'
+  updated_at: '2021-04-07T11:43:38.768Z'
+rubocop_parallel:
+  id: 453280
+  rubygem_name: rubocop
+  dependency_name: parallel
+  type: runtime
+  requirements: "~> 1.10"
+  created_at: '2021-04-07T11:43:39.855Z'
+  updated_at: '2021-04-07T11:43:39.855Z'
+rubocop_parser:
+  id: 453288
+  rubygem_name: rubocop
+  dependency_name: parser
+  type: runtime
+  requirements: ">= 3.0.0.0"
+  created_at: '2021-04-07T11:43:40.942Z'
+  updated_at: '2021-04-07T11:43:40.942Z'
+rubocop_rainbow:
+  id: 453295
+  rubygem_name: rubocop
+  dependency_name: rainbow
+  type: runtime
+  requirements: ">= 2.2.2, < 4.0"
+  created_at: '2021-04-07T11:43:41.996Z'
+  updated_at: '2021-04-07T11:43:41.996Z'
+rubocop_regexp_parser:
+  id: 453302
+  rubygem_name: rubocop
+  dependency_name: regexp_parser
+  type: runtime
+  requirements: ">= 1.8, < 3.0"
+  created_at: '2021-04-07T11:43:43.172Z'
+  updated_at: '2021-04-07T11:43:43.172Z'
+rubocop_rexml:
+  id: 453309
+  rubygem_name: rubocop
+  dependency_name: rexml
+  type: runtime
+  requirements: ">= 0"
+  created_at: '2021-04-07T11:43:43.987Z'
+  updated_at: '2021-04-07T11:43:43.987Z'
+rubocop_rubocop-ast:
+  id: 453315
+  rubygem_name: rubocop
+  dependency_name: rubocop-ast
+  type: runtime
+  requirements: ">= 1.5.0, < 2.0"
+  created_at: '2021-04-07T11:43:45.221Z'
+  updated_at: '2021-05-23T01:06:58.071Z'
+rubocop_ruby-progressbar:
+  id: 453324
+  rubygem_name: rubocop
+  dependency_name: ruby-progressbar
+  type: runtime
+  requirements: "~> 1.7"
+  created_at: '2021-04-07T11:43:46.619Z'
+  updated_at: '2021-04-07T11:43:46.619Z'
+rubocop_unicode-display_width:
+  id: 453332
+  rubygem_name: rubocop
+  dependency_name: unicode-display_width
+  type: runtime
+  requirements: ">= 1.4.0, < 3.0"
+  created_at: '2021-04-07T11:43:47.929Z'
+  updated_at: '2021-04-07T11:43:47.929Z'
+rspec_rspec-core:
+  id: 527518
+  rubygem_name: rspec
+  dependency_name: rspec-core
+  type: runtime
+  requirements: "~> 3.10.0"
+  created_at: '2021-04-09T14:15:15.043Z'
+  updated_at: '2021-04-09T14:15:15.043Z'
+rspec_rspec-expectations:
+  id: 527519
+  rubygem_name: rspec
+  dependency_name: rspec-expectations
+  type: runtime
+  requirements: "~> 3.10.0"
+  created_at: '2021-04-09T14:15:15.120Z'
+  updated_at: '2021-04-09T14:15:15.120Z'
+rspec_rspec-mocks:
+  id: 527522
+  rubygem_name: rspec
+  dependency_name: rspec-mocks
+  type: runtime
+  requirements: "~> 3.10.0"
+  created_at: '2021-04-09T14:15:15.199Z'
+  updated_at: '2021-04-09T14:15:15.199Z'
+minitest_hoe:
+  id: 488283
+  rubygem_name: minitest
+  dependency_name: hoe
+  type: development
+  requirements: "~> 3.22"
+  created_at: '2021-04-08T19:20:59.643Z'
+  updated_at: '2021-04-08T19:20:59.643Z'
+minitest_rdoc:
+  id: 488289
+  rubygem_name: minitest
+  dependency_name: rdoc
+  type: development
+  requirements: ">= 4.0, < 7"
+  created_at: '2021-04-08T19:21:00.307Z'
+  updated_at: '2021-04-08T19:21:00.307Z'

--- a/spec/fixtures/rubygems.yml
+++ b/spec/fixtures/rubygems.yml
@@ -1,3 +1,4 @@
+# Generated from realistic dataset using lib/make_fixtures.rb, please don't modify manually
 ---
 nokogiri:
   name: nokogiri
@@ -249,75 +250,6 @@ rubocop:
     2020-4: 16
     2021-1: 7
     2021-2: 4
-rspec:
-  name: rspec
-  downloads: 540209012
-  current_version: 3.10.0
-  authors: Steven Baker, David Chelimsky, Myron Marston
-  description: BDD for Ruby
-  licenses:
-  - MIT
-  bug_tracker_url: https://github.com/rspec/rspec/issues
-  changelog_url:
-  documentation_url: https://rspec.info/documentation/
-  homepage_url: http://github.com/rspec
-  mailing_list_url: https://groups.google.com/forum/#!forum/rspec
-  source_code_url: https://github.com/rspec/rspec
-  wiki_url:
-  created_at: '2018-01-03T01:32:39.960Z'
-  updated_at: '2021-05-25T16:52:58.302Z'
-  first_release_on: '2005-08-11'
-  latest_release_on: '2020-10-30'
-  releases_count: 167
-  reverse_dependencies_count: 55525
-  quarterly_release_counts:
-    2005-3: 9
-    2006-1: 4
-    2006-2: 14
-    2006-3: 7
-    2006-4: 7
-    2007-1: 4
-    2007-2: 11
-    2007-3: 3
-    2007-4: 2
-    2008-1: 2
-    2008-2: 1
-    2008-3: 2
-    2008-4: 6
-    2009-1: 4
-    2009-2: 5
-    2009-3: 1
-    2009-4: 1
-    2010-1: 14
-    2010-2: 11
-    2010-3: 6
-    2010-4: 8
-    2011-1: 2
-    2011-2: 5
-    2011-4: 4
-    2012-1: 3
-    2012-2: 1
-    2012-3: 1
-    2012-4: 1
-    2013-1: 1
-    2013-2: 1
-    2013-3: 2
-    2013-4: 2
-    2014-1: 2
-    2014-2: 4
-    2014-3: 1
-    2015-1: 1
-    2015-2: 1
-    2015-4: 1
-    2016-1: 2
-    2016-2: 2
-    2016-3: 1
-    2016-4: 2
-    2017-2: 1
-    2017-4: 1
-    2018-3: 1
-    2019-4: 1
-    2020-4: 1
 minitest:
   name: minitest
   downloads: 380211284

--- a/spec/fixtures/rubygems.yml
+++ b/spec/fixtures/rubygems.yml
@@ -1,0 +1,434 @@
+---
+nokogiri:
+  name: nokogiri
+  downloads: 398962784
+  current_version: 1.11.5
+  authors: Mike Dalessio, Aaron Patterson, Yoko Harada, Akinori MUSHA, John Shahid,
+    Karol Bucek, Lars Kanis, Sergio Arbeo, Timothy Elliott, Nobuyoshi Nakada
+  description: |
+    Nokogiri (鋸) makes it easy and painless to work with XML and HTML from Ruby. It provides a
+    sensible, easy-to-understand API for reading, writing, modifying, and querying documents. It is
+    fast and standards-compliant by relying on native parsers like libxml2 (C) and xerces (Java).
+  licenses:
+  - MIT
+  bug_tracker_url: https://github.com/sparklemotion/nokogiri/issues
+  changelog_url:
+  documentation_url: https://nokogiri.org/rdoc/index.html
+  homepage_url: https://nokogiri.org
+  mailing_list_url:
+  source_code_url: https://github.com/sparklemotion/nokogiri
+  wiki_url:
+  created_at: '2018-01-03T00:54:01.378Z'
+  updated_at: '2021-05-23T09:35:29.603Z'
+  first_release_on: '2008-10-30'
+  latest_release_on: '2021-05-20'
+  releases_count: 508
+  reverse_dependencies_count: 7166
+  quarterly_release_counts:
+    2008-4: 9
+    2009-1: 5
+    2009-2: 3
+    2009-3: 1
+    2009-4: 2
+    2010-2: 3
+    2010-3: 3
+    2010-4: 4
+    2011-1: 1
+    2011-2: 2
+    2011-3: 2
+    2012-1: 5
+    2012-2: 12
+    2012-3: 2
+    2012-4: 2
+    2013-1: 6
+    2013-2: 3
+    2013-4: 2
+    2014-2: 8
+    2014-3: 2
+    2014-4: 3
+    2015-1: 2
+    2015-3: 2
+    2015-4: 6
+    2016-1: 3
+    2016-2: 1
+    2016-4: 2
+    2017-1: 2
+    2017-2: 2
+    2017-3: 1
+    2018-1: 1
+    2018-2: 1
+    2018-3: 1
+    2018-4: 4
+    2019-1: 4
+    2019-2: 1
+    2019-3: 1
+    2019-4: 3
+    2020-1: 3
+    2020-2: 1
+    2020-3: 2
+    2020-4: 1
+    2021-1: 3
+    2021-2: 3
+bundler:
+  name: bundler
+  downloads: 661962459
+  current_version: 2.2.18
+  authors: André Arko, Samuel Giddins, Colby Swandale, Hiroshi Shibata, David Rodríguez,
+    Grey Baker, Stephanie Morillo, Chris Morris, James Wen, Tim Moore, André Medeiros,
+    Jessica Lynn Suttles, Terence Lee, Carl Lerche, Yehuda Katz
+  description: Bundler manages an application's dependencies through its entire life,
+    across many machines, systematically and repeatably
+  licenses:
+  - MIT
+  bug_tracker_url: https://github.com/rubygems/rubygems/issues?q=is%3Aopen+is%3Aissue+label%3ABundler
+  changelog_url:
+  documentation_url:
+  homepage_url: https://bundler.io/
+  mailing_list_url:
+  source_code_url: https://github.com/rubygems/rubygems/
+  wiki_url:
+  created_at: '2018-01-03T03:27:28.619Z'
+  updated_at: '2021-05-28T00:57:29.375Z'
+  first_release_on: '2009-07-29'
+  latest_release_on: '2021-05-25'
+  releases_count: 303
+  reverse_dependencies_count: 65406
+  quarterly_release_counts:
+    2009-3: 6
+    2009-4: 3
+    2010-1: 25
+    2010-2: 14
+    2010-3: 12
+    2010-4: 4
+    2011-1: 4
+    2011-2: 9
+    2011-3: 11
+    2011-4: 6
+    2012-1: 6
+    2012-2: 3
+    2012-3: 5
+    2012-4: 5
+    2013-1: 12
+    2013-2: 1
+    2013-3: 3
+    2013-4: 4
+    2014-1: 8
+    2014-2: 3
+    2014-3: 10
+    2014-4: 10
+    2015-1: 18
+    2015-2: 22
+    2015-3: 1
+    2015-4: 5
+    2016-1: 3
+    2016-2: 11
+    2016-3: 4
+    2016-4: 7
+    2017-1: 8
+    2017-2: 6
+    2017-3: 5
+    2017-4: 3
+    2018-2: 1
+    2018-3: 4
+    2018-4: 9
+    2019-1: 2
+    2019-2: 1
+    2019-3: 2
+    2019-4: 4
+    2020-1: 2
+    2020-3: 1
+    2020-4: 6
+    2021-1: 11
+    2021-2: 3
+simplecov:
+  name: simplecov
+  downloads: 141246376
+  current_version: 0.21.2
+  authors: Christoph Olszowka, Tobias Pfeiffer
+  description: Code coverage for Ruby with a powerful configuration library and automatic
+    merging of coverage across test suites
+  licenses:
+  - MIT
+  bug_tracker_url: https://github.com/simplecov-ruby/simplecov/issues
+  changelog_url:
+  documentation_url: https://www.rubydoc.info/gems/simplecov/0.21.2
+  homepage_url: https://github.com/simplecov-ruby/simplecov
+  mailing_list_url: https://groups.google.com/forum/#!forum/simplecov
+  source_code_url: https://github.com/simplecov-ruby/simplecov/tree/v0.21.2
+  wiki_url:
+  created_at: '2018-01-03T01:48:03.557Z'
+  updated_at: '2021-05-22T23:37:29.817Z'
+  first_release_on: '2010-08-21'
+  latest_release_on: '2021-01-09'
+  releases_count: 57
+  reverse_dependencies_count: 11202
+  quarterly_release_counts:
+    2010-3: 6
+    2010-4: 1
+    2011-1: 3
+    2011-2: 1
+    2011-3: 2
+    2011-4: 1
+    2012-1: 2
+    2012-2: 3
+    2012-4: 2
+    2013-2: 1
+    2013-3: 1
+    2013-4: 2
+    2014-3: 2
+    2015-1: 1
+    2015-2: 1
+    2015-4: 2
+    2016-1: 1
+    2016-3: 1
+    2017-1: 3
+    2017-3: 2
+    2018-1: 2
+    2019-3: 2
+    2020-1: 9
+    2020-3: 1
+    2020-4: 2
+    2021-1: 3
+rubocop:
+  name: rubocop
+  downloads: 159048832
+  current_version: 1.15.0
+  authors: Bozhidar Batsov, Jonas Arvidsson, Yuji Nakayama
+  description: |2
+        RuboCop is a Ruby code style checking and code formatting tool.
+        It aims to enforce the community-driven Ruby Style Guide.
+  licenses:
+  - MIT
+  bug_tracker_url: https://github.com/rubocop/rubocop/issues
+  changelog_url:
+  documentation_url: https://docs.rubocop.org/rubocop/1.15/
+  homepage_url: https://rubocop.org/
+  mailing_list_url:
+  source_code_url: https://github.com/rubocop/rubocop/
+  wiki_url:
+  created_at: '2018-01-03T01:34:12.800Z'
+  updated_at: '2021-05-23T01:06:42.080Z'
+  first_release_on: '2012-05-03'
+  latest_release_on: '2021-05-17'
+  releases_count: 177
+  reverse_dependencies_count: 9464
+  quarterly_release_counts:
+    2012-2: 1
+    2012-4: 1
+    2013-1: 4
+    2013-2: 18
+    2013-3: 8
+    2013-4: 4
+    2014-1: 5
+    2014-2: 6
+    2014-3: 4
+    2014-4: 3
+    2015-1: 2
+    2015-2: 5
+    2015-3: 4
+    2015-4: 2
+    2016-1: 6
+    2016-2: 3
+    2016-3: 3
+    2016-4: 4
+    2017-1: 3
+    2017-2: 3
+    2017-3: 1
+    2017-4: 3
+    2018-1: 2
+    2018-2: 5
+    2018-3: 6
+    2018-4: 3
+    2019-1: 6
+    2019-2: 9
+    2019-3: 3
+    2019-4: 4
+    2020-1: 3
+    2020-2: 7
+    2020-3: 9
+    2020-4: 16
+    2021-1: 7
+    2021-2: 4
+rspec:
+  name: rspec
+  downloads: 540209012
+  current_version: 3.10.0
+  authors: Steven Baker, David Chelimsky, Myron Marston
+  description: BDD for Ruby
+  licenses:
+  - MIT
+  bug_tracker_url: https://github.com/rspec/rspec/issues
+  changelog_url:
+  documentation_url: https://rspec.info/documentation/
+  homepage_url: http://github.com/rspec
+  mailing_list_url: https://groups.google.com/forum/#!forum/rspec
+  source_code_url: https://github.com/rspec/rspec
+  wiki_url:
+  created_at: '2018-01-03T01:32:39.960Z'
+  updated_at: '2021-05-25T16:52:58.302Z'
+  first_release_on: '2005-08-11'
+  latest_release_on: '2020-10-30'
+  releases_count: 167
+  reverse_dependencies_count: 55525
+  quarterly_release_counts:
+    2005-3: 9
+    2006-1: 4
+    2006-2: 14
+    2006-3: 7
+    2006-4: 7
+    2007-1: 4
+    2007-2: 11
+    2007-3: 3
+    2007-4: 2
+    2008-1: 2
+    2008-2: 1
+    2008-3: 2
+    2008-4: 6
+    2009-1: 4
+    2009-2: 5
+    2009-3: 1
+    2009-4: 1
+    2010-1: 14
+    2010-2: 11
+    2010-3: 6
+    2010-4: 8
+    2011-1: 2
+    2011-2: 5
+    2011-4: 4
+    2012-1: 3
+    2012-2: 1
+    2012-3: 1
+    2012-4: 1
+    2013-1: 1
+    2013-2: 1
+    2013-3: 2
+    2013-4: 2
+    2014-1: 2
+    2014-2: 4
+    2014-3: 1
+    2015-1: 1
+    2015-2: 1
+    2015-4: 1
+    2016-1: 2
+    2016-2: 2
+    2016-3: 1
+    2016-4: 2
+    2017-2: 1
+    2017-4: 1
+    2018-3: 1
+    2019-4: 1
+    2020-4: 1
+minitest:
+  name: minitest
+  downloads: 380211284
+  current_version: 5.14.4
+  authors: Ryan Davis
+  description: |-
+    minitest provides a complete suite of testing facilities supporting
+    TDD, BDD, mocking, and benchmarking.
+
+        "I had a class with Jim Weirich on testing last week and we were
+         allowed to choose our testing frameworks. Kirk Haines and I were
+         paired up and we cracked open the code for a few test
+         frameworks...
+
+         I MUST say that minitest is *very* readable / understandable
+         compared to the 'other two' options we looked at. Nicely done and
+         thank you for helping us keep our mental sanity."
+
+        -- Wayne E. Seguin
+
+    minitest/test is a small and incredibly fast unit testing framework.
+    It provides a rich set of assertions to make your tests clean and
+    readable.
+
+    minitest/spec is a functionally complete spec engine. It hooks onto
+    minitest/test and seamlessly bridges test assertions over to spec
+    expectations.
+
+    minitest/benchmark is an awesome way to assert the performance of your
+    algorithms in a repeatable manner. Now you can assert that your newb
+    co-worker doesn't replace your linear algorithm with an exponential
+    one!
+
+    minitest/mock by Steven Baker, is a beautifully tiny mock (and stub)
+    object framework.
+
+    minitest/pride shows pride in testing and adds coloring to your test
+    output. I guess it is an example of how to write IO pipes too. :P
+
+    minitest/test is meant to have a clean implementation for language
+    implementors that need a minimal set of methods to bootstrap a working
+    test suite. For example, there is no magic involved for test-case
+    discovery.
+
+        "Again, I can't praise enough the idea of a testing/specing
+         framework that I can actually read in full in one sitting!"
+
+        -- Piotr Szotkowski
+
+    Comparing to rspec:
+
+        rspec is a testing DSL. minitest is ruby.
+
+        -- Adam Hawkins, "Bow Before MiniTest"
+
+    minitest doesn't reinvent anything that ruby already provides, like:
+    classes, modules, inheritance, methods. This means you only have to
+    learn ruby to use minitest and all of your regular OO practices like
+    extract-method refactorings still apply.
+  licenses:
+  - MIT
+  bug_tracker_url: https://github.com/seattlerb/minitest/issues
+  changelog_url:
+  documentation_url:
+  homepage_url: https://github.com/seattlerb/minitest
+  mailing_list_url:
+  source_code_url:
+  wiki_url:
+  created_at: '2018-01-03T00:41:42.780Z'
+  updated_at: '2021-05-23T10:53:44.621Z'
+  first_release_on: '2008-10-09'
+  latest_release_on: '2021-02-24'
+  releases_count: 119
+  reverse_dependencies_count: 11539
+  quarterly_release_counts:
+    2008-4: 1
+    2009-1: 1
+    2009-2: 3
+    2010-1: 2
+    2010-3: 3
+    2010-4: 3
+    2011-2: 6
+    2011-3: 5
+    2011-4: 7
+    2012-1: 6
+    2012-2: 6
+    2012-3: 4
+    2012-4: 6
+    2013-1: 6
+    2013-2: 12
+    2013-3: 2
+    2013-4: 2
+    2014-1: 5
+    2014-2: 4
+    2014-3: 3
+    2014-4: 2
+    2015-1: 1
+    2015-2: 3
+    2015-3: 2
+    2015-4: 2
+    2016-1: 1
+    2016-2: 1
+    2016-3: 2
+    2016-4: 2
+    2017-2: 1
+    2017-3: 1
+    2017-4: 1
+    2018-1: 4
+    2019-3: 3
+    2019-4: 1
+    2020-1: 1
+    2020-2: 1
+    2020-3: 1
+    2021-1: 2

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe ApplicationHelper, type: :helper do
+  fixtures :all
+
   describe "#expiring_cache" do
     it "builds a cache key based on given label, time, and release version" do
       allow(ENV).to receive(:[]).with("HEROKU_RELEASE_VERSION").and_return("v42")

--- a/spec/helpers/component_helpers_spec.rb
+++ b/spec/helpers/component_helpers_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe ComponentHelpers, type: :helper do
+  fixtures :all
+
   let(:group) do
     CategoryGroup.create! permalink: "unimportant", name: "unimportant"
   end

--- a/spec/helpers/stats_helpers_spec.rb
+++ b/spec/helpers/stats_helpers_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe StatsHelpers, type: :helper do
+RSpec.describe StatsHelpers, :clean_database, type: :helper do
   describe "#percentiles" do
     it "returns a hash of number distribution percentiles" do
       Factories.project "example"

--- a/spec/helpers/stats_helpers_spec.rb
+++ b/spec/helpers/stats_helpers_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe StatsHelpers, :clean_database, type: :helper do
+  fixtures :all
+
   describe "#percentiles" do
     it "returns a hash of number distribution percentiles" do
       Factories.project "example"

--- a/spec/integration/catalog_import_spec.rb
+++ b/spec/integration/catalog_import_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe CatalogImport do
+RSpec.describe CatalogImport, :clean_database do
   let(:catalog_data) { Oj.load Rails.root.join("lib", "base-catalog.json").read }
 
   let(:category_data) { catalog_data["category_groups"].map { |g| g["categories"] }.flatten }

--- a/spec/integration/catalog_import_spec.rb
+++ b/spec/integration/catalog_import_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe CatalogImport, :clean_database do
+  fixtures :all
+
   let(:catalog_data) { Oj.load Rails.root.join("lib", "base-catalog.json").read }
 
   let(:category_data) { catalog_data["category_groups"].map { |g| g["categories"] }.flatten }

--- a/spec/integration/github_client_spec.rb
+++ b/spec/integration/github_client_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe GithubClient, :real_http do
+  fixtures :all
+
   let(:client) { described_class.new }
 
   describe "#fetch_repository" do

--- a/spec/integration/github_repo_update_spec.rb
+++ b/spec/integration/github_repo_update_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe GithubRepoUpdateJob, :real_http do
+  fixtures :all
+
   let(:job) { described_class.new }
   let(:do_perform) { job.perform repo_path }
 

--- a/spec/integration/i18n_spec.rb
+++ b/spec/integration/i18n_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe I18n do
+  fixtures :all
+
   describe "#metrics" do
     it "has a valid icon for each metric" do
       expect(described_class.t(:metrics).map { |_, t| t }).to all(satisfy { |t| t[:icon].present? })

--- a/spec/integration/project_sync_spec.rb
+++ b/spec/integration/project_sync_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Full Project Sync", :real_http, :sidekiq_inline do
+RSpec.describe "Full Project Sync", :clean_database, :real_http, :sidekiq_inline do
   describe "for Rubygem-based projects", vcr: { cassette_name: "full-project-sync-from-gem" } do
     let(:do_perform) { RubygemUpdateJob.perform_async "thread_safe" }
 

--- a/spec/integration/project_sync_spec.rb
+++ b/spec/integration/project_sync_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe "Full Project Sync", :clean_database, :real_http, :sidekiq_inline do
+  fixtures :all
+
   describe "for Rubygem-based projects", vcr: { cassette_name: "full-project-sync-from-gem" } do
     let(:do_perform) { RubygemUpdateJob.perform_async "thread_safe" }
 

--- a/spec/integration/rubygem_update_spec.rb
+++ b/spec/integration/rubygem_update_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe RubygemUpdateJob, :real_http do
+  fixtures :all
+
   let(:job) { described_class.new }
   let(:do_perform) { job.perform gem_name }
 

--- a/spec/jobs/catalog_import_job_spec.rb
+++ b/spec/jobs/catalog_import_job_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe CatalogImportJob, type: :job do
+  fixtures :all
+
   let(:job) { described_class.new }
 
   describe "#perform" do

--- a/spec/jobs/category_ranking_job_spec.rb
+++ b/spec/jobs/category_ranking_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe CategoryRankingJob, type: :job do
+RSpec.describe CategoryRankingJob, :clean_database, type: :job do
   let(:job) { described_class.new }
 
   before do

--- a/spec/jobs/category_ranking_job_spec.rb
+++ b/spec/jobs/category_ranking_job_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe CategoryRankingJob, :clean_database, type: :job do
+  fixtures :all
+
   let(:job) { described_class.new }
 
   before do

--- a/spec/jobs/github_repo_update_job_spec.rb
+++ b/spec/jobs/github_repo_update_job_spec.rb
@@ -4,6 +4,8 @@ require "rails_helper"
 
 # rubocop:disable RSpec/MultipleMemoizedHelpers
 RSpec.describe GithubRepoUpdateJob, type: :job do
+  fixtures :all
+
   let(:repo_data) do
     json = Rails.root.join("spec", "fixtures", "graphql_responses", "github", "rails.json").read
     GithubClient::RepositoryData.new Oj.load(json)

--- a/spec/jobs/project_score_job_spec.rb
+++ b/spec/jobs/project_score_job_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe ProjectScoreJob, :clean_database, type: :job do
+  fixtures :all
+
   let(:job) { described_class.new }
 
   describe "#perform" do

--- a/spec/jobs/project_score_job_spec.rb
+++ b/spec/jobs/project_score_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe ProjectScoreJob, type: :job do
+RSpec.describe ProjectScoreJob, :clean_database, type: :job do
   let(:job) { described_class.new }
 
   describe "#perform" do

--- a/spec/jobs/project_search_index_job_spec.rb
+++ b/spec/jobs/project_search_index_job_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe ProjectSearchIndexJob, type: :job do
+  fixtures :all
+
   let(:job) do
     described_class.new
   end

--- a/spec/jobs/project_update_job_spec.rb
+++ b/spec/jobs/project_update_job_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe ProjectUpdateJob, type: :job do
+  fixtures :all
+
   let(:job) { described_class.new }
   let(:do_perform) { job.perform permalink }
   let(:permalink) { "rspec" }

--- a/spec/jobs/remote_update_scheduler_job_spec.rb
+++ b/spec/jobs/remote_update_scheduler_job_spec.rb
@@ -6,16 +6,10 @@ RSpec.describe RemoteUpdateSchedulerJob, type: :job do
   let(:job) { described_class.new }
   let(:do_perform) { job.perform }
 
-  it "does not queue gem updates when no gems need an update" do
-    allow(Rubygem).to receive(:update_batch).and_return([])
-    expect(RubygemUpdateJob).not_to receive(:perform_async)
-    do_perform
-  end
-
-  it "does not queue repo updates when no repos need an update" do
-    allow(GithubRepo).to receive(:update_batch).and_return([])
-    expect(GithubRepoUpdateJob).not_to receive(:perform_async)
-    do_perform
+  def pluckable_relation(attribute, result)
+    relation = instance_double ActiveRecord::Relation
+    allow(relation).to receive(:pluck).with(attribute).and_return(result)
+    relation
   end
 
   it "purges all github repos without projects from the db" do
@@ -25,19 +19,31 @@ RSpec.describe RemoteUpdateSchedulerJob, type: :job do
     do_perform
   end
 
+  it "does not queue gem updates when no gems need an update" do
+    allow(Rubygem).to receive(:update_batch).and_return(pluckable_relation(:name, []))
+    expect(RubygemUpdateJob).not_to receive(:perform_async)
+    do_perform
+  end
+
+  it "does not queue repo updates when no repos need an update" do
+    allow(GithubRepo).to receive(:update_batch).and_return(pluckable_relation(:path, []))
+    expect(GithubRepoUpdateJob).not_to receive(:perform_async)
+    do_perform
+  end
+
   # I am not aware of a better way to test consecutive calls here,
   # if you know one, please send a PR :)
   #
   # rubocop:disable RSpec/MultipleExpectations
   it "enqueues updates for all gems returned in the update_batch" do
-    allow(Rubygem).to receive(:update_batch).and_return(%w[foo bar])
+    allow(Rubygem).to receive(:update_batch).and_return(pluckable_relation(:name, %w[foo bar]))
     expect(RubygemUpdateJob).to receive(:perform_async).with("foo")
     expect(RubygemUpdateJob).to receive(:perform_async).with("bar")
     do_perform
   end
 
   it "enqueues updates for all github repos returned in the update_batch" do
-    allow(GithubRepo).to receive(:update_batch).and_return(%w[foo/bar hello/world])
+    allow(GithubRepo).to receive(:update_batch).and_return(pluckable_relation(:path, %w[foo/bar hello/world]))
     expect(GithubRepoUpdateJob).to receive(:perform_async).with("foo/bar")
     expect(GithubRepoUpdateJob).to receive(:perform_async).with("hello/world")
     do_perform

--- a/spec/jobs/remote_update_scheduler_job_spec.rb
+++ b/spec/jobs/remote_update_scheduler_job_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe RemoteUpdateSchedulerJob, type: :job do
+  fixtures :all
+
   let(:job) { described_class.new }
   let(:do_perform) { job.perform }
 

--- a/spec/jobs/rubygem_downloads_persistence_job_spec.rb
+++ b/spec/jobs/rubygem_downloads_persistence_job_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe RubygemDownloadsPersistenceJob, :clean_database, type: :job do
+  fixtures :all
+
   let(:job) { described_class.new }
   let(:do_perform) { job.perform }
 

--- a/spec/jobs/rubygem_downloads_persistence_job_spec.rb
+++ b/spec/jobs/rubygem_downloads_persistence_job_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe RubygemDownloadsPersistenceJob, type: :job do
+RSpec.describe RubygemDownloadsPersistenceJob, :clean_database, type: :job do
   let(:job) { described_class.new }
   let(:do_perform) { job.perform }
 

--- a/spec/jobs/rubygem_trends_job_spec.rb
+++ b/spec/jobs/rubygem_trends_job_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe RubygemTrendsJob, type: :job do
+  fixtures :all
+
   let(:job) { described_class.new }
   let(:do_perform) { job.perform date }
   let(:date) { Time.current.to_date }

--- a/spec/jobs/rubygem_update_job_spec.rb
+++ b/spec/jobs/rubygem_update_job_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe RubygemUpdateJob, type: :job do
+  fixtures :all
+
   let(:job) { described_class.new }
   let(:do_perform) { job.perform gem_name }
   let(:gem_name) { "rspec" }

--- a/spec/jobs/rubygems_sync_job_spec.rb
+++ b/spec/jobs/rubygems_sync_job_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe RubygemsSyncJob, type: :job do
+  fixtures :all
+
   let(:job) { described_class.new }
 
   describe "remote spec fetching" do

--- a/spec/models/blog_spec.rb
+++ b/spec/models/blog_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Blog, type: :model do
+  fixtures :all
+
   describe "with posts from fixtures" do
     let(:root) { Rails.root.join("spec", "fixtures", "blog_posts") }
     let(:blog) { described_class.new root: root }

--- a/spec/models/category_group_spec.rb
+++ b/spec/models/category_group_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe CategoryGroup, type: :model do
+  fixtures :all
+
   describe ".for_welcome_page" do
     subject(:scope) { described_class.for_welcome_page.to_sql }
 

--- a/spec/models/category_group_spec.rb
+++ b/spec/models/category_group_spec.rb
@@ -4,13 +4,8 @@ require "rails_helper"
 
 RSpec.describe CategoryGroup, type: :model do
   describe ".for_welcome_page" do
-    it "returns all CategoryGroups ordered by name" do
-      described_class.create! [
-        { permalink: "one", name: "Group1" },
-        { permalink: "two", name: "Group2" },
-        { permalink: "three", name: "Group3" },
-      ]
-      expect(described_class.for_welcome_page.pluck(:name)).to be == %w[Group1 Group2 Group3]
-    end
+    subject(:scope) { described_class.for_welcome_page.to_sql }
+
+    it { is_expected.to be == described_class.order(name: :asc).includes(:categories).to_sql }
   end
 end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Category, type: :model do
+  fixtures :all
+
   let(:group) do
     CategoryGroup.create! permalink: "unimportant", name: "unimportant"
   end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Category, type: :model do
   end
 
   describe ".by_rank" do
-    it "returns only ranked categories, ordered by rank" do
+    it "returns only ranked categories, ordered by rank", :clean_database do
       described_class.create! permalink: "A", name: "A", category_group: group
       described_class.create! permalink: "B", name: "B", category_group: group, rank: 2
       described_class.create! permalink: "C", name: "C", category_group: group, rank: 1
@@ -49,7 +49,7 @@ RSpec.describe Category, type: :model do
   end
 
   describe ".featured" do
-    it "returns up to 16 ranked categories" do
+    it "returns up to 16 ranked categories", :clean_database do
       20.times do |i|
         described_class.create! permalink: (i + 1).to_s,
                                 name: (i + 1).to_s,

--- a/spec/models/display_mode_spec.rb
+++ b/spec/models/display_mode_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe DisplayMode, type: :model do
+  fixtures :all
+
   describe "#current" do
     it "is the default when none requested" do
       expect(described_class.new.current).to be == "full"

--- a/spec/models/docs_spec.rb
+++ b/spec/models/docs_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Docs do
+  fixtures :all
+
   let(:docs) { described_class.new }
 
   describe described_class::Page do

--- a/spec/models/github/readme_spec.rb
+++ b/spec/models/github/readme_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Github::Readme, type: :model do
+  fixtures :all
+
   let(:repo) do
     GithubRepo.new(
       path:           "foo/bar",

--- a/spec/models/github_ignore_spec.rb
+++ b/spec/models/github_ignore_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe GithubIgnore, type: :model do
+  fixtures :all
+
   let(:path) { "foo/bar" }
 
   describe ".track!" do

--- a/spec/models/github_repo_spec.rb
+++ b/spec/models/github_repo_spec.rb
@@ -12,23 +12,22 @@ RSpec.describe GithubRepo, type: :model do
   end
 
   describe ".update_batch" do
-    before do
-      create_repo! path: "foo/up-to-date", updated_at: 23.hours.ago
-      create_repo! path: "foo/outdated1", updated_at: 27.hours.ago
-      create_repo! path: "foo/outdated2", updated_at: 26.hours.ago
+    subject(:scope) { described_class.update_batch.to_sql }
+
+    let(:expected_sql) do
+      described_class.where("fetched_at < ? ", 24.hours.ago.utc)
+                     .order(fetched_at: :asc)
+                     .limit((described_class.count / 24.0).ceil)
+                     .to_sql
     end
 
-    it "contains a subset of repos that should be updated" do
-      expect(described_class.update_batch).to match %w[foo/outdated1]
-    end
-
-    it "the subset grows with to the total count of repos" do
-      24.times do |i|
-        create_repo! path: "foo/outdated#{i + 3}", updated_at: 25.hours.ago
+    around do |example|
+      Timecop.freeze Time.current do
+        example.run
       end
-
-      expect(described_class.update_batch).to match %w[foo/outdated1 foo/outdated2]
     end
+
+    it { is_expected.to be == expected_sql }
   end
 
   describe ".without_projects" do

--- a/spec/models/github_repo_spec.rb
+++ b/spec/models/github_repo_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe GithubRepo, type: :model do
+  fixtures :all
+
   def create_repo!(path:, updated_at: 1.day.ago)
     GithubRepo.create! path:             path,
                        updated_at:       updated_at,

--- a/spec/models/github_spec.rb
+++ b/spec/models/github_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Github, type: :model do
+  fixtures :all
+
   describe ".detect_repo_name" do
     {
       [nil]                                                  => nil,

--- a/spec/models/project/fork_detector_spec.rb
+++ b/spec/models/project/fork_detector_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Project::ForkDetector, type: :model do
+  fixtures :all
+
   let(:detector) { described_class.new(project) }
 
   describe "for a project that references a significantly more popular gem via it's github repo" do

--- a/spec/models/project/health/checks_spec.rb
+++ b/spec/models/project/health/checks_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Project::Health::Checks, type: :model do
+  fixtures :all
+
   describe "GITHUB_REPO_ARCHIVED" do
     let(:check) { described_class::GITHUB_REPO_ARCHIVED }
 

--- a/spec/models/project/health_spec.rb
+++ b/spec/models/project/health_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Project::Health, type: :model do
+  fixtures :all
+
   def status(key: :healthy, level: :green, icon: :heartbeat, &block)
     Project::Health::Status.new key, level, icon, &block
   end

--- a/spec/models/project/order_spec.rb
+++ b/spec/models/project/order_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Project::Order, type: :model do
+  fixtures :all
+
   describe described_class::Direction do
     describe "#key" do
       it "is a composite of given group and attribute" do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -3,9 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Project, type: :model do
+  fixtures :all
+
   it "does not allow mismatches between permalink and rubygem name" do
-    project = described_class.create! permalink: "simplecov"
-    expect { project.update! rubygem_name: "rails" }.to raise_error(
+    project = described_class.create! permalink: "somegem"
+    expect { project.update! rubygem_name: "othergem" }.to raise_error(
       ActiveRecord::StatementInvalid,
       /check_project_permalink_and_rubygem_name_parity/
     )
@@ -46,12 +48,12 @@ RSpec.describe Project, type: :model do
     end
 
     it "omits bugfix_forks when given false" do
-      expect(described_class.with_bugfix_forks(false).pluck(:permalink)).to be == %w[regular]
+      expect(described_class.with_bugfix_forks(false).pluck(:permalink)).not_to include("forked")
     end
 
     it "includes bugfix_forks when given true" do
       scope = described_class.with_bugfix_forks(true).order(permalink: :asc)
-      expect(scope.pluck(:permalink)).to be == %w[forked regular]
+      expect(scope.pluck(:permalink)).to include("forked", "regular")
     end
   end
 

--- a/spec/models/rubygem/download_stat/timeseries_spec.rb
+++ b/spec/models/rubygem/download_stat/timeseries_spec.rb
@@ -4,6 +4,8 @@ require "rails_helper"
 
 # rubocop:disable RSpec/ExampleLength Data-heavy stuff, and I prefer readability over brevity on those
 RSpec.describe Rubygem::DownloadStat::Timeseries, type: :model do
+  fixtures :all
+
   let(:rubygem) { Factories.rubygem "example" }
 
   before do

--- a/spec/models/rubygem/download_stat_spec.rb
+++ b/spec/models/rubygem/download_stat_spec.rb
@@ -4,6 +4,8 @@ require "rails_helper"
 
 # rubocop:disable RSpec/ExampleLength Data-heavy stuff, and I prefer readability over brevity on those
 RSpec.describe Rubygem::DownloadStat, type: :model do
+  fixtures :all
+
   let(:rubygem) { Factories.rubygem "example" }
 
   it "has a unique index on rubygem name and date" do

--- a/spec/models/rubygem/trend/navigation_spec.rb
+++ b/spec/models/rubygem/trend/navigation_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Rubygem::Trend::Navigation, type: :model do
+  fixtures :all
+
   let(:rubygem) { Factories.rubygem "example" }
 
   before do

--- a/spec/models/rubygem/trend_spec.rb
+++ b/spec/models/rubygem/trend_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Rubygem::Trend, type: :model do
+  fixtures :all
+
   describe ".for_date" do
     before do
       Factories.project "a"

--- a/spec/models/rubygem_dependency_spec.rb
+++ b/spec/models/rubygem_dependency_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe RubygemDependency, type: :model do
+  fixtures :all
+
   subject(:model) { described_class.new }
 
   describe described_class::Collection do

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Search, type: :model do
+  fixtures :all
+
   describe "#query" do
     it "is the cleaned up search query" do
       expect(described_class.new(" foo bar ").query).to be == "foo bar"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -92,6 +92,13 @@ RSpec.configure do |config|
     Capybara.current_session.current_window.resize_to 450, 900
   end
 
+  # Some specs assume a clean database, which conflicts with some
+  # baseline data provided by fixtures. In this case, this annotation
+  # ensures the fixtures get purged before each example.
+  config.before clean_database: true do
+    DatabaseCleaner.clean_with :truncation
+  end
+
   # Fail js capybara tests when the browser log has JS errors.
   # Snippet courtesy of:
   # https://medium.com/@coorasse/catch-javascript-errors-in-your-system-tests-89c2fe6773b1

--- a/spec/requests/api/projects/compare_spec.rb
+++ b/spec/requests/api/projects/compare_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe "Project Comparison API", type: :request do
+  fixtures :all
+
   def do_request
     get "/api/projects/compare/#{query}"
   end

--- a/spec/routes/blog_routes_spec.rb
+++ b/spec/routes/blog_routes_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe "Blog routes", type: :routing do
+  fixtures :all
+
   it "routes valid post slugs correctly" do
     expect(get("/blog/2018-12-01/foo-bar")).to route_to(
       controller: "blog",

--- a/spec/routes/project_routes_spec.rb
+++ b/spec/routes/project_routes_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe "Project routes", type: :routing do
+  fixtures :all
+
   it "routes rubygems-based projects to the project page" do
     expect(get("/projects/simplecov")).to route_to(
       controller: "projects",

--- a/spec/services/catalog_import_spec.rb
+++ b/spec/services/catalog_import_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe CatalogImport, type: :service do
+  fixtures :all
+
   describe ".perform" do
     let(:import) do
       instance_double(described_class, perform: nil)

--- a/spec/services/cron_spec.rb
+++ b/spec/services/cron_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Cron, type: :service do
+  fixtures :all
+
   let(:cron) { described_class.new }
 
   def time_at(hour)

--- a/spec/services/github_client/repository_data_spec.rb
+++ b/spec/services/github_client/repository_data_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe GithubClient::RepositoryData, type: :service do
+  fixtures :all
+
   def data(fields = {})
     described_class.new("data" => { "repository" => fields.deep_stringify_keys })
   end

--- a/spec/services/github_client_spec.rb
+++ b/spec/services/github_client_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe GithubClient do
+  fixtures :all
+
   let(:token) { "Hello World" }
   let(:client) { described_class.new token: token }
 

--- a/spec/services/http_service_spec.rb
+++ b/spec/services/http_service_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe HttpService do
+  fixtures :all
+
   describe ".client" do
     let(:client) { described_class.client }
 

--- a/spec/services/meili_search_spec.rb
+++ b/spec/services/meili_search_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe MeiliSearch, type: :service do
+  fixtures :all
+
   let(:search) do
     described_class.new(url: "https://example.com")
   end


### PR DESCRIPTION
I'm currently working on bringing display of project reverse dependencies to the site and acceptance testing this with realistic data proved fairly cumbersome, so I decided to sidetrack and add some baseline test data via fixtures generated from real projects to the spec suite.

This should also help with improving the automated visual regression tests of the styleguide components, by filling them with more realistic data.

Last but not least, this also provides a simple way to get some sample data for local development, reflected by updating the README accordingly.

I ran into some trouble because some specs in the suite depend on a clean database (mostly stats/ranking related stuff that takes the whole dataset into account) so the introduction of fixtures broke those. I adjusted some specs manually but the majority of cases were handled simply by cleaning the database in these cases manually, which turned out to be much less involved.