### PR TITLE
Safer approach at convert rubygem downloads count to bigint

### DIFF
--- a/db/migrate/20240628122603_change_downloads_column_type_to_bigint.rb
+++ b/db/migrate/20240628122603_change_downloads_column_type_to_bigint.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class ChangeDownloadsColumnTypeToBigint < ActiveRecord::Migration[7.1]
+  def up
+    change_column :rubygems, :downloads, :bigint, null: false
+    change_column :rubygem_download_stats, :total_downloads, :bigint, null: false
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/migrate/20240628122603_change_downloads_column_type_to_bigint.rb
+++ b/db/migrate/20240628122603_change_downloads_column_type_to_bigint.rb
@@ -2,8 +2,24 @@
 
 class ChangeDownloadsColumnTypeToBigint < ActiveRecord::Migration[7.1]
   def up
-    change_column :rubygems, :downloads, :bigint, null: false
-    change_column :rubygem_download_stats, :total_downloads, :bigint, null: false
+    add_column :rubygems, :bigint_downloads, :bigint
+    add_column :rubygem_download_stats, :bigint_total_downloads, :bigint
+
+    # rubocop:disable Rails/SkipsModelValidations
+    Rubygem.update_all "bigint_downloads = downloads"
+    Rubygem::DownloadStat.update_all "bigint_total_downloads = total_downloads"
+    # rubocop:enable Rails/SkipsModelValidations
+
+    remove_column :rubygems, :downloads
+    remove_column :rubygem_download_stats, :total_downloads
+
+    rename_column :rubygems, :bigint_downloads, :downloads
+    rename_column :rubygem_download_stats, :bigint_total_downloads, :total_downloads
+
+    change_column_null :rubygems, :downloads, false
+    change_column_null :rubygem_download_stats, :total_downloads, false
+
+    add_index :rubygem_download_stats, :total_downloads, order: "DESC NULLS LAST", algorithm: :concurrently
   end
 
   def down

--- a/db/migrate/20240628122603_change_downloads_column_type_to_bigint.rb
+++ b/db/migrate/20240628122603_change_downloads_column_type_to_bigint.rb
@@ -2,24 +2,16 @@
 
 class ChangeDownloadsColumnTypeToBigint < ActiveRecord::Migration[7.1]
   def up
-    add_column :rubygems, :bigint_downloads, :bigint
-    add_column :rubygem_download_stats, :bigint_total_downloads, :bigint
+    # On production, I have performed this migration manually on the rails console
+    # against a secondary forked database, which then was promoted to become the new primary.
+    #
+    # We just want to get the version tracked on the migrations table.
+    #
+    # See https://github.com/rubytoolbox/rubytoolbox/pull/1366
+    return if Rails.env.production?
 
-    # rubocop:disable Rails/SkipsModelValidations
-    Rubygem.update_all "bigint_downloads = downloads"
-    Rubygem::DownloadStat.update_all "bigint_total_downloads = total_downloads"
-    # rubocop:enable Rails/SkipsModelValidations
-
-    remove_column :rubygems, :downloads
-    remove_column :rubygem_download_stats, :total_downloads
-
-    rename_column :rubygems, :bigint_downloads, :downloads
-    rename_column :rubygem_download_stats, :bigint_total_downloads, :total_downloads
-
-    change_column_null :rubygems, :downloads, false
-    change_column_null :rubygem_download_stats, :total_downloads, false
-
-    add_index :rubygem_download_stats, :total_downloads, order: "DESC NULLS LAST", algorithm: :concurrently
+    change_column :rubygems, :downloads, :bigint, null: false
+    change_column :rubygem_download_stats, :total_downloads, :bigint, null: false
   end
 
   def down

--- a/db/migrate/20240628122914_adjust_trends_trigger_to_bigint.rb
+++ b/db/migrate/20240628122914_adjust_trends_trigger_to_bigint.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+#
+# Just copied over from CreateGemTrendsColumnsAndCalculationTrigger migration,
+# but with bigint as the type for the downloads input as the max downloads count value
+# exceeded the 4-byte integer column type
+#
+class AdjustTrendsTriggerToBigint < ActiveRecord::Migration[7.1]
+  def up
+    drop_trigger :rubygem_stats_calculation_month, :rubygem_download_stats
+    create_stats_trigger :month, 28
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  private
+
+  def create_stats_trigger(name, distance_in_days)
+    create_trigger("rubygem_stats_calculation_#{name}", compatibility: 1)
+      .on(:rubygem_download_stats)
+      .declare("previous_downloads bigint; previous_relative_change decimal;")
+      .before(:insert,
+              :update,
+              &difference_to_previous_trigger_sql(name, distance_in_days))
+  end
+
+  def difference_to_previous_trigger_sql(name, distance_in_days)
+    lambda do
+      <<~SQL.squish
+        SELECT total_downloads, relative_change_#{name} INTO previous_downloads, previous_relative_change
+          FROM rubygem_download_stats
+          WHERE
+            rubygem_name = NEW.rubygem_name AND date = NEW.date - #{distance_in_days};
+
+        IF previous_downloads IS NOT NULL THEN
+          NEW.absolute_change_#{name} := NEW.total_downloads - previous_downloads;
+          IF previous_downloads > 0 THEN
+            NEW.relative_change_#{name} := ROUND((NEW.absolute_change_#{name} * 100.0) / previous_downloads, 2);
+
+            IF previous_relative_change IS NOT NULL THEN
+              NEW.growth_change_#{name} := NEW.relative_change_#{name} - previous_relative_change;
+            END IF;
+          END IF;
+        END IF;
+      SQL
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -101,24 +101,10 @@ CREATE FUNCTION public.rubygem_stats_calculation_month() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 DECLARE
-    previous_downloads int;
+    previous_downloads bigint;
     previous_relative_change decimal;
 BEGIN
-    SELECT total_downloads, relative_change_month INTO previous_downloads, previous_relative_change
-      FROM rubygem_download_stats
-      WHERE
-        rubygem_name = NEW.rubygem_name AND date = NEW.date - 28;
-    
-    IF previous_downloads IS NOT NULL THEN
-      NEW.absolute_change_month := NEW.total_downloads - previous_downloads;
-      IF previous_downloads > 0 THEN
-        NEW.relative_change_month := ROUND((NEW.absolute_change_month * 100.0) / previous_downloads, 2);
-    
-        IF previous_relative_change IS NOT NULL THEN
-          NEW.growth_change_month := NEW.relative_change_month - previous_relative_change;
-        END IF;
-      END IF;
-    END IF;
+    SELECT total_downloads, relative_change_month INTO previous_downloads, previous_relative_change FROM rubygem_download_stats WHERE rubygem_name = NEW.rubygem_name AND date = NEW.date - 28; IF previous_downloads IS NOT NULL THEN NEW.absolute_change_month := NEW.total_downloads - previous_downloads; IF previous_downloads > 0 THEN NEW.relative_change_month := ROUND((NEW.absolute_change_month * 100.0) / previous_downloads, 2); IF previous_relative_change IS NOT NULL THEN NEW.growth_change_month := NEW.relative_change_month - previous_relative_change; END IF; END IF; END IF;
     RETURN NEW;
 END;
 $$;
@@ -508,7 +494,7 @@ CREATE TABLE public.rubygem_download_stats (
     id bigint NOT NULL,
     rubygem_name character varying NOT NULL,
     date date NOT NULL,
-    total_downloads integer NOT NULL,
+    total_downloads bigint NOT NULL,
     absolute_change_month integer,
     relative_change_month numeric,
     growth_change_month numeric
@@ -574,7 +560,7 @@ ALTER SEQUENCE public.rubygem_trends_id_seq OWNED BY public.rubygem_trends.id;
 
 CREATE TABLE public.rubygems (
     name character varying NOT NULL,
-    downloads integer NOT NULL,
+    downloads bigint NOT NULL,
     current_version character varying NOT NULL,
     authors character varying,
     description text,
@@ -1169,6 +1155,8 @@ ALTER TABLE ONLY public.projects
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20240628122914'),
+('20240628122603'),
 ('20240607091753'),
 ('20240412142913'),
 ('20240412142709'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -494,10 +494,10 @@ CREATE TABLE public.rubygem_download_stats (
     id bigint NOT NULL,
     rubygem_name character varying NOT NULL,
     date date NOT NULL,
+    total_downloads bigint NOT NULL,
     absolute_change_month integer,
     relative_change_month numeric,
-    growth_change_month numeric,
-    total_downloads bigint
+    growth_change_month numeric
 );
 
 
@@ -560,6 +560,7 @@ ALTER SEQUENCE public.rubygem_trends_id_seq OWNED BY public.rubygem_trends.id;
 
 CREATE TABLE public.rubygems (
     name character varying NOT NULL,
+    downloads bigint NOT NULL,
     current_version character varying NOT NULL,
     authors character varying,
     description text,
@@ -578,8 +579,7 @@ CREATE TABLE public.rubygems (
     releases_count integer,
     reverse_dependencies_count integer,
     fetched_at timestamp without time zone,
-    quarterly_release_counts jsonb DEFAULT '{}'::jsonb NOT NULL,
-    downloads bigint
+    quarterly_release_counts jsonb DEFAULT '{}'::jsonb NOT NULL
 );
 
 
@@ -980,6 +980,13 @@ CREATE INDEX index_rubygem_download_stats_on_relative_change_month ON public.rub
 --
 
 CREATE UNIQUE INDEX index_rubygem_download_stats_on_rubygem_name_and_date ON public.rubygem_download_stats USING btree (rubygem_name, date);
+
+
+--
+-- Name: index_rubygem_download_stats_on_total_downloads; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_rubygem_download_stats_on_total_downloads ON public.rubygem_download_stats USING btree (total_downloads DESC NULLS LAST);
 
 
 --

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -494,10 +494,10 @@ CREATE TABLE public.rubygem_download_stats (
     id bigint NOT NULL,
     rubygem_name character varying NOT NULL,
     date date NOT NULL,
-    total_downloads bigint NOT NULL,
     absolute_change_month integer,
     relative_change_month numeric,
-    growth_change_month numeric
+    growth_change_month numeric,
+    total_downloads bigint
 );
 
 
@@ -560,7 +560,6 @@ ALTER SEQUENCE public.rubygem_trends_id_seq OWNED BY public.rubygem_trends.id;
 
 CREATE TABLE public.rubygems (
     name character varying NOT NULL,
-    downloads bigint NOT NULL,
     current_version character varying NOT NULL,
     authors character varying,
     description text,
@@ -579,7 +578,8 @@ CREATE TABLE public.rubygems (
     releases_count integer,
     reverse_dependencies_count integer,
     fetched_at timestamp without time zone,
-    quarterly_release_counts jsonb DEFAULT '{}'::jsonb NOT NULL
+    quarterly_release_counts jsonb DEFAULT '{}'::jsonb NOT NULL,
+    downloads bigint
 );
 
 
@@ -980,13 +980,6 @@ CREATE INDEX index_rubygem_download_stats_on_relative_change_month ON public.rub
 --
 
 CREATE UNIQUE INDEX index_rubygem_download_stats_on_rubygem_name_and_date ON public.rubygem_download_stats USING btree (rubygem_name, date);
-
-
---
--- Name: index_rubygem_download_stats_on_total_downloads; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_rubygem_download_stats_on_total_downloads ON public.rubygem_download_stats USING btree (total_downloads DESC NULLS LAST);
 
 
 --


### PR DESCRIPTION
A new take on https://github.com/rubytoolbox/rubytoolbox/pull/1364 after #1365 - especially the download stats table is too huge for this to work with the naive approach, should've thought of that :facepalm: 