### PR TITLE
Advisories plumbing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,9 @@ gem "addressable"
 
 gem "blueprinter"
 
+gem "dry-struct"
+gem "dry-types"
+
 # Use ActiveStorage variant
 # gem 'mini_magick', '~> 4.8'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,6 +145,26 @@ GEM
       dotenv (= 3.1.2)
       railties (>= 6.1)
     drb (2.2.1)
+    dry-core (1.0.1)
+      concurrent-ruby (~> 1.0)
+      zeitwerk (~> 2.6)
+    dry-inflector (1.0.0)
+    dry-logic (1.5.0)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 1.0, < 2)
+      zeitwerk (~> 2.6)
+    dry-struct (1.6.0)
+      dry-core (~> 1.0, < 2)
+      dry-types (>= 1.7, < 2)
+      ice_nine (~> 0.11)
+      zeitwerk (~> 2.6)
+    dry-types (1.7.2)
+      bigdecimal (~> 3.0)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 1.0)
+      dry-inflector (~> 1.0)
+      dry-logic (~> 1.4)
+      zeitwerk (~> 2.6)
     erubi (1.12.0)
     execjs (2.8.1)
     feedjira (3.2.3)
@@ -205,6 +225,7 @@ GEM
       ffi-compiler (>= 1.0, < 2.0)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
+    ice_nine (0.11.2)
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
@@ -564,6 +585,8 @@ DEPENDENCIES
   database_cleaner-active_record
   db-query-matchers
   dotenv-rails
+  dry-struct
+  dry-types
   feedjira
   font-awesome-rails
   foreman

--- a/app/jobs/rubygem_advisories_sync_job.rb
+++ b/app/jobs/rubygem_advisories_sync_job.rb
@@ -19,7 +19,8 @@ class RubygemAdvisoriesSyncJob < ApplicationJob
     return :unknown_gem unless Rubygem.exists?(name: rubygem_name)
 
     Rubygem::Advisory.find_or_initialize_by(rubygem_name:, identifier: advisory.id).tap do |record|
-      record.update! date: advisory.date, advisory_data: advisory.to_h
+      # The path is just the local bundler-audit yaml file, so it's not relevant to keep
+      record.update! date: advisory.date, advisory_data: advisory.to_h.excluding(:path)
     end
   end
 

--- a/app/models/application_struct.rb
+++ b/app/models/application_struct.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+#
+# Base class for dry-struct value objects
+#
+class ApplicationStruct < Dry::Struct
+  transform_keys(&:to_sym)
+end

--- a/app/models/database/selective_export.rb
+++ b/app/models/database/selective_export.rb
@@ -54,6 +54,10 @@ class Database::SelectiveExport
         RubygemDependency.where rubygem: rubygems, dependency: rubygems
       end
 
+      def rubygem_advisories
+        Rubygem::Advisory.where rubygem: rubygems
+      end
+
       def rubygem_trends
         Rubygem::Trend.where(rubygem: rubygems).where("date >= ?", 1.month.ago.to_date)
       end

--- a/app/models/rubygem/advisory.rb
+++ b/app/models/rubygem/advisory.rb
@@ -22,6 +22,8 @@ class Rubygem::Advisory < ApplicationRecord
 
     attribute :title, Types::Strict::String.optional
     attribute :description, Types::Strict::String.optional
+
+    alias identifier id
   end
 
   belongs_to :rubygem,
@@ -32,7 +34,12 @@ class Rubygem::Advisory < ApplicationRecord
   validates :date, presence: true
   validates :rubygem_name, presence: true
 
+  delegate(*Rubygem::Advisory::Info.instance_methods(false).excluding(:id, :date), to: :info)
+
   def info
+    # If the underlying data changes, the info struct would get stale,
+    # but that's fine because normally this data is updated out-of-band in the
+    # advisory sync job, so no need for adding complex memo busting logic
     @info ||= Info.new advisory_data
   end
 end

--- a/app/models/rubygem/advisory.rb
+++ b/app/models/rubygem/advisory.rb
@@ -6,6 +6,14 @@ class Rubygem::Advisory < ApplicationRecord
   # gem to make it accessible via a real ruby object
   #
   class Info < ApplicationStruct
+    # The input data structure for this from upstream is a bit complex, see the
+    # fixtures file for an example - we simplify this here somewhat
+    VersionRequirements = Types::Strict::Array.of(Types::Strict::String).constructor do |input|
+      input.fetch("requirements").map do |(comparison, info)|
+        Types::Strict::String["#{comparison} #{info.fetch('version')}"]
+      end
+    end
+
     attribute :id, Types::Strict::String
     attribute :url, Types::Strict::String.optional
     attribute :date, Types::Params::Date
@@ -22,6 +30,9 @@ class Rubygem::Advisory < ApplicationRecord
 
     attribute :title, Types::Strict::String.optional
     attribute :description, Types::Strict::String.optional
+
+    attribute :patched_versions, Types::Strict::Array.of(VersionRequirements)
+    attribute :unaffected_versions, Types::Strict::Array.of(VersionRequirements)
 
     alias identifier id
   end

--- a/app/models/rubygem/advisory.rb
+++ b/app/models/rubygem/advisory.rb
@@ -1,6 +1,29 @@
 # frozen_string_literal: true
 
 class Rubygem::Advisory < ApplicationRecord
+  #
+  # Just a simple wrapper on the base data we get from the bundler-audit
+  # gem to make it accessible via a real ruby object
+  #
+  class Info < ApplicationStruct
+    attribute :id, Types::Strict::String
+    attribute :url, Types::Strict::String.optional
+    attribute :date, Types::Params::Date
+
+    attribute :cve, Types::Strict::String.optional
+    attribute :ghsa, Types::Strict::String.optional
+    # We make this coercible because those are integers, and hence
+    # during conversion they end up as ints on the database
+    attribute :osvdb, Types::Coercible::String.optional
+
+    attribute :cvss_v2, Types::Coercible::Float.optional
+    attribute :cvss_v3, Types::Coercible::Float.optional
+    attribute :criticality, Types::Strict::String.optional
+
+    attribute :title, Types::Strict::String.optional
+    attribute :description, Types::Strict::String.optional
+  end
+
   belongs_to :rubygem,
              primary_key: :name,
              foreign_key: :rubygem_name,
@@ -8,4 +31,8 @@ class Rubygem::Advisory < ApplicationRecord
 
   validates :date, presence: true
   validates :rubygem_name, presence: true
+
+  def info
+    @info ||= Info.new advisory_data
+  end
 end

--- a/app/models/types.rb
+++ b/app/models/types.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Types
+  include Dry.Types()
+end

--- a/spec/fixtures/rubygem/advisories.yml
+++ b/spec/fixtures/rubygem/advisories.yml
@@ -1,0 +1,34 @@
+nokogiri1:
+  rubygem_name: nokogiri
+  identifier: CVE-2019-18197
+  date: '2022-05-24'
+  created_at: <%= Time.current %>
+  updated_at: <%= Time.current %>
+  advisory_data:
+    id: CVE-2019-18197
+    cve: 2019-18197
+    url: https://github.com/sparklemotion/nokogiri/issues/1943
+    date: '2022-05-24'
+    ghsa: 242x-7cm6-4w8j
+    osvdb:
+    title: Nokogiri affected by libxslt Use of Uninitialized Resource/ Use After Free
+      vulnerability
+    cvss_v2: 5.1
+    cvss_v3: 7.5
+    criticality: high
+    description: |
+      In xsltCopyText in transform.c in libxslt 1.1.33, a pointer variable
+      isn't reset under certain circumstances. If the relevant memory area
+      happened to be freed and reused in a certain way, a bounds check could
+      fail and memory outside a buffer could be written to, or uninitialized
+      data could be disclosed.
+
+      Nokogiri prior to version 1.10.5 contains a vulnerable version of
+      libxslt. Nokogiri version 1.10.5 upgrades the dependency to
+      libxslt 1.1.34, which contains a patch for this issue.
+    patched_versions:
+    - requirements:
+      - - ">="
+        - version: 1.10.5
+          segments:
+    unaffected_versions: []

--- a/spec/fixtures/rubygem/advisories.yml
+++ b/spec/fixtures/rubygem/advisories.yml
@@ -32,3 +32,79 @@ nokogiri1:
         - version: 1.10.5
           segments:
     unaffected_versions: []
+
+actionpack1:
+  # This is actually a vulnerability on actionpack, but we don't have that in the
+  # fixtures so might as well just re-map it
+  rubygem_name: actionpack
+  identifier: CVE-2022-22577
+  date: "2022-04-27"
+  created_at: <%= Time.current %>
+  updated_at: <%= Time.current %>
+  advisory_data:
+    id: CVE-2022-22577
+    cve: 2022-22577
+    url: https://groups.google.com/g/ruby-security-ann/c/NuFRKaN5swI
+    date: '2022-04-27'
+    ghsa: mm33-5vfq-3mm3
+    osvdb:
+    title: Possible XSS Vulnerability in Action Pack
+    cvss_v2:
+    cvss_v3: 6.1
+    criticality: medium
+    description: |
+      There is a possible XSS vulnerability in Rails / Action Pack. This vulnerability has been
+      assigned the CVE identifier CVE-2022-22577.
+
+      Versions Affected:  >= 5.2.0
+      Not affected:       < 5.2.0
+      Fixed Versions:     7.0.2.4, 6.1.5.1, 6.0.4.8, 5.2.7.1
+
+      ## Impact
+
+      CSP headers were only sent along with responses that Rails considered as
+      "HTML" responses.  This left API requests without CSP headers, which could
+      possibly expose users to XSS attacks.
+
+      ## Releases
+
+      The FIXED releases are available at the normal locations.
+
+      ## Workarounds
+
+      Set a CSP for your API responses manually.
+    patched_versions:
+    - requirements:
+      - - "~>"
+        - version: 5.2.7
+          segments:
+      - - ">="
+        - version: 5.2.7.1
+          segments:
+    - requirements:
+      - - "~>"
+        - version: 6.0.4
+          segments:
+      - - ">="
+        - version: 6.0.4.8
+          segments:
+    - requirements:
+      - - "~>"
+        - version: 6.1.5
+          segments:
+      - - ">="
+        - version: 6.1.5.1
+          segments:
+    - requirements:
+      - - ">="
+        - version: 7.0.2.4
+          segments:
+    unaffected_versions:
+    - requirements:
+      - - "<"
+        - version: 5.2.0
+          segments:
+          prerelease: false
+          canonical_segments:
+          - 5
+          - 2

--- a/spec/fixtures/rubygems.yml
+++ b/spec/fixtures/rubygems.yml
@@ -364,3 +364,99 @@ minitest:
     2020-2: 1
     2020-3: 1
     2021-1: 2
+actionpack:
+  name: actionpack
+  downloads: 531303567
+  current_version: 7.1.3.2
+  authors: David Heinemeier Hansson
+  description: Web apps on Rails. Simple, battle-tested conventions for building and
+    testing MVC web applications. Works with any Rack-compatible server.
+  licenses:
+  - MIT
+  bug_tracker_url: https://github.com/rails/rails/issues
+  changelog_url:
+  documentation_url: https://api.rubyonrails.org/v7.1.3.2/
+  homepage_url: https://rubyonrails.org
+  mailing_list_url: https://discuss.rubyonrails.org/c/rubyonrails-talk
+  source_code_url: https://github.com/rails/rails/tree/v7.1.3.2/actionpack
+  wiki_url:
+  created_at: '2018-01-03T03:27:19.356Z'
+  updated_at: '2024-04-19T11:24:02.200Z'
+  first_release_on: '2004-10-25'
+  latest_release_on: '2024-02-21'
+  releases_count: 464
+  reverse_dependencies_count: 1495
+  fetched_at: '2024-04-19T11:24:02.200Z'
+  quarterly_release_counts:
+    2004-4: 5
+    2005-1: 8
+    2005-2: 2
+    2005-3: 2
+    2005-4: 5
+    2006-1: 1
+    2006-2: 3
+    2006-3: 2
+    2007-1: 4
+    2007-4: 6
+    2008-2: 1
+    2008-3: 2
+    2008-4: 3
+    2009-1: 1
+    2009-3: 3
+    2009-4: 1
+    2010-1: 1
+    2010-2: 7
+    2010-3: 5
+    2010-4: 4
+    2011-1: 7
+    2011-2: 19
+    2011-3: 9
+    2011-4: 8
+    2012-1: 12
+    2012-2: 11
+    2012-3: 9
+    2012-4: 7
+    2013-1: 15
+    2013-2: 3
+    2013-3: 3
+    2013-4: 12
+    2014-1: 7
+    2014-2: 12
+    2014-3: 15
+    2014-4: 14
+    2015-1: 14
+    2015-2: 7
+    2015-3: 4
+    2015-4: 7
+    2016-1: 13
+    2016-2: 5
+    2016-3: 9
+    2016-4: 3
+    2017-1: 6
+    2017-2: 11
+    2017-3: 13
+    2017-4: 2
+    2018-1: 6
+    2018-2: 1
+    2018-3: 2
+    2018-4: 6
+    2019-1: 11
+    2019-2: 1
+    2019-3: 2
+    2019-4: 9
+    2020-1: 2
+    2020-2: 7
+    2020-3: 2
+    2020-4: 4
+    2021-1: 9
+    2021-2: 6
+    2021-3: 4
+    2021-4: 10
+    2022-1: 16
+    2022-2: 8
+    2022-3: 7
+    2023-1: 7
+    2023-2: 4
+    2023-3: 8
+    2023-4: 4
+    2024-1: 5

--- a/spec/jobs/rubygem_advisories_sync_job_spec.rb
+++ b/spec/jobs/rubygem_advisories_sync_job_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe RubygemAdvisoriesSyncJob do
                       path:,
                       id:   "FOO-123",
                       date: Time.zone.today,
-                      to_h: { "the" => "data" }
+                      to_h: { the: "data", path: "local at import, so excluded" }
     end
 
     let(:advisory_count) do
@@ -25,7 +25,7 @@ RSpec.describe RubygemAdvisoriesSyncJob do
           rubygem_name:  "nokogiri",
           identifier:    advisory.id,
           date:          advisory.date,
-          advisory_data: advisory.to_h
+          advisory_data: advisory.to_h.excluding(:path)
         ).count
       end
     end
@@ -44,8 +44,11 @@ RSpec.describe RubygemAdvisoriesSyncJob do
       it { expect { import }.not_to change(Rubygem::Advisory, :count) }
 
       it "updates the existing record in place" do
+        advisory_data = advisory.to_h.excluding(:path).stringify_keys
+
         import
-        expect(existing_advisory.reload).to have_attributes(date: advisory.date, advisory_data: advisory.to_h)
+        expect(existing_advisory.reload).to have_attributes(date:          advisory.date,
+                                                            advisory_data:)
       end
     end
 

--- a/spec/models/database/selective_export_spec.rb
+++ b/spec/models/database/selective_export_spec.rb
@@ -35,6 +35,9 @@ RSpec.describe Database::SelectiveExport do
     expect_scope :rubygem_dependencies do
       RubygemDependency.where rubygem: described_class.rubygems, dependency: described_class.rubygems
     end
+    expect_scope :rubygem_advisories do
+      Rubygem::Advisory.where rubygem: described_class.rubygems
+    end
     expect_scope :rubygem_trends do
       Rubygem::Trend.where(rubygem: described_class.rubygems).where("date >= ?", 1.month.ago.to_date)
     end

--- a/spec/models/rubygem/advisory_spec.rb
+++ b/spec/models/rubygem/advisory_spec.rb
@@ -16,4 +16,26 @@ RSpec.describe Rubygem::Advisory do
 
   it { expect(model).to validate_presence_of(:date) }
   it { expect(model).to validate_presence_of(:rubygem_name) }
+
+  describe "#info" do
+    subject(:info) { rubygem_advisories(:nokogiri1).info }
+
+    it { is_expected.to be_a(ApplicationStruct) }
+
+    it do # rubocop:disable RSpec/ExampleLength
+      expect(info).to have_attributes(
+        id:          "CVE-2019-18197",
+        cve:         "2019-18197",
+        url:         "https://github.com/sparklemotion/nokogiri/issues/1943",
+        date:        Date.new(2022, 5, 24),
+        ghsa:        "242x-7cm6-4w8j",
+        osvdb:       nil,
+        title:       "Nokogiri affected by libxslt Use of Uninitialized Resource/ Use After Free vulnerability",
+        cvss_v2:     5.1,
+        cvss_v3:     7.5,
+        criticality: "high",
+        description: /\AIn xsltCopyText/
+      )
+    end
+  end
 end

--- a/spec/models/rubygem/advisory_spec.rb
+++ b/spec/models/rubygem/advisory_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Rubygem::Advisory do
   fixtures :all
 
-  subject(:model) { described_class.new }
+  subject(:model) { rubygem_advisories(:nokogiri1) }
 
   it {
     expect(model).to belong_to(:rubygem)
@@ -17,14 +17,30 @@ RSpec.describe Rubygem::Advisory do
   it { expect(model).to validate_presence_of(:date) }
   it { expect(model).to validate_presence_of(:rubygem_name) }
 
+  %i[
+    criticality
+    cve
+    cvss_v2
+    cvss_v3
+    ghsa
+    identifier
+    osvdb
+    title
+    url
+    description
+  ].each do |property|
+    it { is_expected.to delegate_method(property).to(:info) }
+  end
+
   describe "#info" do
-    subject(:info) { rubygem_advisories(:nokogiri1).info }
+    subject(:info) { model.info }
 
     it { is_expected.to be_a(ApplicationStruct) }
 
     it do # rubocop:disable RSpec/ExampleLength
       expect(info).to have_attributes(
         id:          "CVE-2019-18197",
+        identifier:  "CVE-2019-18197",
         cve:         "2019-18197",
         url:         "https://github.com/sparklemotion/nokogiri/issues/1943",
         date:        Date.new(2022, 5, 24),

--- a/spec/models/rubygem/advisory_spec.rb
+++ b/spec/models/rubygem/advisory_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe Rubygem::Advisory do
     title
     url
     description
+    patched_versions
+    unaffected_versions
   ].each do |property|
     it { is_expected.to delegate_method(property).to(:info) }
   end
@@ -39,19 +41,32 @@ RSpec.describe Rubygem::Advisory do
 
     it do # rubocop:disable RSpec/ExampleLength
       expect(info).to have_attributes(
-        id:          "CVE-2019-18197",
-        identifier:  "CVE-2019-18197",
-        cve:         "2019-18197",
-        url:         "https://github.com/sparklemotion/nokogiri/issues/1943",
-        date:        Date.new(2022, 5, 24),
-        ghsa:        "242x-7cm6-4w8j",
-        osvdb:       nil,
-        title:       "Nokogiri affected by libxslt Use of Uninitialized Resource/ Use After Free vulnerability",
-        cvss_v2:     5.1,
-        cvss_v3:     7.5,
-        criticality: "high",
-        description: /\AIn xsltCopyText/
+        id:               "CVE-2019-18197",
+        identifier:       "CVE-2019-18197",
+        cve:              "2019-18197",
+        url:              "https://github.com/sparklemotion/nokogiri/issues/1943",
+        date:             Date.new(2022, 5, 24),
+        ghsa:             "242x-7cm6-4w8j",
+        osvdb:            nil,
+        title:            "Nokogiri affected by libxslt Use of Uninitialized Resource/ Use After Free vulnerability",
+        cvss_v2:          5.1,
+        cvss_v3:          7.5,
+        criticality:      "high",
+        description:      /\AIn xsltCopyText/,
+        patched_versions: [[">= 1.10.5"]]
       )
+    end
+
+    describe "for an advisory with complex patched and unaffected versions" do
+      let(:model) { rubygem_advisories :actionpack1 }
+
+      it do
+        expect(info).to have_attributes(
+          patched_versions:    [["~> 5.2.7", ">= 5.2.7.1"], ["~> 6.0.4", ">= 6.0.4.8"], ["~> 6.1.5", ">= 6.1.5.1"],
+                                [">= 7.0.2.4"]],
+          unaffected_versions: [["< 5.2.0"]]
+        )
+      end
     end
   end
 end

--- a/spec/models/rubygem/advisory_spec.rb
+++ b/spec/models/rubygem/advisory_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Rubygem::Advisory do
+  fixtures :all
+
   subject(:model) { described_class.new }
 
   it {


### PR DESCRIPTION
This is a followup to #1342 for #1196

* Add a ruby-ish way to access the vulnerability info from the advisory model
* Add fixtures
* Include the advisories in the selective export for local setup
* Don't store the local path at import time, it's irrelevant for our purposes as it's just some temp directory location

The changes here are a building block for actually completing #1342 by showing the advisory info in the UI