### PR TITLE
Import ruby-advisory-db advisories

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -102,6 +102,11 @@ gem "turbolinks", "~> 5"
 
 gem "rack-cors"
 
+# We use this in development environment / CI for checking the bundle against known vulnerabilities,
+# but also at runtime as an easy way to fetch the latest db and sync it into our own database for
+# display on the site
+gem "bundler-audit"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: %i[mri mingw x64_mingw]
@@ -146,7 +151,6 @@ group :development do
   gem "ruby-lsp-rspec"
 
   gem "brakeman", require: false
-  gem "bundler-audit", require: false
 
   gem "pghero"
 

--- a/app/jobs/rubygem_advisories_sync_job.rb
+++ b/app/jobs/rubygem_advisories_sync_job.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+#
+# Utilizes the bundler-audit gem to download the ruby advisory db
+# from https://github.com/rubysec/ruby-advisory-db and sync it's data
+# into our own `Rubygem::Advisory` model
+#
+class RubygemAdvisoriesSyncJob < ApplicationJob
+  def self.import(advisory)
+    # Just in case at some point in the future it doesn't only return
+    # advisories that refer to gems we do check the source path for the
+    # advisory and return early otherwise
+    return :not_a_gem unless advisory.path.include? "/gems/"
+
+    # Bundler::Audit::Advisory doesn't contain the actual gem name, so
+    # we have to infer it from the definition source path
+    rubygem_name = File.basename(File.dirname(advisory.path))
+
+    return :unknown_gem unless Rubygem.exists?(name: rubygem_name)
+
+    Rubygem::Advisory.find_or_initialize_by(rubygem_name:, identifier: advisory.id).tap do |record|
+      record.update! date: advisory.date, advisory_data: advisory.to_h
+    end
+  end
+
+  delegate :import, to: :class
+
+  def perform
+    Bundler::Audit::Database.update!
+    Bundler::Audit::Database.new.advisories.each { import _1 }
+    :complete
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -26,6 +26,8 @@ class Project < ApplicationRecord
            through: :rubygem,
            source:  :reverse_dependency_projects
 
+  has_many :advisories, through: :rubygem
+
   belongs_to :github_repo,
              primary_key: :path,
              foreign_key: :github_repo_path,
@@ -33,7 +35,7 @@ class Project < ApplicationRecord
              inverse_of:  :projects
 
   scope :includes_associations, lambda {
-    includes(:github_repo, :rubygem, :categories)
+    includes(:github_repo, :categories, rubygem: %i[advisories])
       .left_outer_joins(:github_repo, :rubygem, :categories)
   }
 

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -9,6 +9,13 @@ class Rubygem < ApplicationRecord
           inverse_of:  :rubygem,
           dependent:   :destroy
 
+  has_many :advisories, -> { order(date: :desc) },
+           class_name:  "Rubygem::Advisory",
+           primary_key: :name,
+           foreign_key: :rubygem_name,
+           inverse_of:  :rubygem,
+           dependent:   :destroy
+
   has_many :download_stats, -> { order(date: :asc) },
            class_name:  "Rubygem::DownloadStat",
            primary_key: :name,

--- a/app/models/rubygem/advisory.rb
+++ b/app/models/rubygem/advisory.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Rubygem::Advisory < ApplicationRecord
+  belongs_to :rubygem,
+             primary_key: :name,
+             foreign_key: :rubygem_name,
+             inverse_of:  :advisories
+
+  validates :date, presence: true
+  validates :rubygem_name, presence: true
+end

--- a/db/migrate/20240607091753_create_rubygem_advisories.rb
+++ b/db/migrate/20240607091753_create_rubygem_advisories.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class CreateRubygemAdvisories < ActiveRecord::Migration[7.1]
+  def change
+    create_table :rubygem_advisories do |t|
+      t.string :rubygem_name, null: false
+      t.string :identifier, null: false
+      t.date :date, null: false
+      t.jsonb :advisory_data, null: false, default: {}
+      t.timestamps
+    end
+
+    add_foreign_key :rubygem_advisories, :rubygems, column: :rubygem_name, primary_key: :name
+
+    add_index :rubygem_advisories, %i[rubygem_name identifier], unique: true
+
+    # Queue the first data sync right away
+    RubygemAdvisoriesSyncJob.perform_in 2.minutes
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -417,6 +417,40 @@ CREATE TABLE public.projects (
 
 
 --
+-- Name: rubygem_advisories; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.rubygem_advisories (
+    id bigint NOT NULL,
+    rubygem_name character varying NOT NULL,
+    identifier character varying NOT NULL,
+    date date NOT NULL,
+    advisory_data jsonb DEFAULT '{}'::jsonb NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: rubygem_advisories_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.rubygem_advisories_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: rubygem_advisories_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.rubygem_advisories_id_seq OWNED BY public.rubygem_advisories.id;
+
+
+--
 -- Name: rubygem_code_statistics; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -608,6 +642,13 @@ ALTER TABLE ONLY public.database_exports ALTER COLUMN id SET DEFAULT nextval('pu
 
 
 --
+-- Name: rubygem_advisories id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.rubygem_advisories ALTER COLUMN id SET DEFAULT nextval('public.rubygem_advisories_id_seq'::regclass);
+
+
+--
 -- Name: rubygem_dependencies id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -674,6 +715,14 @@ ALTER TABLE ONLY public.categorizations
 
 ALTER TABLE ONLY public.database_exports
     ADD CONSTRAINT database_exports_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: rubygem_advisories rubygem_advisories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.rubygem_advisories
+    ADD CONSTRAINT rubygem_advisories_pkey PRIMARY KEY (id);
 
 
 --
@@ -885,6 +934,13 @@ CREATE UNIQUE INDEX index_projects_on_rubygem_name ON public.projects USING btre
 
 
 --
+-- Name: index_rubygem_advisories_on_rubygem_name_and_identifier; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_rubygem_advisories_on_rubygem_name_and_identifier ON public.rubygem_advisories USING btree (rubygem_name, identifier);
+
+
+--
 -- Name: index_rubygem_code_statistics_on_rubygem_name_and_language; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1091,6 +1147,14 @@ ALTER TABLE ONLY public.rubygem_code_statistics
 
 
 --
+-- Name: rubygem_advisories fk_rails_da0771e125; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.rubygem_advisories
+    ADD CONSTRAINT fk_rails_da0771e125 FOREIGN KEY (rubygem_name) REFERENCES public.rubygems(name);
+
+
+--
 -- Name: projects fk_rails_ddb4eb0108; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1105,6 +1169,7 @@ ALTER TABLE ONLY public.projects
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20240607091753'),
 ('20240412142913'),
 ('20240412142709'),
 ('20211210110108'),

--- a/spec/jobs/rubygem_advisories_sync_job_spec.rb
+++ b/spec/jobs/rubygem_advisories_sync_job_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RubygemAdvisoriesSyncJob do
+  fixtures :all
+
+  subject(:job) { described_class.new }
+
+  describe ".import(advisory)" do
+    subject(:import) { described_class.import advisory }
+
+    let(:path) { "/gems/nokogiri/example.yaml" }
+    let(:advisory) do
+      instance_double Bundler::Audit::Advisory,
+                      path:,
+                      id:   "FOO-123",
+                      date: Time.zone.today,
+                      to_h: { "the" => "data" }
+    end
+
+    let(:advisory_count) do
+      lambda do
+        Rubygem::Advisory.where(
+          rubygem_name:  "nokogiri",
+          identifier:    advisory.id,
+          date:          advisory.date,
+          advisory_data: advisory.to_h
+        ).count
+      end
+    end
+
+    it "persists the given advisory in the database" do
+      expect { import }.to change(&advisory_count).from(0).to(1)
+    end
+
+    it { is_expected.to be_a Rubygem::Advisory }
+
+    context "when the advisory already exists" do
+      let!(:existing_advisory) do
+        Rubygem::Advisory.create! rubygem_name: "nokogiri", identifier: advisory.id, date: 3.years.ago
+      end
+
+      it { expect { import }.not_to change(Rubygem::Advisory, :count) }
+
+      it "updates the existing record in place" do
+        import
+        expect(existing_advisory.reload).to have_attributes(date: advisory.date, advisory_data: advisory.to_h)
+      end
+    end
+
+    context "when the gem is not in our database" do
+      let(:path) { "/foo/gems/very_unknown404/foo.yaml" }
+
+      it { is_expected.to eq :unknown_gem }
+      it { expect { import }.not_to change(Rubygem::Advisory, :count) }
+    end
+
+    context "when the path does not include a gems subdirectory" do
+      let(:path) { "hmmmmmmmm" }
+
+      it { is_expected.to eq :not_a_gem }
+      it { expect { import }.not_to change(Rubygem::Advisory, :count) }
+    end
+  end
+
+  describe ".perform" do
+    subject(:perform) { job.perform }
+
+    let(:database) { instance_double Bundler::Audit::Database, advisories: }
+
+    let(:advisories) { Array.new(1) { instance_double Bundler::Audit::Advisory } }
+
+    before do
+      allow(Bundler::Audit::Database).to receive(:update!)
+      allow(Bundler::Audit::Database).to receive(:new).and_return database
+      allow(described_class).to receive(:import).with(advisories.first)
+    end
+
+    it { is_expected.to eq :complete }
+
+    it "performs a local database update" do
+      expect(Bundler::Audit::Database).to receive(:update!)
+      perform
+    end
+
+    it "imports each advisory" do
+      expect(described_class).to receive(:import).with(advisories.first)
+      perform
+    end
+  end
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -35,6 +35,11 @@ RSpec.describe Project do
     }
 
     it {
+      expect(model).to have_many(:advisories)
+        .through(:rubygem)
+    }
+
+    it {
       expect(model).to belong_to(:github_repo)
         .with_primary_key(:path)
         .with_foreign_key(:github_repo_path)
@@ -59,10 +64,10 @@ RSpec.describe Project do
     it "only makes expected amount of queries" do
       nested_accessor = ->(p) { [p.categories.map(&:name), p.rubygem_downloads, p.github_repo_stargazers_count] }
 
-      # Sometimes activerecord sprinkles in a `SELECT a.attname, format_type(a.atttypid, a.atttypmod),`
-      # here for good measure. Actually it's supposed to be 4 queries.
+      # Sometimes activerecord sprinkles in a few `SELECT a.attname, format_type(a.atttypid, a.atttypmod),`
+      # here for good measure. Actually it's supposed to be 5 queries.
       expect { described_class.includes_associations.map(&nested_accessor) }
-        .to make_database_queries(count: 4..6)
+        .to make_database_queries(count: 5..9)
     end
   end
 

--- a/spec/models/rubygem/advisory_spec.rb
+++ b/spec/models/rubygem/advisory_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Rubygem::Advisory do
+  subject(:model) { described_class.new }
+
+  it {
+    expect(model).to belong_to(:rubygem)
+      .with_primary_key(:name)
+      .with_foreign_key(:rubygem_name)
+      .inverse_of(:advisories)
+  }
+
+  it { expect(model).to validate_presence_of(:date) }
+  it { expect(model).to validate_presence_of(:rubygem_name) }
+end

--- a/spec/models/rubygem_spec.rb
+++ b/spec/models/rubygem_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Rubygem do
 
   describe "associations" do
     it { is_expected.to have_one(:project) }
+    it { is_expected.to have_many(:advisories).order(date: :desc) }
     it { is_expected.to have_many(:download_stats).order(date: :asc) }
     it { is_expected.to have_many(:trends).order(date: :asc) }
     it { is_expected.to have_many(:rubygem_dependencies).order(dependency_name: :asc).dependent(:destroy) }


### PR DESCRIPTION
This is for #1196 and adds a job that utilizes bundler-audit to sync https://github.com/rubysec/ruby-advisory-db into our own database, for later displaying on the site itself.

On a side note, I am developing this feature using codespaces, giving https://www.ruby-toolbox.com/blog/2024-05-31/devcontainers a spin in realistic conditions to figure out any quirks and issues and find out if it's fully functional as a work environment as it is or whether it needs further improvements