### PR TITLE
Fix error when github returns null on a non-nullable graphql property

### DIFF
--- a/app/services/github_client/repository_data.rb
+++ b/app/services/github_client/repository_data.rb
@@ -123,6 +123,12 @@ class GithubClient
 
       dates = edges.map { |edge| Time.zone.parse edge.dig("node", "authoredDate") }
       Time.zone.at dates.sum(&:to_i) / dates.count
+    # Yip, sometimes github actually has a 500 when accessing the commits history, i.e.
+    # https://github.com/grosser/open_id_authentication/commits/master/
+    #
+    # And then we get a null on this GraphQL property declared as non-nullable.
+    rescue TypeError
+      nil
     end
 
     def topics

--- a/spec/services/github_client/repository_data_spec.rb
+++ b/spec/services/github_client/repository_data_spec.rb
@@ -42,6 +42,37 @@ RSpec.describe GithubClient::RepositoryData, type: :service do
     end
   end
 
+  describe "#average_recent_committed_at" do
+    subject(:average_recent_committed_at) { repo.average_recent_committed_at }
+
+    let(:repo) do
+      data defaultBranchRef: {
+        target: {
+          history: {
+            edges:,
+          },
+        },
+      }
+    end
+
+    let(:edges) do
+      [
+        { node: { authoredDate: Time.utc(2024, 7, 1, 12).iso8601 } },
+        { node: { authoredDate: Time.utc(2024, 7, 7, 12).iso8601 } },
+      ]
+    end
+
+    it { is_expected.to eq Time.utc(2024, 7, 4, 12) }
+
+    # Yip, this can happen. https://github.com/grosser/open_id_authentication/commits/master/ throws a 500
+    # even on Github itself
+    context "when github doesn't return a proper authoredDate" do
+      before { edges.sample.fetch(:node)[:authoredDate] = nil }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
   describe "#pull_request_acceptance_rate" do
     it "is nil if PR data is missing" do
       expect(data.pull_request_acceptance_rate).to be_nil


### PR DESCRIPTION
This popped up on Appsignal. The field is declared as non-nullable on GraphQL, but Github actually crashes with a 500 when you open https://github.com/grosser/open_id_authentication/commits/master/, and we get a null value for authoredDate from GraphQL despite the schema saying otherwise, so I guess we just work around this to ensure the updates still work and we don't get error notifications