### PR TITLE
Deploy to fly.io automatically after successful CI on main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,38 @@
+name: Deploy
+on:
+  workflow_run:
+    workflows: ["CI"]
+    branches: ["main"]
+    types:
+      - completed
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    # Only deploy when the CI run actually succeeded
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
+    # The FLY_API_TOKEN secret (an app-scoped deploy token) lives in the
+    # production environment, which is restricted to the main branch
+    environment: production
+
+    # Queue deployments instead of running them concurrently - parallel
+    # bluegreen deploys would fight each other
+    concurrency:
+      group: production-deploy
+      cancel-in-progress: false
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # Deploy exactly the commit CI tested, not whatever main points at
+          # by the time this workflow runs
+          ref: ${{ github.event.workflow_run.head_sha }}
+      - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # v1 / 1.6
+      # Uses the app's fly.toml; the image is built on fly.io's remote
+      # builders, so no local toolchain setup is needed here (which is why
+      # this deliberately does not go through `mise run deploy:fly`)
+      - run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/doc/deployment.md
+++ b/doc/deployment.md
@@ -21,10 +21,16 @@ Two process groups, mirroring the former Procfile:
 
 ## Deploying, migrations & release tasks
 
-A deployment is triggered with `mise run deploy:fly` (wrapping `fly deploy`,
-see [fly.toml](../fly.toml)). It uses a bluegreen strategy: replacement
-machines are started and health-checked before traffic swaps over, giving
-zero-downtime deploys with a single web machine.
+Every push to `main` deploys automatically once CI has passed (see
+[.github/workflows/deploy.yml](../.github/workflows/deploy.yml)), authorized
+by an app-scoped deploy token stored in the `production` GitHub environment,
+which is restricted to the `main` branch. A manual deployment can be
+triggered with `mise run deploy:fly` (wrapping `fly deploy`, see
+[fly.toml](../fly.toml)).
+
+Deployments use a bluegreen strategy: replacement machines are started and
+health-checked before traffic swaps over, giving zero-downtime deploys with
+a single web machine.
 
 Each deployment runs `mise run deploy:release` (which wraps
 `bundle exec rake db:migrate release`, see [tasks/deploy.toml](../tasks/deploy.toml))


### PR DESCRIPTION
Restores deployment automation for #1748, replacing the removed Heroku workflow: pushes to `main` deploy to fly.io automatically once CI has passed.

- Same proven `workflow_run` trigger pattern as the previous Heroku deploy workflow, deploying **exactly the commit CI tested** (pinned `head_sha` checkout)
- Authenticates via an app-scoped deploy token stored in the branch-restricted `production` GitHub environment, exposed only to the single deploy step
- Builds on fly.io's remote builders (`--remote-only`), so the runner needs no toolchain — which is also why this deliberately invokes `flyctl` directly rather than going through `mise run deploy:fly` (documented in a comment)
- Concurrent deployments are queued, keeping bluegreen swaps sequential
- Third-party action pinned to a commit SHA (tags are mutable; this is a public repo)
- `doc/deployment.md` updated: auto-deploy as the primary path, `mise run deploy:fly` as the manual fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)