### PR TITLE
Ignore sidekiq CVE-2023-26141 until we can upgrade to redis 7

### DIFF
--- a/.bundler-audit.yml
+++ b/.bundler-audit.yml
@@ -1,0 +1,7 @@
+---
+ignore:
+  # See https://github.com/sidekiq/sidekiq/discussions/6039
+  # and https://github.com/sidekiq/sidekiq/issues/5594#issuecomment-1697001644
+  # The DoS vulnerability itself seems to only affect authenticated dashboard users
+  # in the first place though so it shouldn't pose that much of a problem for the time being
+  - CVE-2023-26141


### PR DESCRIPTION
See also https://github.com/sidekiq/sidekiq/discussions/6039

I also tried switching from redis enterprise cloud to heroku's redis, however that requires [to configure the connection to not verify SSL](https://devcenter.heroku.com/articles/connecting-heroku-redis#connecting-in-ruby) which I also don't want to do as, regardless of their explanation about self signed certificates. I do wonder though why those self signed cert's cannot be added to the dyno cert chain instead of completely deactivating SSL verification, but I suppose there's reasons.