### PR TITLE
Finally bump sidekiq to 7+

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,9 +66,7 @@ gem "high_voltage"
 
 gem "http", "~> 4.4"
 
-# We have to pin to 6 until our redis provider supports sidekiq 7 :(
-# See https://github.com/sidekiq/sidekiq/issues/5594
-gem "sidekiq", "~> 6.4"
+gem "sidekiq"
 
 gem "sanitize"
 gem "truncato"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -384,7 +384,8 @@ GEM
     rdoc (6.7.0)
       psych (>= 4.0.0)
     redcarpet (3.6.0)
-    redis (4.8.1)
+    redis-client (0.22.2)
+      connection_pool
     regexp_parser (2.9.2)
     reline (0.5.9)
       io-console (~> 0.5)
@@ -488,10 +489,12 @@ GEM
     shellany (0.0.1)
     shoulda-matchers (6.2.0)
       activesupport (>= 5.2.0)
-    sidekiq (6.5.12)
-      connection_pool (>= 2.2.5, < 3)
-      rack (~> 2.0)
-      redis (>= 4.5.0, < 5)
+    sidekiq (7.3.0)
+      concurrent-ruby (< 2)
+      connection_pool (>= 2.3.0)
+      logger
+      rack (>= 2.2.4)
+      redis-client (>= 0.22.2)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -639,7 +642,7 @@ DEPENDENCIES
   sass-rails
   selenium-webdriver
   shoulda-matchers
-  sidekiq (~> 6.4)
+  sidekiq
   simplecov
   slim-rails
   spring


### PR DESCRIPTION
Can you believe it, it's finally possible to switch to RESP3 on redis cloud :tada:  So [this saga](https://github.com/sidekiq/sidekiq/issues/5594) can finally find closure