### PR TITLE
Re-configure selenium headless chrome

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,7 +244,7 @@ GEM
       timeout
     net-smtp (0.4.0)
       net-protocol
-    nio4r (2.5.9)
+    nio4r (2.7.0)
     nokogiri (1.15.5)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
@@ -277,7 +277,7 @@ GEM
     psych (5.1.1.1)
       stringio
     public_suffix (5.0.3)
-    puma (6.4.0)
+    puma (6.4.2)
       nio4r (~> 2.0)
     racc (1.7.3)
     rack (2.2.8)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -60,6 +60,12 @@ Webdrivers.cache_time = 300
 # To clean up test output, comment this line to
 Capybara.server = :puma, { Silent: true }
 
+# Fixes a deprecation with Chrome 120+ - https://github.com/SeleniumHQ/selenium/issues/13112
+Capybara.register_driver :selenium_chrome_headless do |app|
+  Capybara::Selenium::Driver.new(app, browser: :chrome,
+                                      options: Selenium::WebDriver::Options.chrome(args: ["--headless=new"]))
+end
+
 Capybara.javascript_driver = :selenium_chrome_headless
 Capybara.javascript_driver = :selenium_chrome if ENV["CHROME_DEBUG"].present?
 


### PR DESCRIPTION
Resolves an issue that made the build fail from Chrome 120+. Ref: https://github.com/SeleniumHQ/selenium/issues/13112