### PR TITLE
Tame search spam

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,7 +128,7 @@ GEM
       logger (~> 1.5)
     climate_control (1.2.0)
     coderay (1.1.3)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
     crack (1.0.1)
       bigdecimal
@@ -291,7 +291,7 @@ GEM
     msgpack (1.8.0)
     mutex_m (0.3.0)
     nenv (0.3.0)
-    net-imap (0.6.4)
+    net-imap (0.6.4.1)
       date
       net-protocol
     net-pop (0.1.2)
@@ -301,12 +301,12 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
-    nokogiri (1.19.3-x86_64-linux-gnu)
+    nokogiri (1.19.4-x86_64-linux-gnu)
       racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    oj (3.17.1)
+    oj (3.17.3)
       bigdecimal (>= 3.0)
       ostruct (>= 0.2)
     ostruct (0.6.3)
@@ -340,7 +340,7 @@ GEM
       date
       stringio
     public_suffix (7.0.5)
-    puma (8.0.1)
+    puma (8.0.2)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.6)

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -1,6 +1,37 @@
 # frozen_string_literal: true
 
 class SearchesController < ApplicationController
+  # Default upper bound (in milliseconds) on how long a single search
+  # request's database queries may run before Postgres aborts them. This
+  # keeps a pathological query from holding a web dyno until Heroku's 30s H12
+  # request timeout fires. Override via the SEARCH_STATEMENT_TIMEOUT_MS env
+  # var.
+  DEFAULT_STATEMENT_TIMEOUT_MS = 5_000
+
+  rescue_from ActiveRecord::QueryCanceled, with: :render_search_unavailable
+
+  around_action :with_statement_timeout, only: :show
+
+  before_action :reject_disabled_search, only: :show
+
+  delegate :search_disabled?, :statement_timeout_ms, to: :class, private: true
+
+  # Emergency killswitch: when the DISABLE_SEARCH env var is set, search is
+  # turned off entirely. This lets us disable search through a config
+  # var, without a deploy, if it is being abused and causing trouble,
+  # i.e. see https://github.com/rubytoolbox/rubytoolbox/issues/1705
+  def self.search_disabled?
+    ENV["DISABLE_SEARCH"].present?
+  end
+
+  # Maximum runtime for search queries in milliseconds, configurable via the
+  # SEARCH_STATEMENT_TIMEOUT_MS env var. Falls back to
+  # DEFAULT_STATEMENT_TIMEOUT_MS when it is unset or not a positive integer.
+  def self.statement_timeout_ms
+    configured = ENV["SEARCH_STATEMENT_TIMEOUT_MS"].to_i
+    configured.positive? ? configured : DEFAULT_STATEMENT_TIMEOUT_MS
+  end
+
   def show
     @query = params[:q].presence
     return unless @query
@@ -15,6 +46,35 @@ class SearchesController < ApplicationController
   end
 
   private
+
+  # Halts the request with an "unavailable" notice when the search killswitch
+  # (DISABLE_SEARCH) is active, so no search is performed at all.
+  def reject_disabled_search
+    return unless search_disabled?
+
+    @query = params[:q].presence
+    render :unavailable, status: 503
+  end
+
+  # Bounds the database time a search request may consume so a runaway query
+  # fails fast (raising ActiveRecord::QueryCanceled) instead of tying up a web
+  # dyno until Heroku's request timeout. statement_timeout is reset afterwards
+  # so the pooled connection does not carry the limit to other requests.
+  def with_statement_timeout
+    connection = ActiveRecord::Base.connection
+    connection.execute "SET statement_timeout = #{connection.quote statement_timeout_ms}"
+    yield
+  ensure
+    connection&.execute "RESET statement_timeout"
+  end
+
+  # Rendered when a search query is aborted by the statement timeout. Renders
+  # the dedicated unavailable view (rather than the search relations, which
+  # would re-run the slow query) and returns a 503 with a friendly notice.
+  def render_search_unavailable
+    @query ||= params[:q].presence
+    render :unavailable, status: 503
+  end
 
   def perform_search
     @search = Search.new @query, order: current_order, show_forks: show_forks?

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -14,8 +14,17 @@ class Search
     query.present?
   end
 
+  # Whether the query is one we are actually willing to run against the
+  # database. Blank or abusive queries yield no results rather than risking a
+  # slow/expensive search; see Search::QueryCheck.
+  def runnable?
+    QueryCheck.new(query).runnable?
+  end
+
   def projects
-    @projects ||= if ENV["NEW_SEARCH"]
+    @projects ||= if !runnable?
+                    Project.none
+                  elsif ENV["NEW_SEARCH"]
                     meili_search_results
                   else
                     Project.search(query, order:, show_forks:)
@@ -23,7 +32,7 @@ class Search
   end
 
   def categories
-    @categories ||= Category.search(query)
+    @categories ||= runnable? ? Category.search(query) : Category.none
   end
 
   private

--- a/app/services/search/query_check.rb
+++ b/app/services/search/query_check.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+class Search
+  #
+  # Decides whether a given search query is one we are actually willing to run
+  # against the database.
+  #
+  # Bots spam the search with long CJK strings that pg_search expands into
+  # pathological prefix tsqueries (every token becomes a ":*" prefix match,
+  # ANDed together). These can run for tens of seconds and exhaust web dynos,
+  # so we treat overly long or many-token queries as abusive and yield no
+  # results instead of querying.
+  #
+  class QueryCheck
+    # A genuine gem or category lookup is short, so anything substantially
+    # longer is treated as abusive.
+    MAX_QUERY_LENGTH = 30
+
+    # pg_search turns every query token into a ":*" prefix match and ANDs them
+    # together, so the query cost grows with the token count. The spam queries
+    # pack a dozen or more comma-separated phrases, hence the cap.
+    MAX_QUERY_TOKENS = 8
+
+    attr_reader :query
+
+    def initialize(query)
+      @query = query
+    end
+
+    # Whether the query is acceptable to run: present and not abusive.
+    def runnable?
+      query.present? && !abusive?
+    end
+
+    # An abusive query is too long or carries too many tokens to be a
+    # legitimate library search.
+    def abusive?
+      return false if query.blank?
+
+      query.length > MAX_QUERY_LENGTH || token_count > MAX_QUERY_TOKENS
+    end
+
+    private
+
+    # Counts word-character runs, mirroring how the text search parser
+    # tokenizes the query. Punctuation (e.g. CJK 、，) separates tokens, so
+    # spammy comma-separated phrase lists count as many tokens.
+    def token_count
+      query.scan(/[[:word:]]+/).length
+    end
+  end
+end

--- a/app/views/searches/unavailable.html.slim
+++ b/app/views/searches/unavailable.html.slim
@@ -1,0 +1,12 @@
+- content_for :title, "Search".html_safe
+
+.hero.search
+  section.section: .container
+    .columns: .column
+      = render partial: "search_form"
+
+section.section.search-results: .container
+  .columns: .column
+    .notification.is-warning
+      span.icon: i.fa.fa-exclamation-triangle
+      span Search is temporarily unavailable. Please try again in a little while.

--- a/spec/controllers/searches_controller_spec.rb
+++ b/spec/controllers/searches_controller_spec.rb
@@ -5,6 +5,42 @@ require "rails_helper"
 RSpec.describe SearchesController do
   fixtures :all
 
+  # Stubs the getter for a single ENV var without touching the real
+  # environment; other ENV lookups still call through.
+  def stub_env(key, value)
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with(key).and_return(value)
+  end
+
+  describe ".search_disabled?" do
+    it "is false when DISABLE_SEARCH is not set" do
+      stub_env "DISABLE_SEARCH", nil
+      expect(described_class).not_to be_search_disabled
+    end
+
+    it "is true when DISABLE_SEARCH is set" do
+      stub_env "DISABLE_SEARCH", "1"
+      expect(described_class).to be_search_disabled
+    end
+  end
+
+  describe ".statement_timeout_ms" do
+    it "defaults to DEFAULT_STATEMENT_TIMEOUT_MS when the env var is not set" do
+      stub_env "SEARCH_STATEMENT_TIMEOUT_MS", nil
+      expect(described_class.statement_timeout_ms).to eq described_class::DEFAULT_STATEMENT_TIMEOUT_MS
+    end
+
+    it "uses SEARCH_STATEMENT_TIMEOUT_MS when set to a positive integer" do
+      stub_env "SEARCH_STATEMENT_TIMEOUT_MS", "1234"
+      expect(described_class.statement_timeout_ms).to eq 1234
+    end
+
+    it "falls back to the default when the env var is not a positive integer" do
+      stub_env "SEARCH_STATEMENT_TIMEOUT_MS", "nope"
+      expect(described_class.statement_timeout_ms).to eq described_class::DEFAULT_STATEMENT_TIMEOUT_MS
+    end
+  end
+
   describe "GET #show" do
     def do_request(query: "foobar", order: nil, show_forks: nil, display: nil)
       get :show, params: { q: query, order:, show_forks:, display: }
@@ -71,6 +107,26 @@ RSpec.describe SearchesController do
     it "does not redirect when project search has no results but explicit show forks is given" do
       get :show, params: { q: "my query", show_forks: true }
       expect(response).to have_http_status(:success)
+    end
+
+    describe "when search is disabled" do
+      before { allow(described_class).to receive(:search_disabled?).and_return(true) }
+
+      it "does not perform a search" do
+        expect(Search).not_to receive(:new)
+        do_request query: "foobar"
+      end
+
+      it "renders the unavailable template with a service unavailable status" do
+        do_request query: "foobar"
+        expect(response).to have_http_status(:service_unavailable).and render_template(:unavailable)
+      end
+    end
+
+    it "renders the unavailable template when a search query times out" do
+      allow(Search).to receive(:new).and_raise(ActiveRecord::QueryCanceled)
+      do_request query: "foobar"
+      expect(response).to have_http_status(:service_unavailable).and render_template(:unavailable)
     end
   end
 

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -185,6 +185,33 @@ RSpec.describe "Search", :js do
     expect_display_mode "Compact"
   end
 
+  it "treats abusive queries as yielding no results instead of erroring" do
+    search_for "a" * (Search::QueryCheck::MAX_QUERY_LENGTH + 1)
+
+    expect(page).to have_text "No matching projects were found"
+    expect(page).to have_text "No matching categories were found"
+  end
+
+  it "shows an unavailable notice when the search killswitch is enabled", :allow_http_error_logs do
+    allow(SearchesController).to receive(:search_disabled?).and_return(true)
+
+    search_for "widget"
+
+    expect(page).to have_text "Search is temporarily unavailable"
+  end
+
+  it "shows an unavailable notice when a search query exceeds the statement timeout", :allow_http_error_logs do
+    # Mock the timeout to 1ms and force the search query to sleep far longer,
+    # so Postgres aborts it almost immediately — reproducing the real
+    # statement-timeout path end to end without slowing the test down.
+    allow(SearchesController).to receive(:statement_timeout_ms).and_return(1)
+    allow(Project).to receive(:search).and_return(Project.where("pg_sleep(1) IS NOT NULL"))
+
+    search_for "widget"
+
+    expect(page).to have_text "Search is temporarily unavailable"
+  end
+
   private
 
   #

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe Search do
   fixtures :all
 
+  let(:abusive_query) { "a" * (Search::QueryCheck::MAX_QUERY_LENGTH + 1) }
+
   describe "#query" do
     it "is the cleaned up search query" do
       expect(described_class.new(" foo bar ").query).to eq "foo bar"
@@ -22,6 +24,22 @@ RSpec.describe Search do
 
     it "is false for a blank query" do
       expect(described_class.new(" \n ")).not_to be_query
+    end
+  end
+
+  describe "#runnable?" do
+    # Exhaustive length/token boundaries live in Search::QueryCheck's spec;
+    # here we just confirm Search defers the decision to it.
+    it "is true for a regular query" do
+      expect(described_class.new("rails authentication")).to be_runnable
+    end
+
+    it "is false for a blank query" do
+      expect(described_class.new(" \n ")).not_to be_runnable
+    end
+
+    it "is false for an abusive query" do
+      expect(described_class.new(abusive_query)).not_to be_runnable
     end
   end
 
@@ -46,6 +64,15 @@ RSpec.describe Search do
       allow(Project).to receive(:search).with("my query", order: kind_of(Project::Order), show_forks: false)
                                         .and_return(collection)
       expect(described_class.new("my query").projects).to eq collection
+    end
+
+    it "does not run a project search for an abusive query" do
+      expect(Project).not_to receive(:search)
+      described_class.new(abusive_query).projects
+    end
+
+    it "returns no projects for an abusive query" do
+      expect(described_class.new(abusive_query).projects).to be_empty
     end
 
     describe "when NEW_SEARCH is enabled" do
@@ -102,6 +129,15 @@ RSpec.describe Search do
       collection = %w[some projects]
       allow(Category).to receive(:search).with("my query").and_return(collection)
       expect(described_class.new("my query").categories).to eq collection
+    end
+
+    it "does not run a category search for an abusive query" do
+      expect(Category).not_to receive(:search)
+      described_class.new(abusive_query).categories
+    end
+
+    it "returns no categories for an abusive query" do
+      expect(described_class.new(abusive_query).categories).to be_empty
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -126,12 +126,20 @@ RSpec.configure do |config|
   # Fail js capybara tests when the browser log has JS errors.
   # Snippet courtesy of:
   # https://medium.com/@coorasse/catch-javascript-errors-in-your-system-tests-89c2fe6773b1
-  config.after :each, :js, type: :feature do
+  config.after :each, :js, type: :feature do |example|
     # The latest magic incantation courtesy of https://stackoverflow.com/a/73879550
     errors = page.driver.browser.logs.get(:browser)
     if errors.present?
+      # Some examples intentionally exercise non-2xx responses (e.g. the search
+      # "unavailable" page returns 503), which the browser logs as a SEVERE
+      # "Failed to load resource" entry. Those examples can opt out of failing
+      # on that specific message via :allow_http_error_logs.
+      allow_http_error_logs = example.metadata[:allow_http_error_logs]
+
       aggregate_failures "javascript errrors" do
         errors.each do |error|
+          next if allow_http_error_logs && error.message.include?("Failed to load resource")
+
           expect(error.level).not_to eq("SEVERE"), error.message
           next unless error.level == "WARNING"
 

--- a/spec/services/search/query_check_spec.rb
+++ b/spec/services/search/query_check_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Search::QueryCheck do
+  describe "#runnable?" do
+    it "is true for a regular query" do
+      expect(described_class.new("rails authentication")).to be_runnable
+    end
+
+    it "is false for a blank query" do
+      expect(described_class.new(" \n ")).not_to be_runnable
+    end
+
+    it "is false for a nil query" do
+      expect(described_class.new(nil)).not_to be_runnable
+    end
+
+    it "is true for a query at the maximum allowed length" do
+      expect(described_class.new("a" * described_class::MAX_QUERY_LENGTH)).to be_runnable
+    end
+
+    it "is false for a query exceeding the maximum allowed length" do
+      expect(described_class.new("a" * (described_class::MAX_QUERY_LENGTH + 1))).not_to be_runnable
+    end
+
+    it "is true for a query at the maximum allowed token count" do
+      query = Array.new(described_class::MAX_QUERY_TOKENS) { |i| "t#{i}" }.join(" ")
+      expect(described_class.new(query)).to be_runnable
+    end
+
+    it "is false for a query exceeding the maximum allowed token count" do
+      query = Array.new(described_class::MAX_QUERY_TOKENS + 1) { |i| "t#{i}" }.join(" ")
+      expect(described_class.new(query)).not_to be_runnable
+    end
+
+    it "is false for spammy punctuation-separated phrase lists" do
+      # Mirrors bot spam that packs many short phrases separated by
+      # punctuation, which counts as many tokens even when fairly short.
+      expect(described_class.new("aa,bb,cc,dd,ee,ff,gg,hh,ii")).not_to be_runnable
+    end
+  end
+
+  describe "#abusive?" do
+    it "is false for a blank query" do
+      expect(described_class.new(" \n ")).not_to be_abusive
+    end
+
+    it "is false for a regular query" do
+      expect(described_class.new("rails authentication")).not_to be_abusive
+    end
+
+    it "is true for an over-long query" do
+      expect(described_class.new("a" * (described_class::MAX_QUERY_LENGTH + 1))).to be_abusive
+    end
+
+    it "is true for a query with too many tokens" do
+      query = Array.new(described_class::MAX_QUERY_TOKENS + 1) { |i| "t#{i}" }.join(" ")
+      expect(described_class.new(query)).to be_abusive
+    end
+  end
+end


### PR DESCRIPTION
In response to #1705 and closes #1705.

This introduces a few measures to prevent search query spam from taking out the site overall:

* Introduce a (env-configurable) search query PG statement timeout, defaulting to 5 seconds
* Introduce a (env-configurable) killswitch for the search so I can respond to such occurences in the future more quickly

Also, the offending search queries were very long CJK spam, so this also adds a bit of a simple query length & complexity guard - reasonable search queries here are usually short, so we can be restrictive on this.

Off-topic, but in the interest to get this deployed added to the PR as well: A bunch of gem bumps for security advisories from `bundle-audit`