### PR TITLE
WIP: Display rubygem advisories on the site

### DIFF
--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -7,5 +7,6 @@ class WelcomeController < ApplicationController
     @trending_projects = Rubygem::Trend.latest.limit(8)
     @stats = Stats.new
     @recent_posts = BlogController::BLOG.recent_posts.presence
+    @recent_advisories = Rubygem::Advisory.recent
   end
 end

--- a/app/models/rubygem/advisory.rb
+++ b/app/models/rubygem/advisory.rb
@@ -45,6 +45,8 @@ class Rubygem::Advisory < ApplicationRecord
   validates :date, presence: true
   validates :rubygem_name, presence: true
 
+  scope :recent, -> { where(date: 3.months.ago..).order(date: :desc) }
+
   delegate(*Rubygem::Advisory::Info.instance_methods(false).excluding(:id, :date), to: :info)
 
   def info

--- a/app/views/welcome/home.html.slim
+++ b/app/views/welcome/home.html.slim
@@ -25,7 +25,6 @@
                 | &nbsp;
                 strong= post.title
 
-
   section.section: .container: .landing-features
     = landing_feature title: "Categories", image: "startpage/box.png" do
       article
@@ -98,3 +97,29 @@
         - @new_categories.each do |category|
           .category-cards.four
             = category_card category
+
+  - if @recent_advisories.length > 0
+    section.section.recent-advisories: .container
+      / TODO: Link to https://github.com/rubysec/ruby-advisory-db, but the component doesn't support links / html in here
+      = section_heading "Recent Security Advisories", description: "Here are the most recent security advisories for Rubygems, sourced from the Ruby Advisory Database. You can find per-library advisory information and the full history on individual project pages."
+
+      / TODO: Break out into a reusable component
+      .columns.is-multiline
+        - @recent_advisories.each do |advisory|
+          .column.is-half
+            .columns
+              .column.is-one-quarter
+                .date= l advisory.date, format: :long
+                strong= link_to advisory.rubygem_name, project_path(advisory.rubygem_name), class: "button is-outlined is-small is-primary"
+
+              .column
+                div
+                  - if advisory.criticality
+                    - label_type = { high: "is-danger", medium: "is-warning", low: "is-info" }[advisory.criticality.to_sym]
+                    span.tag class=label_type
+                      = advisory.criticality.humanize
+                  - else
+                    | &nbsp;
+
+                a href=advisory.url
+                  strong= advisory.title

--- a/spec/controllers/welcome_controller_spec.rb
+++ b/spec/controllers/welcome_controller_spec.rb
@@ -46,5 +46,12 @@ RSpec.describe WelcomeController do
       do_request
       expect(assigns(:trending_projects)).to be array
     end
+
+    it "assigns recent_advisories" do
+      array = []
+      allow(Rubygem::Advisory).to receive(:recent).and_return array
+      do_request
+      expect(assigns(:recent_advisories)).to be array
+    end
   end
 end

--- a/spec/models/rubygem/advisory_spec.rb
+++ b/spec/models/rubygem/advisory_spec.rb
@@ -17,6 +17,12 @@ RSpec.describe Rubygem::Advisory do
   it { expect(model).to validate_presence_of(:date) }
   it { expect(model).to validate_presence_of(:rubygem_name) }
 
+  describe ".recent" do
+    subject(:recent) { described_class.recent.to_sql }
+
+    it { is_expected.to eq described_class.where(date: 3.months.ago..).order(date: :desc).to_sql }
+  end
+
   %i[
     criticality
     cve


### PR DESCRIPTION
Ticket for context: #1196 

Preparations of the data took place via #1342 and #1352, now it's about actually showing these on project pages, on the home page, and potentially in project cards on overview listings (i.e. compact and full category views)