### PR TITLE
Exempt health check endpoint from canonical host redirects

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -4,6 +4,9 @@
 
 require_relative "config/environment"
 
-use Rack::CanonicalHost, ENV["CANONICAL_HOST"] if ENV["CANONICAL_HOST"].present?
+# The health check endpoint is exempt from canonical host redirects since the
+# hosting platform probes it with non-canonical Host headers - redirecting those
+# requests would make the machines appear unhealthy
+use Rack::CanonicalHost, ENV["CANONICAL_HOST"], ignore: ->(uri) { uri.path == "/up" } if ENV["CANONICAL_HOST"].present?
 
 run Rails.application

--- a/spec/requests/canonical_host_spec.rb
+++ b/spec/requests/canonical_host_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Canonical host enforcement" do
+  subject(:response) { Rack::MockRequest.new(app).get(url) }
+
+  # The canonical host redirect middleware is configured in config.ru, which the
+  # regular request specs bypass, so the app is built from the rackup file with
+  # CANONICAL_HOST configured
+  let(:app) do
+    original_value = ENV.fetch("CANONICAL_HOST", nil)
+    begin
+      ENV["CANONICAL_HOST"] = "www.example.org"
+      Rack::Builder.parse_file(Rails.root.join("config.ru").to_s)
+    ensure
+      ENV["CANONICAL_HOST"] = original_value
+    end
+  end
+
+  context "when requested on a non-canonical host" do
+    let(:url) { "https://legacy.example.org/pages/about" }
+
+    it "redirects permanently" do
+      expect(response).to have_http_status(:moved_permanently)
+    end
+
+    it "points at the same path on the canonical host" do
+      expect(response.headers["location"]).to eq("https://www.example.org/pages/about")
+    end
+  end
+
+  context "when the health check is requested on a non-canonical host" do
+    let(:url) { "https://legacy.example.org/up" }
+
+    it "responds successfully without redirecting" do
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  context "when requested on the canonical host" do
+    let(:url) { "https://www.example.org/up" }
+
+    it "responds successfully" do
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end


### PR DESCRIPTION
Part of #1748.

When `CANONICAL_HOST` is configured, `Rack::CanonicalHost` currently issues permanent redirects for every request that arrives with a different `Host` header — including the platform health check probes against `/up`, which do not use the public hostname. That would make perfectly healthy machines appear unhealthy and break health-checked (bluegreen) deployments the moment the canonical host is enabled.

This exempts the `/up` path from the canonical host redirect via the middleware's `ignore` option, and adds request specs that exercise the actual `config.ru` middleware stack (which regular request specs bypass): non-canonical hosts still get their permanent redirect with the path preserved, while `/up` responds successfully regardless of the requested host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)