### PR TITLE
Actually include the advisories in selective export

### DIFF
--- a/app/models/database/selective_export.rb
+++ b/app/models/database/selective_export.rb
@@ -85,6 +85,7 @@ class Database::SelectiveExport
     rubygem_code_statistics
     rubygem_dependencies
     rubygem_trends
+    rubygem_advisories
     github_repos
     github_readmes
     github_ignores

--- a/spec/models/database/selective_export_spec.rb
+++ b/spec/models/database/selective_export_spec.rb
@@ -82,6 +82,7 @@ RSpec.describe Database::SelectiveExport do
         rubygem_code_statistics
         rubygem_dependencies
         rubygem_trends
+        rubygem_advisories
         github_repos
         github_readmes
         github_ignores


### PR DESCRIPTION
Follows https://github.com/rubytoolbox/rubytoolbox/pull/1352, I forgot to actually declare the scope to be exported as well :facepalm: 