### PR TITLE
Generate selective exports periodically and allow access via an endpoint

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 web:    bundle exec puma --threads 4:$RAILS_MAX_THREADS
 worker: bundle exec sidekiq --concurrency $RAILS_MAX_THREADS -q priority -q default
 # See https://devcenter.heroku.com/articles/release-phase
-release: bundle exec rake db:migrate
+release: bundle exec rake db:migrate release

--- a/app/controllers/database/exports_controller.rb
+++ b/app/controllers/database/exports_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+#
+# This controller gives access to (selective) database exports
+# by redirecting to their file storage URL
+#
+class Database::ExportsController < ApplicationController
+  def selective
+    # latest will raise active record not found when not available,
+    # whill will be treated by standard 404 handling
+    redirect_to Database::Export.latest.file_url, allow_other_host: true
+  end
+end

--- a/app/jobs/database/store_selective_export_job.rb
+++ b/app/jobs/database/store_selective_export_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+#
+# Creates a Database::SelectiveExport and saves it as a Database::Export
+#
+class Database::StoreSelectiveExportJob < ApplicationJob
+  def perform
+    Database::SelectiveExport.call do |export_file|
+      Database::Export.transaction do
+        Database::Export.new.tap do |export_record|
+          export_record.file.attach export_file
+          export_record.save!
+        end
+      end
+    end
+  end
+end

--- a/app/models/database/export.rb
+++ b/app/models/database/export.rb
@@ -7,6 +7,8 @@ class Database::Export < ApplicationRecord
   has_one_attached :file
 
   def self.latest
-    order(created_at: :desc).first
+    order(created_at: :desc).first!
   end
+
+  delegate :url, to: :file, prefix: true
 end

--- a/app/models/database/selective_export.rb
+++ b/app/models/database/selective_export.rb
@@ -108,9 +108,36 @@ class Database::SelectiveExport
     end
   end
 
-  def self.call
+  def self.banner
+    <<~BANNER
+      /*
+       *
+       * ===== The Ruby Toolbox - Selective database export =====
+       *
+       * * https://www.ruby-toolbox.com
+       * * https://github.com/rubytoolbox/rubytoolbox/
+       *
+       * This is a partial database export of the production data of the ruby toolbox,
+       * intended for getting a development environment based on realistic data up & running
+       * quickly without having to load the pretty massive full dataset, which can take several
+       * hours to import.
+       *
+       * More information can be found in https://github.com/rubytoolbox/rubytoolbox/issues/1205
+       *
+       + The latest export can be fetched from https://www.ruby-toolbox.com/database/exports/selective
+       *
+       * This export has been generated at #{Time.current.utc.iso8601}
+       *
+       */
+
+    BANNER
+  end
+
+  def self.call # rubocop:disable Metrics/MethodLength
     Tempfile.create("export.sql.gz") do |file|
       Zlib::GzipWriter.open(file.path) do |gz|
+        gz.write banner
+
         EXPORT_ORDER.each do |table_name|
           sql_inserts_from_scope Scopes.public_send(table_name) do |insert_sql|
             gz.write insert_sql

--- a/app/services/cron.rb
+++ b/app/services/cron.rb
@@ -12,6 +12,8 @@ class Cron
       RubygemsSyncJob.perform_async
     end
 
+    Database::StoreSelectiveExportJob.perform_async if (time.hour % 4).zero?
+
     RubygemDownloadsPersistenceJob.perform_async
     RemoteUpdateSchedulerJob.perform_async
     CatalogImportJob.perform_async

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -72,50 +72,27 @@
     {
       "warning_type": "Redirect",
       "warning_code": 18,
-      "fingerprint": "d97a1e1c0d455e1c36c99d03c57ebb2864e179204eb85027acbe366f39767e40",
+      "fingerprint": "e29dd8666800a3d78cc8ce69367dba383602156b04c4f5e3348ac8056884757c",
       "check_name": "Redirect",
       "message": "Possible unprotected redirect",
-      "file": "app/controllers/categories_controller.rb",
+      "file": "app/controllers/database/exports_controller.rb",
       "line": 11,
       "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
-      "code": "redirect_to(Category.find_for_show!(params[:id], :order => current_order))",
+      "code": "redirect_to(Database::Export.latest.file_url, :allow_other_host => true)",
       "render_path": null,
       "location": {
         "type": "method",
-        "class": "CategoriesController",
-        "method": "show"
+        "class": "Database::ExportsController",
+        "method": "selective"
       },
-      "user_input": "Category.find_for_show!(params[:id], :order => current_order)",
-      "confidence": "High",
-      "cwe_id": [
-        601
-      ],
-      "note": "It's shielded by categories in the db, not random user input"
-    },
-    {
-      "warning_type": "Redirect",
-      "warning_code": 18,
-      "fingerprint": "ed22db20a4f142a7a02c42d900289a3a66370249a1e438397eefe4e18119f656",
-      "check_name": "Redirect",
-      "message": "Possible unprotected redirect",
-      "file": "app/controllers/projects_controller.rb",
-      "line": 7,
-      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
-      "code": "redirect_to(\"/projects/#{Project.strict_loading.find_for_show!(params[:id]).permalink}\")",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "ProjectsController",
-        "method": "show"
-      },
-      "user_input": "Project.strict_loading.find_for_show!(params[:id]).permalink",
-      "confidence": "High",
+      "user_input": "Database::Export.latest.file_url",
+      "confidence": "Weak",
       "cwe_id": [
         601
       ],
       "note": ""
     }
   ],
-  "updated": "2023-04-21 11:05:15 +0200",
-  "brakeman_version": "5.4.1"
+  "updated": "2024-04-19 09:45:09 +0200",
+  "brakeman_version": "6.1.2"
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,5 +46,7 @@ Rails.application.routes.draw do
   mount Sidekiq::Web, at: "/ops/sidekiq"
   mount PgHero::Engine, at: "/ops/pghero" if Rails.env.development?
 
+  get "/database/exports/selective", to: "database/exports#selective"
+
   root "welcome#home"
 end

--- a/lib/tasks/release.rake
+++ b/lib/tasks/release.rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+desc "Tasks to run after each deployment"
+task release: :environment do
+  puts "=== Running additional post-release tasks ==="
+  puts "-> Queueing Database::StoreSelectiveExportJob"
+  Database::StoreSelectiveExportJob.perform_async
+end

--- a/spec/controllers/database/exports_controller_spec.rb
+++ b/spec/controllers/database/exports_controller_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Database::ExportsController do
+  fixtures :all
+
+  describe "GET selective" do
+    subject(:do_request) { get :selective }
+
+    let(:file_url) { "https://example.com/#{SecureRandom.hex(32)}" }
+    let(:export) { instance_double Database::Export, file_url: }
+
+    before do
+      allow(Database::Export).to receive(:latest).and_return export
+    end
+
+    it { is_expected.to redirect_to file_url }
+  end
+end

--- a/spec/jobs/database/store_selective_export_job_spec.rb
+++ b/spec/jobs/database/store_selective_export_job_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Database::StoreSelectiveExportJob do
+  fixtures :all
+
+  let(:job) { described_class.new }
+
+  describe "#perform" do
+    subject(:perform) { job.perform }
+
+    let(:export_file) { Tempfile.create("export-test") }
+
+    before do
+      allow(Database::SelectiveExport).to receive(:call).and_yield export_file
+      File.open(export_file.path, "w+") { _1.puts SecureRandom.hex(128) }
+    end
+
+    it "creates a new export" do
+      expect { perform }.to change(Database::Export, :count).by(1)
+    end
+
+    it { is_expected.to be_a Database::Export }
+
+    it "attaches the export file" do
+      file = perform.file
+
+      expect(file).to have_attributes(
+        download: File.read(export_file),
+        filename: ActiveStorage::Filename.new(File.basename(export_file))
+      )
+    end
+  end
+end

--- a/spec/models/database/export_spec.rb
+++ b/spec/models/database/export_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe Database::Export do
   it { is_expected.to have_attributes(file: kind_of(ActiveStorage::Attached::One)) }
 
+  it { is_expected.to delegate_method(:url).to(:file).with_prefix }
+
   describe ".latest" do
     subject(:latest) { described_class.latest }
 
@@ -13,7 +15,7 @@ RSpec.describe Database::Export do
     before do
       allow(described_class).to receive(:order)
         .with(created_at: :desc)
-        .and_return instance_double(described_class.all.class, first:)
+        .and_return instance_double(described_class.all.class, first!: first)
     end
 
     it { is_expected.to be first }

--- a/spec/models/database/selective_export_spec.rb
+++ b/spec/models/database/selective_export_spec.rb
@@ -101,11 +101,20 @@ RSpec.describe Database::SelectiveExport do
 
     let(:expected_contents) do
       (+"").tap do |output|
+        output << described_class.banner
+
         described_class::EXPORT_ORDER.each do |table_name|
           described_class.sql_inserts_from_scope described_class::Scopes.public_send(table_name) do |sql|
             output << sql
           end
         end
+      end
+    end
+
+    # We have to freeze time due to the banner timestamp
+    around do |example|
+      Timecop.freeze Time.current do
+        example.run
       end
     end
 

--- a/spec/services/cron_spec.rb
+++ b/spec/services/cron_spec.rb
@@ -41,6 +41,21 @@ RSpec.describe Cron, type: :service do
     cron.run time: time_at(1)
   end
 
+  describe "Database::StoreSelectiveExportJob" do
+    let(:allowed_hours) { 0.upto(23).select { (_1 % 4).zero? } }
+    let(:other_hours) { 0.upto(23).to_a - allowed_hours }
+
+    it "is queued every 4th hour" do
+      expect(Database::StoreSelectiveExportJob).to receive(:perform_async)
+      cron.run time: time_at(allowed_hours.sample)
+    end
+
+    it "is not queued on other hours" do
+      expect(Database::StoreSelectiveExportJob).not_to receive(:perform_async)
+      cron.run time: time_at(other_hours.sample)
+    end
+  end
+
   describe "on exceptions" do
     let(:err) { StandardError.new("Foobar") }
 


### PR DESCRIPTION
This follows #1300 and #1301 for #1205.

* Generate the selective database exports via cron every 4 hours via a background job
* Introduce an endpoint that redirects to the latest export