### PR TITLE
Display reverse dependencies

### DIFF
--- a/app/assets/stylesheets/components/project.sass
+++ b/app/assets/stylesheets/components/project.sass
@@ -24,7 +24,7 @@
     @extend .column, .is-3-tablet, .is-6-mobile
     // Align content to bottom
     align-self: flex-end
-    strong
+    .level
       // Compensate for default icon padding in heading above
       margin-left: 5px
       a

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,10 +1,38 @@
 # frozen_string_literal: true
 
 class ProjectsController < ApplicationController
+  before_action :find_project
+
   def show
-    @project = Project.strict_loading.find_for_show! params[:id]
     redirect_to "/projects/#{@project.permalink}" if @project.permalink != params[:id]
 
     @dependencies = RubygemDependency.for_project @project
   end
+
+  def reverse_dependencies
+    @display_mode = DisplayMode.new params[:display], default: "compact"
+
+    @dependencies = @project
+                    .reverse_dependencies
+                    .includes_associations
+                    .with_bugfix_forks(show_forks?)
+                    .order("score DESC NULLS LAST")
+                    .page(params[:page])
+  end
+
+  private
+
+  def find_project
+    @project = Project.strict_loading.find_for_show! params[:id]
+  end
+
+  def show_forks?
+    params[:show_forks].present? && params[:show_forks] == "true"
+  end
+  helper_method :show_forks?
+
+  def current_order
+    @current_order ||= Project::Order.new order: params[:order], directions: Project::Order::DEFAULT_DIRECTIONS
+  end
+  helper_method :current_order
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -144,6 +144,9 @@ class Project < ApplicationRecord
     super Github.normalize_path(permalink)
   end
 
+  # For now we just go with the permalink as the name. In the future
+  # this might support canonical human names (i.e. RSpec instead of rspec
+  # derived from the gem)
   def name
     permalink
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -19,6 +19,13 @@ class Project < ApplicationRecord
              optional:    true,
              inverse_of:  :project
 
+  # Projects that are using this project as a dependency on the
+  # rubygem definition
+  has_many :reverse_dependencies,
+           -> { with_score.order(score: :desc) },
+           through: :rubygem,
+           source:  :reverse_dependency_projects
+
   belongs_to :github_repo,
              primary_key: :path,
              foreign_key: :github_repo_path,

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -144,6 +144,10 @@ class Project < ApplicationRecord
     super Github.normalize_path(permalink)
   end
 
+  def name
+    permalink
+  end
+
   def github_only?
     permalink.include? "/"
   end

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -29,12 +29,21 @@ class Rubygem < ApplicationRecord
            inverse_of:  :rubygem,
            dependent:   :destroy
 
+  # Reverse dependencies of this gem, so gems that use this one
+  # as a dependency
   has_many :reverse_dependencies,
            -> { order(rubygem_name: :asc) },
            class_name:  "RubygemDependency",
            foreign_key: :dependency_name,
            inverse_of:  :dependency,
            dependent:   :destroy
+
+  # The corresponding ruby toolbox project record for the corresponding
+  # reverse dependency rubygem
+  has_many :reverse_dependency_projects,
+           through:    :reverse_dependencies,
+           source:     :depending_project,
+           class_name: "Project"
 
   scope :update_batch, lambda {
     where("fetched_at < ? ", 24.hours.ago.utc)

--- a/app/models/rubygem_dependency.rb
+++ b/app/models/rubygem_dependency.rb
@@ -29,6 +29,13 @@ class RubygemDependency < ApplicationRecord
              # Optional because we might not know about this gem
              optional:    true
 
+  belongs_to :depending_project,
+             class_name:  "Project",
+             optional:    true,
+             foreign_key: :rubygem_name,
+             primary_key: :rubygem_name,
+             inverse_of:  false
+
   belongs_to :dependency_project,
              class_name:  "Project",
              optional:    true,

--- a/app/views/components/project/_metric.html.slim
+++ b/app/views/components/project/_metric.html.slim
@@ -9,3 +9,6 @@
     strong
       = link_to_docs_if_exists docs_page do
         = pretty_metric_value value
+      - if @project && key == :rubygem_reverse_dependencies_count
+        a.button.is-small href=reverse_dependencies_project_path(@project)
+          span.icon: i.fa.fa-search

--- a/app/views/components/project/_metric.html.slim
+++ b/app/views/components/project/_metric.html.slim
@@ -6,9 +6,13 @@
         span.icon
           i.fa class=icon
         span= metric_label key
-    strong
-      = link_to_docs_if_exists docs_page do
-        = pretty_metric_value value
+    .level.is-mobile
+      .level-left: .level-item
+        strong= link_to_docs_if_exists docs_page do
+          = pretty_metric_value value
       - if @project && key == :rubygem_reverse_dependencies_count
-        a.button.is-small href=reverse_dependencies_project_path(@project)
-          span.icon: i.fa.fa-search
+        .level-right: .level-item
+          .field.has-addons
+            p.control
+              a.button.is-small.tooltip.is-tooltip-bottom href=reverse_dependencies_project_path(@project) data-tooltip="Browse gems that depend on this project"
+                span.icon: i.fa.fa-search

--- a/app/views/pages/components/project_comparison.html.slim
+++ b/app/views/pages/components/project_comparison.html.slim
@@ -3,7 +3,7 @@
     p.heading= link_to "Ruby Toolbox UI Components Styleguide", "/pages/components"
     h2= current_page.split("/").last.humanize
 
-- projects = Project.for_display.order(score: :desc).limit(100).sample(15)
+- projects = Project.for_display.order(permalink: :asc).limit(100)
 
 = component_example "Project Comparison" do
   = project_comparison projects

--- a/app/views/projects/reverse_dependencies.html.slim
+++ b/app/views/projects/reverse_dependencies.html.slim
@@ -1,0 +1,45 @@
+- content_for :title, "Reverse Dependencies of #{@project.permalink}"
+
+.hero: section.section: .container
+  .columns
+    .column
+      p.heading Project
+      h2
+        a href=reverse_dependencies_project_path(@project)
+          span Reverse Dependencies for&nbsp;
+          // Note that rails url helpers escape slashes (as seen in github-based projects) and this breaks.
+        strong: a href="/projects/#{@project.permalink}"
+          = @project.permalink
+      p.description
+        | The projects listed here declare #{@project.name} as a runtime or development dependency
+
+section.section: .container
+  .columns: .column.projects
+
+    .level.project-search-nav
+      .level-left: .level-item
+        span &nbsp;
+      .level-right
+        .level-item= project_display_picker @display_mode
+        .level-item
+          .field.has-addons
+            .control
+              - if show_forks?
+                a.button.bugfix-forks-toggle href=link_with_preserved_display_settings(show_forks: "false")
+                  span.icon: i.fa.fa-check-square
+                  span Bugfix forks are <strong>shown</strong>
+
+              - else
+                a.button.bugfix-forks-toggle href=link_with_preserved_display_settings(show_forks: "true")
+                  span.icon: i.fa.fa-square-o
+                  span Bugfix forks are <strong>hidden</strong>
+
+            .control
+              a.button.bugfix-forks-help href=page_path("docs/features/bugfix_forks")
+                span.icon: i.fa.fa-question-circle
+
+    .columns: .column= paginate @dependencies
+
+    = render "projects/listing", projects: @dependencies, show_categories: true, display_mode: @display_mode
+
+    .columns: .column= paginate @dependencies

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,12 @@ Rails.application.routes.draw do
 
   resources :categories, only: %i[index show]
 
-  resources :projects, only: %i[show], constraints: { id: Patterns::ROUTE_PATTERN }
+  resources :projects, only: %i[show], constraints: { id: Patterns::ROUTE_PATTERN } do
+    member do
+      get :reverse_dependencies
+    end
+  end
+
   get "compare(/:id)", to: "comparisons#show", constraints: { id: /.*/ }, as: :comparison
   resources :trends, only: %i[index show]
 

--- a/spec/models/rubygem_dependency_spec.rb
+++ b/spec/models/rubygem_dependency_spec.rb
@@ -24,23 +24,37 @@ RSpec.describe RubygemDependency, type: :model do
   end
 
   describe "associations" do
-    it { is_expected.to belong_to(:rubygem) }
+    it {
+      expect(model).to belong_to(:rubygem)
+        .with_foreign_key(:rubygem_name)
+        .inverse_of(:rubygem_dependencies)
+    }
 
-    it "belongs to dependency optionally" do
+    it {
       expect(model).to belong_to(:dependency)
         .class_name("Rubygem")
         .with_foreign_key(:dependency_name)
         .optional
         .inverse_of(:reverse_dependencies)
-    end
+    }
 
-    it "belongs to dependency_project" do
+    it {
+      expect(model).to belong_to(:depending_project)
+        .class_name("Project")
+        .with_primary_key(:rubygem_name)
+        .with_foreign_key(:rubygem_name)
+        .inverse_of(false)
+        .optional
+    }
+
+    it {
       expect(model).to belong_to(:dependency_project)
         .class_name("Project")
+        .with_primary_key(:rubygem_name)
         .with_foreign_key(:dependency_name)
         .inverse_of(false)
         .optional
-    end
+    }
   end
 
   it { is_expected.to validate_inclusion_of(:type).in_array(described_class::TYPES) }


### PR DESCRIPTION
Based on the dependency data added via #854 for #891 as well as #938 to aid with feature-testing this, this makes reverse dependencies of a project browsable.

![Screen Shot 2021-09-30 at 22 52 04](https://user-images.githubusercontent.com/13972/135528761-68c38038-3c81-45b7-99f4-3bc071f11f97.png)

![Screenshot from 2021-09-30 22-52-45](https://user-images.githubusercontent.com/13972/135528787-b6d26fee-cd3a-496f-937d-e4342774f3c7.png)

There's still some followup work to be done, but that can take place in a followup PR:

* Add custom sorting
* Clean up the shared view and controller logic for the display mode and sorting stuff, which was for now just mostly copied over from the search feature