### PR TITLE
Fix mobile UI width glitches

### DIFF
--- a/app/frontend/entrypoints/application.js
+++ b/app/frontend/entrypoints/application.js
@@ -39,6 +39,7 @@ import BurgerHandler from "~/javascript/bulma_burger"
 import DocsAsideHandler from "~/javascript/docs_aside_handler"
 import LoadingStateHandlers from "~/javascript/loading_state_handlers"
 import ProjectAutocomplete from "~/javascript/project_autocomplete"
+import FixReadmeOverflow from "~/javascript/fix_readme_overflow"
 
 document.addEventListener("DOMContentLoaded", function () {
   // Make the sticky top nav hide on scroll, re-appear on scrolling up.
@@ -49,4 +50,5 @@ document.addEventListener("DOMContentLoaded", function () {
   DocsAsideHandler();
   LoadingStateHandlers();
   ProjectAutocomplete();
+  FixReadmeOverflow()
 });

--- a/app/frontend/entrypoints/application.sass
+++ b/app/frontend/entrypoints/application.sass
@@ -63,6 +63,8 @@ header.main
     box-shadow: $box-shadow
     @extend .is-fixed-top
 
+    max-width: 100vw
+
     &.headroom
       will-change: transform
       transition: transform 200ms linear
@@ -98,7 +100,8 @@ header.main
     // them here to keep it consistent with the adjacent search icon
     // in mobile view
     .navbar-burger
-      margin-left: 0
+      &:last-child
+        margin-left: 0
       &:hover
         background: transparent
         span
@@ -109,15 +112,13 @@ header.main
     // Make the mobile search direct icon appear similar to the
     // navbar burger and ensure it's nicely aligned
     .mobile-search
-      margin-left: auto
+      position: relative
       @extend .is-hidden-widescreen
-      height: $navbar-height
-      width: $navbar-height
       .icon
-        display: inline-block
-        margin: 0 auto
-        width: auto
-        transform: scale(1.1)
+        position: absolute
+        top: 50%
+        left: 50%
+        transform: translateY(-50%) translateX(-50%)
 
 .hero
   @extend .border-bottom

--- a/app/frontend/javascript/fix_readme_overflow.js
+++ b/app/frontend/javascript/fix_readme_overflow.js
@@ -1,0 +1,18 @@
+//
+// We sync the README html of github repositories from their API,
+// but <table> elements there aren't wrapped in a container and break
+// the horizontal frame in mobile view.
+//
+// We could fix this by doing a Nokogiri parse / preprocess step,
+// but just doing it ad-hoc in the browser seems the lower friction way
+//
+export default function() {
+  document.querySelectorAll("section.readme .content > div table").forEach((table) => {
+    const wrapper = document.createElement('div');
+    // Standard bulma responsive table & styling classes
+    wrapper.classList.add("table-container");
+    table.classList.add("table");
+    table.parentNode.insertBefore(wrapper, table);
+    wrapper.appendChild(table);
+  });
+}

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -51,7 +51,7 @@ html.has-navbar-fixed-top lang="en"
 
           a.navbar-burger.burger.mobile-search href=search_path role="button"
             .icon: i.fa.fa-search
-          a.navbar-burger.burger aria-expanded="false" data-target="mainMenu" aria-label="menu" role="button"
+          a.navbar-burger.burger.toggle aria-expanded="false" data-target="mainMenu" aria-label="menu" role="button"
             span aria-hidden="true"
             span aria-hidden="true"
             span aria-hidden="true"

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -49,14 +49,12 @@ html.has-navbar-fixed-top lang="en"
           = link_to "/", title: title(default: true), class: "navbar-item" do
             = vite_image_tag "images/logo/regular.svg", alt: title(default: true)
 
-          a.navbar-item.mobile-search href=search_path
-            span.icon: i.fa.fa-search
-
+          a.navbar-burger.burger.mobile-search href=search_path role="button"
+            .icon: i.fa.fa-search
           a.navbar-burger.burger aria-expanded="false" data-target="mainMenu" aria-label="menu" role="button"
             span aria-hidden="true"
             span aria-hidden="true"
             span aria-hidden="true"
-
         .navbar-menu#mainMenu
           .navbar-end
             a.navbar-item.is-hidden-widescreen-only href="/" class=active_when(controller: :welcome)

--- a/spec/features/mobile_navigation_spec.rb
+++ b/spec/features/mobile_navigation_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Mobile Navigation", :js, viewport: :mobile do
     within "header .navbar" do
       expect(page).to have_no_css(".navbar-menu")
 
-      page.find("a.navbar-burger").click
+      page.find("a.navbar-burger.toggle").click
 
       expect(page).to have_css(".navbar-menu")
       within ".navbar-menu" do


### PR DESCRIPTION
This fixes two issues when opening the site on mobile:

1. The navbar breaks out of the viewport width, hiding or at least partially obstructing the burger

The problem here is that bulma doesn't really seem to have a way to add another icon (like we have here in the search button) into the mobile navbar + burger. The adjustment I made feels a bit hacky still, but I wanted to make it work within what Bulma provides. An alternative would be to just create a custom layout for this, probably best using CSS grid

2. When opening a project page that has a wide table in their readme (like https://www.ruby-toolbox.com/projects/rein) the table was also breaking out of the viewport to the right

The problem is we get the rendered html from Github as it is, and there's no container to declare CSS overflow on in there. Solved this with a little javascript snippet - the alternative would've been to parse the HTML and add the desired element when we sync the readme, but it would have required patching all existing READMEs or waiting for their rolling re-sync, so just addding that little JS snippet seemed to be less friction