### PR TITLE
Disable parallel query for production database sessions

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -90,3 +90,10 @@ production:
   database: rubytoolbox_production
   username: rubytoolbox
   password: <%= ENV['RUBYTOOLBOX_DATABASE_PASSWORD'] %>
+  variables:
+    # Parallel query workers each allocate additional work memory plus
+    # dynamic shared memory segments, which can exhaust the database
+    # server ("could not resize shared memory segment ... No space left
+    # on device"). Parallelism buys us nothing here, so disable it for
+    # our sessions.
+    max_parallel_workers_per_gather: 0


### PR DESCRIPTION
Fixes 500s on query-heavy pages (e.g. the metric documentation pages) on the fly.io production environment (#1748): postgres parallel query workers allocate their own work memory plus dynamic shared memory segments, which can exhaust the database server — surfacing as `PG::DiskFull: could not resize shared memory segment ... No space left on device`.

Parallel gather gains us nothing for these queries, so the app's sessions disable it via the connection's session `variables`.

Already deployed manually and verified: the previously failing pages render again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)