### PR TITLE
Convert rubygem downloads count to bigint

### DIFF
--- a/db/migrate/20240628122603_change_downloads_column_type_to_bigint.rb
+++ b/db/migrate/20240628122603_change_downloads_column_type_to_bigint.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class ChangeDownloadsColumnTypeToBigint < ActiveRecord::Migration[7.1]
+  def up
+    change_column :rubygems, :downloads, :bigint, null: false
+    change_column :rubygem_download_stats, :total_downloads, :bigint, null: false
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/migrate/20240628122914_adjust_trends_trigger_to_bigint.rb
+++ b/db/migrate/20240628122914_adjust_trends_trigger_to_bigint.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+#
+# Just copied over from CreateGemTrendsColumnsAndCalculationTrigger migration,
+# but with bigint as the type for the downloads input as the max downloads count value
+# exceeded the 4-byte integer column type
+#
+class AdjustTrendsTriggerToBigint < ActiveRecord::Migration[7.1]
+  def up
+    drop_trigger :rubygem_stats_calculation_month, :rubygem_download_stats
+    create_stats_trigger :month, 28
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  private
+
+  def create_stats_trigger(name, distance_in_days)
+    create_trigger("rubygem_stats_calculation_#{name}", compatibility: 1)
+      .on(:rubygem_download_stats)
+      .declare("previous_downloads bigint; previous_relative_change decimal;")
+      .before(:insert,
+              :update,
+              &difference_to_previous_trigger_sql(name, distance_in_days))
+  end
+
+  def difference_to_previous_trigger_sql(name, distance_in_days)
+    lambda do
+      <<~SQL.squish
+        SELECT total_downloads, relative_change_#{name} INTO previous_downloads, previous_relative_change
+          FROM rubygem_download_stats
+          WHERE
+            rubygem_name = NEW.rubygem_name AND date = NEW.date - #{distance_in_days};
+
+        IF previous_downloads IS NOT NULL THEN
+          NEW.absolute_change_#{name} := NEW.total_downloads - previous_downloads;
+          IF previous_downloads > 0 THEN
+            NEW.relative_change_#{name} := ROUND((NEW.absolute_change_#{name} * 100.0) / previous_downloads, 2);
+
+            IF previous_relative_change IS NOT NULL THEN
+              NEW.growth_change_#{name} := NEW.relative_change_#{name} - previous_relative_change;
+            END IF;
+          END IF;
+        END IF;
+      SQL
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -101,24 +101,10 @@ CREATE FUNCTION public.rubygem_stats_calculation_month() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 DECLARE
-    previous_downloads int;
+    previous_downloads bigint;
     previous_relative_change decimal;
 BEGIN
-    SELECT total_downloads, relative_change_month INTO previous_downloads, previous_relative_change
-      FROM rubygem_download_stats
-      WHERE
-        rubygem_name = NEW.rubygem_name AND date = NEW.date - 28;
-    
-    IF previous_downloads IS NOT NULL THEN
-      NEW.absolute_change_month := NEW.total_downloads - previous_downloads;
-      IF previous_downloads > 0 THEN
-        NEW.relative_change_month := ROUND((NEW.absolute_change_month * 100.0) / previous_downloads, 2);
-    
-        IF previous_relative_change IS NOT NULL THEN
-          NEW.growth_change_month := NEW.relative_change_month - previous_relative_change;
-        END IF;
-      END IF;
-    END IF;
+    SELECT total_downloads, relative_change_month INTO previous_downloads, previous_relative_change FROM rubygem_download_stats WHERE rubygem_name = NEW.rubygem_name AND date = NEW.date - 28; IF previous_downloads IS NOT NULL THEN NEW.absolute_change_month := NEW.total_downloads - previous_downloads; IF previous_downloads > 0 THEN NEW.relative_change_month := ROUND((NEW.absolute_change_month * 100.0) / previous_downloads, 2); IF previous_relative_change IS NOT NULL THEN NEW.growth_change_month := NEW.relative_change_month - previous_relative_change; END IF; END IF; END IF;
     RETURN NEW;
 END;
 $$;
@@ -508,7 +494,7 @@ CREATE TABLE public.rubygem_download_stats (
     id bigint NOT NULL,
     rubygem_name character varying NOT NULL,
     date date NOT NULL,
-    total_downloads integer NOT NULL,
+    total_downloads bigint NOT NULL,
     absolute_change_month integer,
     relative_change_month numeric,
     growth_change_month numeric
@@ -574,7 +560,7 @@ ALTER SEQUENCE public.rubygem_trends_id_seq OWNED BY public.rubygem_trends.id;
 
 CREATE TABLE public.rubygems (
     name character varying NOT NULL,
-    downloads integer NOT NULL,
+    downloads bigint NOT NULL,
     current_version character varying NOT NULL,
     authors character varying,
     description text,
@@ -1169,6 +1155,8 @@ ALTER TABLE ONLY public.projects
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20240628122914'),
+('20240628122603'),
 ('20240607091753'),
 ('20240412142913'),
 ('20240412142709'),


### PR DESCRIPTION
The rubygem sync got stuck on the bundler gem because it's download count exceeded the integer column type limit :rocket: 

So, this adjusts the relevant column types accordingly to make some space for more downloads, and adjusts the dependent trigger function for the trends calculation accordingly to take a bigint as the argument as well.